### PR TITLE
feat: add config um for umi-plugin-react

### DIFF
--- a/packages/umi-plugin-father-doc/src/index.ts
+++ b/packages/umi-plugin-father-doc/src/index.ts
@@ -63,14 +63,13 @@ export default function (api: IApi, opts: IFatherDocOpts) {
         return {
           name: 'umi',
           validate: () => true,
-          onChange(newConfig) {
+          onChange() {
             api.restart('Configure item umi Changed.');
           },
         };
       };
     });
   }
-
 
   // apply umi-plugin-react for use title
   api.registerPlugin({


### PR DESCRIPTION
增加一个配置，透传配置到 umi-plugin-react，让用户判断是否开启hd 和 antd 
修复编写基于 antd 或者 antd-mobile 做二次封装的组件时，样式要二次引入的问题。