### PR TITLE
docs: fix typo

### DIFF
--- a/docs/config/frontmatter.md
+++ b/docs/config/frontmatter.md
@@ -173,7 +173,7 @@ group:
 hero:
   actions:
     - text: Getting Started
-      linn: /getting-started
+      link: /getting-started
 ```
 
 ### features


### PR DESCRIPTION
`linn` -> `link`