### PR TITLE
chore(demo): overflow hidden

### DIFF
--- a/packages/preset-dumi/src/themes/default/builtins/Previewer.less
+++ b/packages/preset-dumi/src/themes/default/builtins/Previewer.less
@@ -12,6 +12,7 @@
 
   &-demo {
     padding: 40px 24px;
+    overflow: hidden;
   }
 
   &-desc {


### PR DESCRIPTION
主要在于优化移动端弹出类组件的展示效果，如下：

before:

![chrome-capture (1)](https://user-images.githubusercontent.com/13151189/80285588-a4cd2100-8758-11ea-9a91-108c7fab6a6c.gif)

after:

![chrome-capture (2)](https://user-images.githubusercontent.com/13151189/80285591-a991d500-8758-11ea-8a81-de17057d2242.gif)
