### PR TITLE
fix(transformer): compatible JSX Link with normal markdown link(#181)

### DIFF
--- a/packages/preset-dumi/src/transformer/fixtures/expect/remark-link.html
+++ b/packages/preset-dumi/src/transformer/fixtures/expect/remark-link.html
@@ -1,0 +1,20 @@
+<div class="markdown"><p><Link to="./test"></Link>
+<a href="./test"></a>
+<Link to="./test"></Link>
+<Link to="/test"></Link>
+<a href="./test.md"></a>
+<a href="/test.md"></a>
+<Link to="./a/test"></Link>
+<Link to="/a/test"></Link>
+<a href="./a/test.md"></a>
+<a href="/a/test.md"></a>
+<Link to="./test#header"></Link>
+<Link to="./a/test#header"></Link>
+<a href="./test.md#header"></a>
+<a href="./a/test.md#header"></a>
+<Link to="/test#header"></Link>
+<Link to="/a/test#header"></Link>
+<a href="/test.md#header"></a>
+<a href="/a/test.md#header"></a>
+<Link to="/a/test?a=1&b=2#header"></Link>
+<a href="/a/test.md?a=1&b=2#header"></a></p></div>

--- a/packages/preset-dumi/src/transformer/fixtures/raw/remark-link.md
+++ b/packages/preset-dumi/src/transformer/fixtures/raw/remark-link.md
@@ -1,0 +1,20 @@
+[](./test)
+<a href="./test"></a>
+[](./test.MD)
+[](/test.md)
+<a href="./test.md"></a>
+<a href="/test.md"></a>
+[](./a/test.md)
+[](/a/test.md)
+<a href="./a/test.md"></a>
+<a href="/a/test.md"></a>
+[](./test.md#header)
+[](./a/test.md#header)
+<a href="./test.md#header"></a>
+<a href="./a/test.md#header"></a>
+[](/test.md#header)
+[](/a/test.md#header)
+<a href="/test.md#header"></a>
+<a href="/a/test.md#header"></a>
+[](/a/test.md?a=1&b=2#header)
+<a href="/a/test.md?a=1&b=2#header"></a>

--- a/packages/preset-dumi/src/transformer/remark/link.ts
+++ b/packages/preset-dumi/src/transformer/remark/link.ts
@@ -2,6 +2,7 @@ import visit from 'unist-util-visit';
 import toHtml from 'hast-util-to-html';
 import has from 'hast-util-has-property';
 import is from 'hast-util-is-element';
+import url from 'url'
 
 function isAbsoluteUrl(url) {
   return /^(?:https?:)?\/\//.test(url);
@@ -60,9 +61,13 @@ export default () => ast => {
           ],
         });
       } else if (/^(\.|\/)/.test(node.properties.href)) {
+        // compatible with normal markdown link 
+        // see https://github.com/umijs/dumi/issues/181
+        const currentURL = url.parse(node.properties.href)
+        currentURL.pathname = currentURL.pathname.replace(/(\.md)$/ig, '')
         parent.children[i] = {
           type: 'raw',
-          value: `<Link to="${node.properties.href}">${(node.children || [])
+          value: `<Link to="${url.format(currentURL)}">${(node.children || [])
             .map(n => toHtml(n))
             .join('')}</Link>`,
         };

--- a/packages/preset-dumi/src/transformer/remark/link.ts
+++ b/packages/preset-dumi/src/transformer/remark/link.ts
@@ -64,7 +64,7 @@ export default () => ast => {
         // compatible with normal markdown link 
         // see https://github.com/umijs/dumi/issues/181
         const currentURL = url.parse(node.properties.href)
-        currentURL.pathname = currentURL.pathname.replace(/(\.md)$/ig, '')
+        currentURL.pathname = currentURL.pathname.replace(/\.md$/i, '')
         parent.children[i] = {
           type: 'raw',
           value: `<Link to="${url.format(currentURL)}">${(node.children || [])

--- a/packages/preset-dumi/src/transformer/test/remark-link.test.ts
+++ b/packages/preset-dumi/src/transformer/test/remark-link.test.ts
@@ -11,7 +11,6 @@ describe('link example', () => {
       strategy: 'default',
       previewLangs: [],
     }).contents.toString();
-    // console.log(result)
     // compare transform content
     expect(result).toEqual(
       fs.readFileSync(path.join(__dirname, '../fixtures/expect/remark-link.html')).toString(),

--- a/packages/preset-dumi/src/transformer/test/remark-link.test.ts
+++ b/packages/preset-dumi/src/transformer/test/remark-link.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import remark from '../remark';
+
+describe('link example', () => {
+  const FILE_PATH = path.join(__dirname, '../fixtures/raw/remark-link.md');
+
+  it('transform md to jsx', () => {
+    const result = remark(fs.readFileSync(FILE_PATH).toString(), {
+      fileAbsPath: FILE_PATH,
+      strategy: 'default',
+      previewLangs: [],
+    }).contents.toString();
+    // console.log(result)
+    // compare transform content
+    expect(result).toEqual(
+      fs.readFileSync(path.join(__dirname, '../fixtures/expect/remark-link.html')).toString(),
+    );
+  });
+});


### PR DESCRIPTION
兼容普通markdown页面间跳转 #181 