### PR TITLE
fix(l): 默认生成的语言切换选择器被隐藏

### DIFF
--- a/packages/preset-dumi/src/themes/default/SideMenu.less
+++ b/packages/preset-dumi/src/themes/default/SideMenu.less
@@ -86,7 +86,6 @@
   }
 
   &-doc-locale:not(:empty) {
-    display: none;
     padding: 16px 0;
     text-align: center;
     border-bottom: 1px solid @c-border;


### PR DESCRIPTION
对于非空的doc-locale类不应该设置display: none