### PR TITLE
fix: 修复部署到github page后刷新页面锚点丢失问题

### DIFF
--- a/packages/preset-dumi/src/themes/default/layout.tsx
+++ b/packages/preset-dumi/src/themes/default/layout.tsx
@@ -148,7 +148,7 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
 
     // discard end slash for path
     if (/\w\/$/.test(this.props.location.pathname)) {
-      history.replace(this.props.location.pathname.replace(/\/$/, ''));
+      history.replace(this.props.location.pathname.replace(/\/$/, '') + this.props.location.hash);
     }
   }
 


### PR DESCRIPTION
各位大佬好，发现dumi在部署github page后有个问题，就是在刷新或第一次进入带锚点的dumi站点链接时，锚点会丢失。这会导致在chrome中无法滚动定位到页面锚点相应位置，具体可看下面几个例子都是这样：

* https://ggeditor.com/guide/getting-started#flow
* https://tsejx.github.io/webpack-guidebook/basic-summary/core-concepts/mode#mode-%E6%A8%A1%E5%BC%8F
* https://annasearl.github.io/anna-remax-ui/components/data-entry/input#input

观察到github page在每次访问时，会自动在url的`location.pathname`最后添加一个斜杠，而在dumi之前的这次提交：https://github.com/umijs/dumi/commit/b16655b4e3c191a886b5681fef44899472465f2f 中，添加了一个自动去除url末尾斜杠的功能。

但是这里在重写url的时候只考虑了`location.pathname`，少加了`location.hash`，所以导致了此问题。经实际部署github page测试，只要加上`location.hash`这问题就解决了。

具体做的修改很简单请看代码，辛苦各位大佬~