### PR TITLE
fix(scaffold): repair singleton doesn't work in windows

### DIFF
--- a/packages/create-dumi-app/templates/AppGenerator/package.json.tpl
+++ b/packages/create-dumi-app/templates/AppGenerator/package.json.tpl
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "dumi dev",
     "build": "dumi build",
-    "prettier": "prettier --write '**/*.{js,jsx,tsx,ts,less,md,json}'"
+    "prettier": "prettier --write \"**/*.{js,jsx,tsx,ts,less,md,json}\""
   },
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/create-dumi-lib/templates/AppGenerator/package.json.tpl
+++ b/packages/create-dumi-lib/templates/AppGenerator/package.json.tpl
@@ -5,7 +5,7 @@
     "start": "dumi dev",
     "docs:build": "dumi build",
     "build": "father-build",
-    "prettier": "prettier --write '**/*.{js,jsx,tsx,ts,less,md,json}'",
+    "prettier": "prettier --write \"**/*.{js,jsx,tsx,ts,less,md,json}\"",
     "test": "umi-test",
     "test:coverage": "umi-test --coverage"
   },


### PR DESCRIPTION
## 简介
- windows 系统识别单引号失败，导致 prettier 命令是执行失败

## 主要变更
- 修改 package 模板文件中 prettier 命令中的单引号为双引号