### PR TITLE
fix: 使用绝对路径以兼容和 umi 项目共存问题

### DIFF
--- a/packages/preset-dumi/src/routes/decorator/relative.ts
+++ b/packages/preset-dumi/src/routes/decorator/relative.ts
@@ -8,9 +8,7 @@ import { RouteProcessor } from '.';
 export default (function relative(routes) {
   return routes.map(route => {
     if (route.component && !path.isAbsolute(route.component)) {
-      route.component = slash(
-        path.relative(this.umi.paths.absPagesPath, path.join(this.umi.paths.cwd, route.component)),
-      );
+      route.component = slash(path.join(this.umi.paths.cwd, route.component));
     }
 
     return route;

--- a/packages/preset-dumi/src/routes/getRouteConfig.ts
+++ b/packages/preset-dumi/src/routes/getRouteConfig.ts
@@ -37,9 +37,7 @@ export default (api: IApi, opts: IDumiOpts): IRoute[] => {
   // add main routes
   config.push({
     path: '/',
-    component: slash(
-      path.relative(paths.absPagesPath, path.join(__dirname, '../themes/default/layout.js')),
-    ),
+    component: slash(path.join(__dirname, '../themes/default/layout.js')),
     // decorate standard umi routes
     routes: decorateRoutes(childRoutes, opts, api),
     title: opts.title,
@@ -58,10 +56,7 @@ export default (api: IApi, opts: IDumiOpts): IRoute[] => {
       });
 
       // use example component as original example component
-      route.component = path.relative(
-        paths.absPagesPath,
-        path.join(__dirname, '../themes/default/builtins/Example.js'),
-      );
+      route.component = slash(path.join(__dirname, '../themes/default/builtins/Example.js'));
       route.meta.examplePath = examplePath;
     }
   });

--- a/packages/preset-dumi/src/routes/test/examples.test.ts
+++ b/packages/preset-dumi/src/routes/test/examples.test.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { IApi } from '@umijs/types';
 import getRoutes from '../getRouteConfig';
 import { init } from '../../context';
+import getAbsolutePath from '../../utils/getAbsolutePath';
 
 const FIXTURES_PATH = path.join(__dirname, '..', 'fixtures');
 
@@ -36,16 +37,20 @@ describe('routes: examples', () => {
     expect(routes).toEqual([
       {
         path: '/_examples/test',
-        component: '../../examples/test.tsx',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/examples/examples/test.tsx',
+        ),
         title: 'testing example frontmatter',
       },
       {
         path: '/',
-        component: '../../../../../themes/default/layout.js',
+        component: getAbsolutePath('./packages/preset-dumi/src/themes/default/layout.js'),
         routes: [
           {
             path: '/',
-            component: '../../examples/index.md',
+            component: getAbsolutePath(
+              './packages/preset-dumi/src/routes/fixtures/examples/examples/index.md',
+            ),
             exact: true,
             meta: {
               filePath: 'examples/index.md',
@@ -57,7 +62,9 @@ describe('routes: examples', () => {
           },
           {
             path: '/test',
-            component: '../../../../../themes/default/builtins/Example.js',
+            component: getAbsolutePath(
+              './packages/preset-dumi/src/themes/default/builtins/Example.js',
+            ),
             exact: true,
             meta: {
               title: 'testing example frontmatter',

--- a/packages/preset-dumi/src/routes/test/locale.test.js
+++ b/packages/preset-dumi/src/routes/test/locale.test.js
@@ -3,6 +3,7 @@ import getRoute from '../getRouteConfigFromDir';
 import decorateRoute from '../decorator';
 import getMenu from '../getMenuFromRoutes';
 import getLocale from '../getLocaleFromRoutes';
+import getAbsolutePath from "../../utils/getAbsolutePath";
 
 const FIXTURES_PATH = path.join(__dirname, '..', 'fixtures');
 const DEFAULT_LOCALES = [
@@ -116,7 +117,7 @@ describe('routes & menu: locales', () => {
     expect(routes).toEqual([
       {
         path: '/',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/index.en-US.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/index.en-US.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/index.en-US.md',
@@ -129,7 +130,7 @@ describe('routes & menu: locales', () => {
       },
       {
         path: '/zh-CN',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/index.zh-CN.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/index.zh-CN.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/index.zh-CN.md',
@@ -142,7 +143,7 @@ describe('routes & menu: locales', () => {
       },
       {
         path: '/missing/abc',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/missing/abc.en-US.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/missing/abc.en-US.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/missing/abc.en-US.md',
@@ -156,7 +157,7 @@ describe('routes & menu: locales', () => {
       },
       {
         path: '/group/abc',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/sub/abc.en-US.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/sub/abc.en-US.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/sub/abc.en-US.md',
@@ -170,7 +171,7 @@ describe('routes & menu: locales', () => {
       },
       {
         path: '/zh-CN/group/abc',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/sub/abc.zh-CN.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/sub/abc.zh-CN.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/sub/abc.zh-CN.md',
@@ -184,7 +185,7 @@ describe('routes & menu: locales', () => {
       },
       {
         path: '/sub',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/sub/index.en-US.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/sub/index.en-US.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/sub/index.en-US.md',
@@ -198,7 +199,7 @@ describe('routes & menu: locales', () => {
       },
       {
         path: '/zh-CN/sub',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/sub/index.zh-CN.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/sub/index.zh-CN.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/sub/index.zh-CN.md',
@@ -212,7 +213,7 @@ describe('routes & menu: locales', () => {
       },
       {
         path: '/zh-CN/missing/abc',
-        component: '../../packages/preset-dumi/src/routes/fixtures/locale/missing/abc.en-US.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/locale/missing/abc.en-US.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/locale/missing/abc.en-US.md',

--- a/packages/preset-dumi/src/routes/test/normal.test.js
+++ b/packages/preset-dumi/src/routes/test/normal.test.js
@@ -2,6 +2,7 @@ import path from 'path';
 import getRoute from '../getRouteConfigFromDir';
 import decorateRoute from '../decorator';
 import getMenu from '../getMenuFromRoutes';
+import getAbsolutePath from '../../utils/getAbsolutePath';
 
 const FIXTURES_PATH = path.join(__dirname, '..', 'fixtures');
 
@@ -64,7 +65,7 @@ describe('routes & menu: normal', () => {
     expect(routes).toEqual([
       {
         path: '/',
-        component: '../../packages/preset-dumi/src/routes/fixtures/normal/index.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/normal/index.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/normal/index.md',
@@ -76,7 +77,7 @@ describe('routes & menu: normal', () => {
       },
       {
         path: '/test/intro',
-        component: '../../packages/preset-dumi/src/routes/fixtures/normal/intro.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/normal/intro.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/normal/intro.md',
@@ -89,7 +90,9 @@ describe('routes & menu: normal', () => {
       },
       {
         path: '/index',
-        component: '../../packages/preset-dumi/src/routes/fixtures/normal/index/readme.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/normal/index/readme.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/normal/index/readme.md',
@@ -103,7 +106,9 @@ describe('routes & menu: normal', () => {
       },
       {
         path: '/sub/hello-component',
-        component: '../../packages/preset-dumi/src/routes/fixtures/normal/sub/HelloComponent.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/normal/sub/HelloComponent.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/normal/sub/HelloComponent.md',
@@ -116,7 +121,9 @@ describe('routes & menu: normal', () => {
       },
       {
         path: '/sub',
-        component: '../../packages/preset-dumi/src/routes/fixtures/normal/sub/README.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/normal/sub/README.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/normal/sub/README.md',
@@ -129,7 +136,9 @@ describe('routes & menu: normal', () => {
       },
       {
         path: '/rename-sub-sub/still-hello',
-        component: '../../packages/preset-dumi/src/routes/fixtures/normal/sub/subsub/stillHello.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/normal/sub/subsub/stillHello.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/normal/sub/subsub/stillHello.md',
@@ -142,7 +151,9 @@ describe('routes & menu: normal', () => {
       },
       {
         path: '/rename-sub-sub/y-end',
-        component: '../../packages/preset-dumi/src/routes/fixtures/normal/sub/subsub/yEnd.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/normal/sub/subsub/yEnd.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/normal/sub/subsub/yEnd.md',

--- a/packages/preset-dumi/src/routes/test/site.test.js
+++ b/packages/preset-dumi/src/routes/test/site.test.js
@@ -4,6 +4,7 @@ import decorateRoute from '../decorator';
 import getMenu from '../getMenuFromRoutes';
 import getNav from '../getNavFromRoutes';
 import getLocale from '../getLocaleFromRoutes';
+import getAbsolutePath from '../../utils/getAbsolutePath';
 
 const FIXTURES_PATH = path.join(__dirname, '..', 'fixtures');
 
@@ -69,7 +70,7 @@ describe('routes & menu: site mode', () => {
     expect(routes).toEqual([
       {
         path: '/api',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/api.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/site/api.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/api.md',
@@ -85,7 +86,7 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/index.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/site/index.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/index.md',
@@ -97,7 +98,9 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/zh-CN',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
@@ -110,7 +113,9 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/config',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/index.md',
@@ -123,7 +128,9 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/config/others',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/others.md',
@@ -136,7 +143,9 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/test-rewrite/rewrite',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
@@ -150,7 +159,7 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/zh-CN/api',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/api.md',
+        component: getAbsolutePath('./packages/preset-dumi/src/routes/fixtures/site/api.md'),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/api.md',
@@ -167,7 +176,9 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/zh-CN/config',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/index.md',
@@ -181,7 +192,9 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/zh-CN/config/others',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/others.md',
@@ -195,7 +208,9 @@ describe('routes & menu: site mode', () => {
       },
       {
         path: '/zh-CN/test-rewrite/rewrite',
-        component: '../../packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+        component: getAbsolutePath(
+          './packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+        ),
         exact: true,
         meta: {
           filePath: 'packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',

--- a/packages/preset-dumi/src/utils/getAbsolutePath.ts
+++ b/packages/preset-dumi/src/utils/getAbsolutePath.ts
@@ -1,0 +1,6 @@
+import path from 'path';
+import slash from 'slash2';
+
+export default function getAbsolutePath(componentPath: string) {
+  return slash(path.join(process.cwd(), componentPath));
+}


### PR DESCRIPTION
umi 项目包含 pages 目录，则会导致相对目录不正确。使用绝对路径以避免此问题