### PR TITLE
fix(transformer): get NaN updatedTime when create a new md

### DIFF
--- a/packages/preset-dumi/src/transformer/remark/yaml.ts
+++ b/packages/preset-dumi/src/transformer/remark/yaml.ts
@@ -18,13 +18,17 @@ export default function yamlProcessor() {
       vFile.data.filePath = filePath;
 
       try {
-        vFile.data.updatedTime =
+        const updatedTime =
           parseInt(
             execSync(`git log -1 --format=%at ${this.data('fileAbsPath')}`, {
               stdio: 'pipe',
             }).toString(),
             10,
           ) * 1000;
+        if (Number.isNaN(updatedTime)) {
+          throw 'get updatedTime failed';
+        }
+        vFile.data.updatedTime = updatedTime;
       } catch (err) {
         vFile.data.updatedTime = Math.floor(fs.lstatSync(this.data('fileAbsPath')).mtimeMs);
       }


### PR DESCRIPTION
## 简介
-  当新建一个 .md 文件时候， 由于最近更新时间是从 git log 去查询的，所以就导致这个时间是 NaN，从而使得页面渲染的时候 updatedTime 为 1970年 这个错误时间点

## issue
#194 

## 主要变更
- 获取 updateTime 之后 判断是否为 NaN，若是则抛出错误，就会去获取文件的 mtimeMs