### PR TITLE
docs: add theme color config guide

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -75,6 +75,20 @@ export default {
 
 该配置项用于自定义侧边菜单的展示，目前仅 `site` 模式下可用，分多语言模式和单语言模式，使用方式详见 [指南 - 配置式侧边菜单](/guide/control-menu-generate#配置式侧边菜单)。
 
+## theme
+
+- 类型：`Object`
+- 默认值：`默认主题`
+- 详细：
+
+主题颜色变量名称参照 `node_modules/@umijs/preset-dumi/lib/themes/default/variables.less`
+
+```js
+  theme: {
+    '@c-primary': '#ff652f',
+  }
+```
+
 ## navs
 
 - 类型：`Object | Array`


### PR DESCRIPTION
增加主题颜色配置字段的说明。下意识以为和 `antd` 主题[配置](https://ant.design/docs/react/customize-theme-cn#%E5%9C%A8-Umi-%E9%87%8C%E9%85%8D%E7%BD%AE%E4%B8%BB%E9%A2%98)相同，使用
```js
  theme: {
    '@primary-color': '#ff652f',
  },
```
失败，遂查看源码，发现正确的配置字段应该是
```js
  theme: {
    '@c-primary': '#ff652f',
  },
```
于是添加此说明