### PR TITLE
fix: jsx output bug in transformer

### DIFF
--- a/docs/lab/index.md
+++ b/docs/lab/index.md
@@ -17,7 +17,7 @@ sidemenu: false
 
 <p style="text-align: center;">
   <img src="https://gw.alipayobjects.com/zos/bmw-prod/a873195d-32fe-427d-9756-a002d7644d85/kc5y7qpk_w2078_h1757.png" width="800" >
-</a>
+</p>
 
 ### 使用方式
 

--- a/packages/preset-dumi/src/transformer/fixtures/expect/remark-basic.html
+++ b/packages/preset-dumi/src/transformer/fixtures/expect/remark-basic.html
@@ -32,44 +32,44 @@
 <SourceCode code={"// some code here\n"} lang="unknown" />
 <p>语法高亮</p>
 <SourceCode code={"console.log('Hello World!');\n"} lang="js" />
-<pre>$ npm i dumi{"\n"}$ npx dumi dev{"\n"}</pre>
-<table>
-<thead>
-<tr>
-<th>名词</th>
-<th>解释</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>father</td>
-<td>Library toolkit based on rollup, docz, storybook, jest, prettier and eslint.</td>
-</tr>
-<tr>
-<td>Umi</td>
-<td>Pluggable enterprise-level react application framework.</td>
-</tr>
-</tbody>
-</table>
+<SourceCode code={"$ npm i dumi\n$ npx dumi dev\n"} lang="unknown" />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th>名词</th><th>解释</th></tr></thead><tbody><tr><td>father</td><td>Library toolkit based on rollup, docz, storybook, jest, prettier and eslint.</td></tr><tr><td>Umi</td><td>Pluggable enterprise-level react application framework.</td></tr></tbody></table>
 <p>单元格右对齐</p>
-<table>
-<thead>
-<tr>
-<th align="right">名词</th>
-<th align="right">解释</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td align="right">father</td>
-<td align="right">Library toolkit based on rollup, docz, storybook, jest, prettier and eslint.</td>
-</tr>
-<tr>
-<td align="right">Umi</td>
-<td align="right">Pluggable enterprise-level react application framework.</td>
-</tr>
-</tbody>
-</table>
-<p><a href="https://umijs.org" target="_blank" rel="noopener noreferrer">前往 Umi 官网<svg xmlns="http://www.w3.org/2000/svg" aria-hidden={true} x="0px" y="0px" viewBox="0 0 100 100" width={15} height={15} className="__dumi-default-external-link-icon"><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z" /><polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9" /></svg></a></p>
-<p>自动转换超链接 <a href="https://umijs.org" target="_blank" rel="noopener noreferrer">https://umijs.org<svg xmlns="http://www.w3.org/2000/svg" aria-hidden={true} x="0px" y="0px" viewBox="0 0 100 100" width={15} height={15} className="__dumi-default-external-link-icon"><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z" /><polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9" /></svg></a></p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th align="right">名词</th><th align="right">解释</th></tr></thead><tbody><tr><td align="right">father</td><td align="right">Library toolkit based on rollup, docz, storybook, jest, prettier and eslint.</td></tr><tr><td align="right">Umi</td><td align="right">Pluggable enterprise-level react application framework.</td></tr></tbody></table>
+<p><a href="https://umijs.org" target="_blank" rel={["noopener","noreferrer"]}>前往 Umi 官网<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" className={["__dumi-default-external-link-icon"]}><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z" /><polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9" /></svg></a></p>
+<p>自动转换超链接 <a href="https://umijs.org" target="_blank" rel={["noopener","noreferrer"]}>https://umijs.org<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" className={["__dumi-default-external-link-icon"]}><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z" /><polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9" /></svg></a></p>
 <p><Link to="./test">内部 Markdown 链接</Link></p></div>

--- a/packages/preset-dumi/src/transformer/fixtures/expect/remark-demo.html
+++ b/packages/preset-dumi/src/transformer/fixtures/expect/remark-demo.html
@@ -1,3 +1,3 @@
 <React.Fragment><div className="markdown"><SourceCode code={"import React from 'react';\n\nexport default () => <h1>Hello World!</h1>;\n"} lang="jsx" />
 </div><DumiPreviewer source={{"jsx":"import React from 'react';\n\nexport default () => <h1>Hello World!</h1>;\n","tsx":"import React from 'react';\n\nexport default () => <h1>Hello World!</h1>;"}} files={{}} dependencies={{}} desc="<div class=&#x22;markdown&#x22;><p>testing</p></div>"><DumiDemo1 /></DumiPreviewer><div className="markdown">
-</div><DumiPreviewer source={{"jsx":"export default () => <></>;\n","tsx":"export default () => <></>;"}} files={{}} dependencies={{}} hideactions={["CSB"]} path="/_demos/demo-missing-react"><DumiDemo2 /></DumiPreviewer></React.Fragment>
+</div><DumiPreviewer source={{"jsx":"export default () => <></>;\n","tsx":"export default () => <></>;"}} files={{}} dependencies={{}} hideActions={["CSB"]} path="/_demos/demo-missing-react"><DumiDemo2 /></DumiPreviewer></React.Fragment>

--- a/packages/preset-dumi/src/transformer/index.ts
+++ b/packages/preset-dumi/src/transformer/index.ts
@@ -54,6 +54,6 @@ export default {
       // remove * from comments
       .replace(/(^|\n)\s*\*+/g, '$1');
 
-    return { content, meta: yaml.safeLoad(frontmatter) };
+    return { content, meta: yaml.safeLoad(frontmatter) as object };
   },
 };

--- a/packages/preset-dumi/src/transformer/remark/code.ts
+++ b/packages/preset-dumi/src/transformer/remark/code.ts
@@ -8,6 +8,11 @@ import { saveFileOnDepChange } from '../../utils/watcher';
 import { addDemoRoute } from '../../routes/getDemoRoutes';
 import transformer from '..';
 
+const ATTR_MAPPING = {
+  hideactions: 'hideActions',
+  defaultshowcode: 'defaultShowCode',
+};
+
 /**
  * remark plugin for parse code tag to external demo
  */
@@ -25,6 +30,14 @@ export default function code() {
 
         // read external demo content and convert node to demo node
         const result = transformer.code(fs.readFileSync(absPath).toString());
+
+        // restore camelCase attrs, because hast-util-raw will transform camlCase to lowercase
+        Object.entries(ATTR_MAPPING).forEach(([mark, attr]) => {
+          if (attrs[mark]) {
+            attrs[attr] = attrs[mark];
+            delete attrs[mark];
+          }
+        });
 
         // add single route for external demo
         attrs.path = addDemoRoute(absPath);

--- a/packages/preset-dumi/src/transformer/remark/jsxify.ts
+++ b/packages/preset-dumi/src/transformer/remark/jsxify.ts
@@ -12,6 +12,14 @@ export default function jsxify() {
       node.properties = formatJSXProps(node.properties);
     });
 
-    return toJSX(ast, { wrapper: 'fragment' });
+    let JSX = toJSX(ast, { wrapper: 'fragment' });
+
+    // TODO: find a elegant way to keep camelCase props like defaultShowCode or hideActions
+    JSX = JSX.replace(/hide-actions={\[/g, 'hideActions={[').replace(
+      /default-show-code={true}/g,
+      'defaultShowCode',
+    );
+
+    return JSX;
   };
 }

--- a/packages/preset-dumi/src/transformer/remark/jsxify.ts
+++ b/packages/preset-dumi/src/transformer/remark/jsxify.ts
@@ -12,7 +12,7 @@ export default function jsxify() {
       node.properties = formatJSXProps(node.properties);
     });
 
-    let JSX = toJSX(ast, { wrapper: 'fragment' });
+    let JSX = toJSX(ast, { wrapper: 'fragment' }) || '';
 
     // TODO: find a elegant way to keep camelCase props like defaultShowCode or hideActions
     JSX = JSX.replace(/hide-actions={\[/g, 'hideActions={[').replace(

--- a/packages/preset-dumi/src/transformer/remark/raw.ts
+++ b/packages/preset-dumi/src/transformer/remark/raw.ts
@@ -1,34 +1,66 @@
 import visit from 'unist-util-visit';
+import has from 'hast-util-has-property';
 import raw from 'hast-util-raw';
+
+/**
+ * detect properties whether has complex value
+ * @param props
+ */
+function hasComplexProp(props: object) {
+  return Object.values(props).some(
+    prop => ['object', 'function'].includes(typeof prop) || Array.isArray(prop),
+  );
+}
 
 /**
  * rehype plugin for compile raw node to hast
  */
 export default () => ast => {
-  // workaround to avoid lowercase for React Component tag name
-  visit(ast, 'raw', (node, i, parent) => {
+  const props = [];
+
+  visit(ast, node => {
+    // workaround to avoid lowercase for React Component tag name
     // mark React Compnoent via dumi-raw prefixer, eg Alert => dumi-raw-alert
-    node.value = (node.value as string).replace(/(<\/?)([A-Z]\w)+/g, (_, prefix, tagName) => {
-      return `${prefix}dumi-raw${tagName.replace(/[A-Z]/g, s => `-${s.toLowerCase()}`)}`;
-    });
+    if (typeof node.tagName === 'string' && /^[A-Z]/.test(node.tagName)) {
+      node.tagName = `dumi-raw${node.tagName.replace(/[A-Z]/g, s => `-${s.toLowerCase()}`)}`;
+    } else if (typeof node.value === 'string' && node.type === 'raw') {
+      node.value = node.value.replace(/(<\/?)([A-Z]\w+)/g, (_, prefix, tagName) => {
+        return `${prefix}dumi-raw${tagName.replace(/[A-Z]/g, s => `-${s.toLowerCase()}`)}`;
+      });
+    }
 
-    const parsed = raw(node);
+    // workaround to avoid parse React Component properties to string in the raw step
+    if (typeof node.properties === 'object' && hasComplexProp(node.properties)) {
+      props.push(node.properties);
+      node.properties = {
+        _index: props.length - 1,
+      };
+    }
 
-    // restore React Component
-    visit(parsed, 'element', elm => {
-      if (/^dumi-raw/.test(elm.tagName as string)) {
-        elm.tagName = (elm.tagName as string)
-          .replace('dumi-raw', '')
-          .replace(/-([a-z])/g, (_, word) => word.toUpperCase());
-      }
-    });
-
-    // replace original node
-    (parent.children as Array<any>).splice(
-      i,
-      1,
-      // ignore root element if there has parent node
-      ...(parent && parsed.type === 'root' ? parsed.children : [parsed]),
-    );
+    // special process <code />, <code > to <code></code>
+    // to avoid non-self-closing exception in the raw step
+    if (typeof node.value === 'string' && /<code/.test(node.value)) {
+      node.value = node.value.replace(/ ?\/?>/g, '></code>');
+    }
   });
+
+  // raw to hast tree
+  const parsed = raw(ast);
+
+  // restore React Component & it's properties
+  visit(parsed, 'element', elm => {
+    // restore tag name
+    if (/^dumi-raw/.test(elm.tagName as string)) {
+      elm.tagName = (elm.tagName as string)
+        .replace('dumi-raw', '')
+        .replace(/-([a-z])/g, (_, word) => word.toUpperCase());
+    }
+
+    // restore properties from temp array
+    if (has(elm, '_index')) {
+      elm.properties = props[(elm.properties as any)._index];
+    }
+  });
+
+  return parsed;
 };

--- a/packages/preset-dumi/src/transformer/remark/sourceCode.ts
+++ b/packages/preset-dumi/src/transformer/remark/sourceCode.ts
@@ -11,7 +11,7 @@ function createSourceCode(lang: string, code: string, position: any) {
       // use wrapper element to workaround for skip props escape
       // https://github.com/mapbox/jsxtreme-markdown/blob/main/packages/hast-util-to-jsx/index.js#L159
       // eslint-disable-next-line no-new-wrappers
-      code: new String(code),
+      code: new String(JSON.stringify(code)),
       lang: lang || 'unknown',
     },
   };

--- a/packages/preset-dumi/src/transformer/remark/sourceCode.ts
+++ b/packages/preset-dumi/src/transformer/remark/sourceCode.ts
@@ -1,28 +1,57 @@
 import visit from 'unist-util-visit';
 import toString from 'hast-util-to-string';
+import raw from 'hast-util-raw';
+
+function createSourceCode(lang: string, code: string, position: any) {
+  return {
+    type: 'element',
+    tagName: 'SourceCode',
+    position,
+    properties: {
+      // use wrapper element to workaround for skip props escape
+      // https://github.com/mapbox/jsxtreme-markdown/blob/main/packages/hast-util-to-jsx/index.js#L159
+      // eslint-disable-next-line no-new-wrappers
+      code: new String(code),
+      lang: lang || 'unknown',
+    },
+  };
+}
 
 /**
  * rehype plugin for convert code block to SourceCode compomnent
  */
 export default () => {
-  return tree => {
-    visit(tree, 'element', (node, i, parent) => {
+  return ast => {
+    // handle md code block syntax
+    visit(ast, 'element', (node, i, parent) => {
       if (node.tagName === 'pre' && node.children?.[0]?.tagName === 'code') {
         const cls = node.children[0].properties.className || [];
         const lang = cls.join('').match(/language-(\w+)(?:$| )/)?.[1] || 'unknown';
 
-        (parent.children as any).splice(i, 1, {
-          type: 'element',
-          position: node.position,
-          tagName: 'SourceCode',
-          properties: {
-            // use wrapper element to workaround for skip props escape
-            // https://github.com/mapbox/jsxtreme-markdown/blob/main/packages/hast-util-to-jsx/index.js#L159
-            // eslint-disable-next-line no-new-wrappers
-            code: new String(JSON.stringify(toString(node.children[0]))),
-            lang,
-          },
-        });
+        (parent.children as any).splice(
+          i,
+          1,
+          createSourceCode(lang, toString(node.children[0]), node.position),
+        );
+      }
+    });
+
+    // handle pre tag syntax
+    visit(ast, 'raw', (node, i, parent) => {
+      if (/^<pre/.test(node.value as string)) {
+        const parsed = raw(node);
+
+        if (parsed.tagName === 'pre') {
+          const [, content] = (node.value as string).match(/^<pre[^>]*>\n?([^]*?)<\/pre>$/) || [];
+
+          if (content) {
+            (parent.children as any).splice(
+              i,
+              1,
+              createSourceCode(parsed.properties?.lang, content, node.position),
+            );
+          }
+        }
       }
     });
   };

--- a/packages/preset-dumi/src/transformer/utils.ts
+++ b/packages/preset-dumi/src/transformer/utils.ts
@@ -14,7 +14,11 @@ export const formatJSXProps = (props: { [key: string]: any }): { [key: string]: 
 
     // use wrapper object for workaround implement raw props render
     // https://github.com/mapbox/jsxtreme-markdown/blob/main/packages/hast-util-to-jsx/index.js#L167
-    if (props[key] !== null && (typeof props[key] === 'object' || Array.isArray(props[key]))) {
+    if (
+      !(props[key] instanceof String) &&
+      props[key] !== null &&
+      (typeof props[key] === 'object' || Array.isArray(props[key]))
+    ) {
       result[key] = new String(JSON.stringify(props[key]));
     }
 

--- a/packages/preset-dumi/src/transformer/utils.ts
+++ b/packages/preset-dumi/src/transformer/utils.ts
@@ -14,11 +14,7 @@ export const formatJSXProps = (props: { [key: string]: any }): { [key: string]: 
 
     // use wrapper object for workaround implement raw props render
     // https://github.com/mapbox/jsxtreme-markdown/blob/main/packages/hast-util-to-jsx/index.js#L167
-    if (
-      !(props[key] instanceof String) &&
-      props[key] !== null &&
-      (typeof props[key] === 'object' || Array.isArray(props[key]))
-    ) {
+    if (props[key] !== null && (typeof props[key] === 'object' || Array.isArray(props[key]))) {
       result[key] = new String(JSON.stringify(props[key]));
     }
 


### PR DESCRIPTION
## 修复内容
- `<pre>` 标签支持高亮源代码，可通过 `lang` 属性配置代码块语言，同时解决重写 transformer 后 `<pre>` 标签内写 JSX 会报错的问题
- 解决 `hast-util-raw` 处理后 Node 的属性值全部变成字符串的问题
- [临时方案] 解决 hast-util-to-jsx 处理后 camelCase 的 props 都被转换成 kebab-case 的问题

## 遗留问题
- hast-util-raw 和 hast-util-to-jsx 终态还是需要 fork 一份做特殊定制，或者给上游 PR 提升可配置性