### PR TITLE
feat(preset): support to set repository branch in package

### DIFF
--- a/docs/guide/mode.md
+++ b/docs/guide/mode.md
@@ -25,6 +25,8 @@ export default {
 - 没有定制化的首页
 - 支持 `description` 配置项展示简介
 - 支持通过 `package.json` 中的 `repository` 配置自动展示 GitHub Stars 数
+- 支持通过 `package.json` 中的 `repository` 配置自动展示 `markdown` 文件 `footer` 中 `Edit this doc on GitHub` 的超链接
+- 支持通过 `package.json` 中的 `repository.branch` 配置可修改 `Edit this doc on GitHub` 该超链接跳转的分支，默认为 `master` 分支
 
 ## 站点模式
 

--- a/packages/preset-dumi/src/plugins/core.ts
+++ b/packages/preset-dumi/src/plugins/core.ts
@@ -120,7 +120,10 @@ export default function(api: IApi) {
       logo: opts.logo,
       desc: opts.description,
       mode: opts.mode,
-      repoUrl: getRepoUrl(pkg.repository?.url || pkg.repository),
+      repository: {
+        url: getRepoUrl(pkg.repository?.url || pkg.repository),
+        branch: pkg.repository?.branch || 'master',
+      },
       algolia: opts.algolia,
     };
 

--- a/packages/preset-dumi/src/themes/default/layout.tsx
+++ b/packages/preset-dumi/src/themes/default/layout.tsx
@@ -23,7 +23,10 @@ export interface ILayoutProps {
   menus: IMenu[];
   locales: ILocale[];
   mode: IDumiOpts['mode'];
-  repoUrl?: string;
+  repository?: {
+    url: string;
+    branch?: string;
+  };
 }
 
 /**
@@ -296,7 +299,8 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
   );
 
   render() {
-    const { mode, title, desc, logo, repoUrl, locales, algolia, children } = this.props;
+    const { mode, title, desc, logo, repository, locales, algolia, children } = this.props;
+    const { url: repoUrl, branch } = repository;
     const { navs, menus, menuCollapsed, currentLocale, currentSlug, currentRouteMeta } = this.state;
     const siteMode = this.props.mode === 'site';
     const showHero = siteMode && currentRouteMeta.hero;
@@ -374,7 +378,7 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
                   <a
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={`${repoUrl}/edit/master/${currentRouteMeta.filePath}`}
+                    href={`${repoUrl}/edit/${branch}/${currentRouteMeta.filePath}`}
                   >
                     {isCN
                       ? `在 ${repoPlatform} 上编辑这篇文档`


### PR DESCRIPTION
### 简介
- 支持在 `package.json` 中设置 `repository.branch` 来设置 `edit` 的时候跳转的分支，默认为 `master`

### 主要变更
- 用 `repository.url` 来代替原先的 `repoUrl`，用 `repository.branch` 设置 `branch`
- 更新 `markdown` 文档

### 相关 issue
#214 