### PR TITLE
feat: support peerDep

### DIFF
--- a/packages/preset-dumi/src/transformer/demo/dependencies.ts
+++ b/packages/preset-dumi/src/transformer/demo/dependencies.ts
@@ -66,7 +66,7 @@ function analyzeDeps(
           });
 
           if (pkg.peerDependencies) {
-            Object.keys(pkg.peerDependencies).forEach(item => dependencies[item] = pkg.peerDependencies[item]);
+            Object.assign(dependencies, pkg.peerDependencies)
           }
 
           dependencies[pkg.name] = pkg.version;

--- a/packages/preset-dumi/src/transformer/demo/dependencies.ts
+++ b/packages/preset-dumi/src/transformer/demo/dependencies.ts
@@ -65,6 +65,10 @@ function analyzeDeps(
             extensions: LOCAL_MODULE_EXT,
           });
 
+          if (pkg.peerDependencies) {
+            Object.keys(pkg.peerDependencies).forEach(item => dependencies[item] = pkg.peerDependencies[item]);
+          }
+
           dependencies[pkg.name] = pkg.version;
         } else if (
           // only analysis for valid local file type

--- a/packages/preset-dumi/src/transformer/demo/dependencies.ts
+++ b/packages/preset-dumi/src/transformer/demo/dependencies.ts
@@ -66,7 +66,7 @@ function analyzeDeps(
           });
 
           if (pkg.peerDependencies) {
-            Object.assign(dependencies, pkg.peerDependencies)
+            Object.assign(dependencies, pkg.peerDependencies);
           }
 
           dependencies[pkg.name] = pkg.version;

--- a/packages/preset-dumi/src/transformer/fixtures/demo-deps/peer/index.ts
+++ b/packages/preset-dumi/src/transformer/fixtures/demo-deps/peer/index.ts
@@ -1,0 +1,3 @@
+import Clipboard from 'react-clipboard.js';
+
+export default Clipboard;

--- a/packages/preset-dumi/src/transformer/test/demo-deps.test.ts
+++ b/packages/preset-dumi/src/transformer/test/demo-deps.test.ts
@@ -38,4 +38,14 @@ describe('demo transformer: dependencies', () => {
     expect(Object.keys(result.files).length).toEqual(1);
     expect(result.dependencies['js-yaml']).not.toBeUndefined();
   });
+
+  it("merge dep's peerDependencies", () => {
+    const filePath = path.join(__dirname, '../fixtures/demo-deps/peer/index.ts');
+    const result = analyzeDeps(fs.readFileSync(filePath).toString(), {
+      isTSX: false,
+      fileAbsPath: filePath,
+    });
+
+    expect(result.dependencies.react).not.toBeUndefined();
+  });
 });

--- a/packages/preset-dumi/src/utils/moduleResolver.ts
+++ b/packages/preset-dumi/src/utils/moduleResolver.ts
@@ -43,9 +43,9 @@ export const getModuleResolvePkg = ({
   sourcePath,
   extensions = DEFAULT_EXT,
 }: IModuleResolverOpts) => {
-  let version: string | null = null;
-  let name: string | null = null;
-  let peerDependencies: any[] | null = [];
+  let version: string | null;
+  let name: string | null;
+  let peerDependencies: any | null;
   const resolvePath = getModuleResolvePath({ basePath, sourcePath, extensions });
   const modulePath = resolvePath.match(/^(.*?node_modules\/(?:@[^/]+\/)?[^/]+)/)?.[1];
   const pkgPath = path.join(modulePath, 'package.json');

--- a/packages/preset-dumi/src/utils/moduleResolver.ts
+++ b/packages/preset-dumi/src/utils/moduleResolver.ts
@@ -45,6 +45,7 @@ export const getModuleResolvePkg = ({
 }: IModuleResolverOpts) => {
   let version: string | null = null;
   let name: string | null = null;
+  let peerDependencies: any[] | null = [];
   const resolvePath = getModuleResolvePath({ basePath, sourcePath, extensions });
   const modulePath = resolvePath.match(/^(.*?node_modules\/(?:@[^/]+\/)?[^/]+)/)?.[1];
   const pkgPath = path.join(modulePath, 'package.json');
@@ -54,11 +55,12 @@ export const getModuleResolvePkg = ({
 
     version = pkg.version;
     name = pkg.name;
+    peerDependencies = pkg.peerDependencies;
   } else {
     ctx.umi?.logger.error(`[dumi]: cannot find valid package.json for module ${modulePath}`);
   }
 
-  return { name, version };
+  return { name, version, peerDependencies };
 };
 
 /**


### PR DESCRIPTION
比如我在开发组件库 A，peer 了 antd，但 demo 的依赖只识别依赖到 A，那 codesandbox 就只会安装 A，但 A 没有 antd 跑不起来，所以 demo 的依赖应该默认把 A 的 peer 都加进来。

react 的依赖会被重置，其他的peer 依赖会被添加。比如，胡乱改了版本。
![image](https://user-images.githubusercontent.com/11746742/87025163-9e552e00-c20c-11ea-8953-a402c974b3b3.png)
