### PR TITLE
feat(theme): add demo anchor

### DIFF
--- a/packages/preset-dumi/src/themes/default/builtins/Previewer.less
+++ b/packages/preset-dumi/src/themes/default/builtins/Previewer.less
@@ -12,6 +12,10 @@
     padding: 40px 24px;
   }
 
+  &-target {
+    border-color: #3d62d2;
+  }
+
   &-desc {
     &:not(:empty) {
       padding: 1em;
@@ -30,6 +34,7 @@
     &[title] {
       position: relative;
       padding-top: 1.2em;
+      pointer-events: none;
 
       &::before {
         content: attr(title);
@@ -42,6 +47,8 @@
         font-weight: 500;
         background-color: #fff;
         transform: translateY(-50%);
+        pointer-events: auto;
+        cursor: pointer;
       }
 
       &:empty {

--- a/packages/preset-dumi/src/themes/default/builtins/Previewer.tsx
+++ b/packages/preset-dumi/src/themes/default/builtins/Previewer.tsx
@@ -238,7 +238,7 @@ ${issueLink}`,
         {...props}
         className={[
           '__dumi-default-previewer',
-          decodeURI(history.location.hash.replace('#', '')) === id
+          decodeURI(history.location.hash.replace('#', '')) === id && title
             ? '__dumi-default-previewer-target'
             : '',
           props.className,

--- a/packages/preset-dumi/src/themes/default/builtins/Previewer.tsx
+++ b/packages/preset-dumi/src/themes/default/builtins/Previewer.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React, { Component } from 'react';
+import { history } from 'umi';
 import innertext from 'innertext';
 import CopyButton from '../CopyButton';
 import SourceCode from './SourceCode';
 import finaliseCSB, { issueLink } from '../../../utils/codesandbox';
 import localePropsHoc from '../localePropsHoc';
 import CsbButton from '../csbButton';
+import { scrollToSlug } from '../SlugList';
 import './Previewer.less';
 
 export interface IPreviewerProps {
@@ -112,6 +114,12 @@ class Previewer extends Component<IPreviewerProps> {
         'https://private-alipayobjects.alipay.com/alipay-rmsdeploy-image/rmsportal/RKuAiriJqrUhyqW.png';
     }
   }
+
+  handleAnchorClick = (title: string) => {
+    const demoAnchor = `${history.location.pathname}#${title}`;
+    history.push(demoAnchor);
+    scrollToSlug(title);
+  };
 
   initCSBData = () => {
     const { source, desc = '', title, dependencies, files } = this.props;
@@ -221,7 +229,19 @@ ${issueLink}`,
     }
 
     return (
-      <div {...props} className={['__dumi-default-previewer', props.className].join(' ')}>
+      <div
+        {...props}
+        className={[
+          '__dumi-default-previewer',
+          decodeURI(history.location.hash.replace('#', '')) === title
+            ? '__dumi-default-previewer-target'
+            : '',
+          props.className,
+        ]
+          .filter(c => c)
+          .join(' ')}
+        id={title}
+      >
         <div
           className="__dumi-default-previewer-demo"
           style={{
@@ -234,6 +254,7 @@ ${issueLink}`,
         </div>
         <div
           className="__dumi-default-previewer-desc"
+          onClick={() => this.handleAnchorClick(title)}
           title={title}
           // eslint-disable-next-line
           dangerouslySetInnerHTML={{ __html: desc }}

--- a/packages/preset-dumi/src/themes/default/builtins/Previewer.tsx
+++ b/packages/preset-dumi/src/themes/default/builtins/Previewer.tsx
@@ -57,6 +57,10 @@ export interface IPreviewerProps {
    */
   dependencies: { [key: string]: string };
   /**
+   * demo anchor id
+   */
+  id?: string;
+  /**
    * 1-level files that include by demo
    */
   files: {
@@ -115,10 +119,10 @@ class Previewer extends Component<IPreviewerProps> {
     }
   }
 
-  handleAnchorClick = (title: string) => {
-    const demoAnchor = `${history.location.pathname}#${title}`;
+  handleAnchorClick = (id: string) => {
+    const demoAnchor = `${history.location.pathname}#${id}`;
     history.push(demoAnchor);
-    scrollToSlug(title);
+    scrollToSlug(id);
   };
 
   initCSBData = () => {
@@ -216,6 +220,7 @@ ${issueLink}`,
       path,
       dependencies,
       files,
+      id,
       ...props
     } = this.props;
     const { showSource, sourceType, showRiddle, currentFile } = this.state;
@@ -233,14 +238,14 @@ ${issueLink}`,
         {...props}
         className={[
           '__dumi-default-previewer',
-          decodeURI(history.location.hash.replace('#', '')) === title
+          decodeURI(history.location.hash.replace('#', '')) === id
             ? '__dumi-default-previewer-target'
             : '',
           props.className,
         ]
           .filter(c => c)
           .join(' ')}
-        id={title}
+        id={id}
       >
         <div
           className="__dumi-default-previewer-demo"
@@ -254,7 +259,7 @@ ${issueLink}`,
         </div>
         <div
           className="__dumi-default-previewer-desc"
-          onClick={() => this.handleAnchorClick(title)}
+          onClick={() => this.handleAnchorClick(id)}
           title={title}
           // eslint-disable-next-line
           dangerouslySetInnerHTML={{ __html: desc }}

--- a/packages/preset-dumi/src/themes/default/layout.tsx
+++ b/packages/preset-dumi/src/themes/default/layout.tsx
@@ -220,6 +220,9 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
     const { slugs = [] } = this.state.currentRouteMeta;
     const { currentSlug } = this.state;
     // 如果当前的 slugs 不含 currentSlug, 就去更新
+    if (slugs.find(slug => slug.heading === currentSlug)) {
+      return;
+    }
     const container = window;
     const linkSections: Array<{ heading: string; top: number }> = [];
     [...slugs]

--- a/packages/preset-dumi/src/transformer/remark/previewer.ts
+++ b/packages/preset-dumi/src/transformer/remark/previewer.ts
@@ -1,8 +1,12 @@
 import { Node } from 'unist';
+import slugger from 'github-slugger';
 import visit from 'unist-util-visit';
+import has from 'hast-util-has-property';
 import ctx from '../../context';
 import demoTransformer, { DEMO_COMPONENT_NAME, getDepsForDemo } from '../demo';
 import transformer from '..';
+
+const slugs = slugger();
 
 function visitor(node, i, parent: Node) {
   if (node.tagName === 'div' && node.properties?.type === 'previewer') {
@@ -91,12 +95,15 @@ export default () => <Demo />;`;
         1} = React.memo(${code});`,
     );
 
+    if (!has(node, 'id')) {
+      (node.properties as any).id = slugs.slug(yaml.title);
+    }
     // save demos which have title into slugs
     if (yaml.title) {
       this.vFile.data.slugs.push({
         depth: 5,
         value: yaml.title,
-        heading: yaml.title,
+        heading: node.properties.id,
       });
     }
 
@@ -109,6 +116,7 @@ export default () => <Demo />;`;
         source,
         files,
         dependencies,
+        id: node.properties.id,
         ...yaml,
       },
       children: [

--- a/packages/preset-dumi/src/transformer/remark/previewer.ts
+++ b/packages/preset-dumi/src/transformer/remark/previewer.ts
@@ -91,6 +91,15 @@ export default () => <Demo />;`;
         1} = React.memo(${code});`,
     );
 
+    // save demos which have title into slugs
+    if (yaml.title) {
+      this.vFile.data.slugs.push({
+        depth: 5,
+        value: yaml.title,
+        heading: yaml.title,
+      });
+    }
+
     // replace original node
     parent.children[i] = {
       previewer: true,

--- a/packages/preset-dumi/src/transformer/remark/previewer.ts
+++ b/packages/preset-dumi/src/transformer/remark/previewer.ts
@@ -132,6 +132,7 @@ export default () => <Demo />;`;
 
 export default function previewer() {
   return (ast: Node, vFile) => {
+    slugs.reset();
     visit(ast, 'element', visitor.bind({ vFile, data: this.data }));
   };
 }


### PR DESCRIPTION
## 简介
- 支持 `demo` 锚点
- 修复 `slug` 精准跳转的问题

## 主要变更
- `demo` 新增 `id` 属性
- `demo` 的 `title` 支持点击跳转
- 修复 `slug` 精准跳转的问题
- 当跳转到 `demo` 锚点位置时，新增 `target` 样式

## 相关 issue
#230  
#245  