### PR TITLE
[WIP] feat: add mobile device

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,8 @@
 ---
 title: 文档示例
 legacy: /example
+demoUrl: 'https://d.umijs.org'
+demoSourceUrl: 'https://github.com/umijs/dumi'
 nav:
   order: 3
   title: 渲染示例
@@ -133,3 +135,14 @@ $$
 [前往 Umi 官网](https://umijs.org)
 
 自动转换超链接 https://umijs.org
+
+## 移动端组件展示
+
+只需要在 yaml 中写明 demoUrl 和 demoSourceUrl 即可，demoUrl 用于展示页面，demoSourceUrl 一般为 demo 的源码地址。
+
+```
+---
+demoUrl: 'https://d.umijs.org'
+demoSourceUrl: 'https://github.com/umijs/dumi'
+---
+```

--- a/packages/preset-dumi/package.json
+++ b/packages/preset-dumi/package.json
@@ -42,6 +42,7 @@
     "lz-string": "^1.4.4",
     "prism-react-renderer": "^1.0.2",
     "prismjs": "^1.20.0",
+    "qrcode.react": "^1.0.0",
     "react-clipboard.js": "^2.0.16",
     "rehype-autolink-headings": "^2.0.5",
     "rehype-katex": "^3.0.0",

--- a/packages/preset-dumi/src/themes/default/device.less
+++ b/packages/preset-dumi/src/themes/default/device.less
@@ -1,0 +1,135 @@
+@import (reference) './variables.less';
+
+.@{prefix}-device {
+  --device-aspect-ratio: 2.125;
+  --device-padding: 2rem;
+  padding: var(--device-padding);
+  position: sticky;
+  top: 0;
+  max-width: 375px;
+  min-width: 375px;
+}
+
+.@{prefix}-device > figure {
+  border-radius: 32px;
+  box-shadow: 0 0 0 14px #090a0d, 0 0 0 17px #9fa3a8, 0 0 34px 17px rgba(0, 0, 0, 0.2);
+  height: 0;
+  margin: 0;
+  max-width: 320px;
+  min-width: 320px;
+  overflow: hidden;
+  padding-bottom: calc(var(--device-aspect-ratio) * 100%);
+  position: relative;
+  width: calc(
+    (100vh - var(--header-height) - var(--device-padding) * 2) / var(--device-aspect-ratio)
+  );
+  z-index: 1;
+}
+
+.@{prefix}-device > figure > iframe {
+  border: none;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  border-radius: 30px;
+}
+
+.@{prefix}-mode-toggle {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding-top: 1rem;
+}
+
+.@{prefix}-mode-toggle button {
+  background-color: transparent;
+  border: none;
+  border-radius: 16px;
+  color: var(--text-color--light);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  line-height: 24px;
+  margin: 0px 3px;
+  padding: 0 9px;
+  text-transform: uppercase;
+  transition: 200ms background-color ease, 200ms color ease;
+}
+
+.@{prefix}-mode-toggle button:focus,
+.@{prefix}-mode-toggle button:active {
+  outline: none;
+}
+
+.@{prefix}-mode-toggle button.is-selected {
+  background-color: var(--text-color--dark);
+  color: white;
+}
+
+.@{prefix}-source {
+  align-items: center;
+  display: flex;
+  font-size: 13px;
+  justify-content: center;
+  margin-top: 26px;
+}
+
+@media (max-width: 1160px) {
+  .@{prefix}-device,
+  .@{prefix}-mode-toggle,
+  .@{prefix}-source {
+    display: none;
+  }
+}
+
+.@{prefix}-device__ios-notch {
+  display: none;
+  fill: #090a0d;
+  left: 50%;
+  position: absolute;
+  top: -1px;
+  transform: translateX(-50%);
+  width: 165px;
+  z-index: 2;
+}
+
+.@{prefix}-device.ios figure:after {
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 2px;
+  bottom: 6px;
+  content: '';
+  display: none;
+  height: 4px;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+  width: 35%;
+  z-index: 1;
+}
+
+.@{prefix}-device.ios .@{prefix}-device__ios-notch,
+.@{prefix}-device.ios figure:after {
+  display: block;
+}
+
+.@{prefix}-device.md figure {
+  border-radius: 20px;
+}
+
+.@{prefix}-device__md-bar {
+  display: none;
+}
+
+.@{prefix}-device.md .@{prefix}-device__md-bar {
+  display: block;
+  fill: #090a0d;
+  opacity: 0.1;
+  padding: 0.5rem 0.75rem;
+  position: relative;
+  width: 100%;
+  z-index: 2;
+}

--- a/packages/preset-dumi/src/themes/default/device.tsx
+++ b/packages/preset-dumi/src/themes/default/device.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/jsx-no-target-blank */
+import React, { useState, FC } from 'react';
+import Popover from 'antd/es/popover';
+// @ts-ignore
+import QRCode from 'qrcode.react';
+import 'antd/es/popover/style/index';
+import './device.less';
+
+// 先用qrcode.react，担心大小太大了，可能的话，自己实现
+// https://github.com/davidshimjs/qrcodejs
+interface DeviceProps {
+  url: string;
+  source: string;
+  isCN?: any;
+}
+interface DeviceLocale {
+  view_source: string;
+}
+const getLocale = (isCN: string) => {
+  const locales: { [key: string]: DeviceLocale } = {
+    'zh-cn': {
+      view_source: '查看源码',
+    },
+    en: {
+      view_source: 'View Source',
+    },
+  };
+  // 把key转成全小写的
+  return locales[isCN ? 'zh-cn' : 'en'];
+};
+const Device: FC<DeviceProps> = ({ url, source, isCN = true }) => {
+  const locale = getLocale(isCN);
+  const content = <QRCode value={url} size={258} />;
+  return (
+    <>
+      <div className="__dumi-default-device ios">
+        <figure>
+          <svg className="__dumi-default-device__md-bar" viewBox="0 0 1384.3 40.3">
+            <path
+              className="st0"
+              d="M1343 5l18.8 32.3c.8 1.3 2.7 1.3 3.5 0L1384 5c.8-1.3-.2-3-1.7-3h-37.6c-1.5 0-2.5 1.7-1.7 3z"
+            />
+            <circle className="st0" cx="1299" cy="20.2" r="20" />
+            <path
+              className="st0"
+              d="M1213 1.2h30c2.2 0 4 1.8 4 4v30c0 2.2-1.8 4-4 4h-30c-2.2 0-4-1.8-4-4v-30c0-2.3 1.8-4 4-4zM16 4.2h64c8.8 0 16 7.2 16 16s-7.2 16-16 16H16c-8.8 0-16-7.2-16-16s7.2-16 16-16z"
+            />
+          </svg>
+          <iframe title="dumi mobile" src={url} />
+        </figure>
+        <a href={source} className="__dumi-default-source" target="_blank" title="Demo Source">
+          <Popover content={content} trigger="hover">
+            <QRCode value={url} size={24} style={{ marginRight: '5px' }} />
+          </Popover>
+          {locale.view_source}
+        </a>
+      </div>
+    </>
+  );
+};
+
+export default Device;

--- a/packages/preset-dumi/src/themes/default/layout.less
+++ b/packages/preset-dumi/src/themes/default/layout.less
@@ -62,6 +62,10 @@ body {
     }
   }
 
+  &-col {
+    display: flex;
+  }
+
   &-hero {
     margin: -50px -58px 0;
     padding: 100px 0;

--- a/packages/preset-dumi/src/themes/default/layout.tsx
+++ b/packages/preset-dumi/src/themes/default/layout.tsx
@@ -9,6 +9,7 @@ import Navbar from './Navbar';
 import SideMenu from './SideMenu';
 import SlugList, { scrollToSlug } from './SlugList';
 import SearchBar from './SearchBar';
+import Device from './device';
 import 'prismjs/themes/prism.css';
 import 'katex/dist/katex.min.css';
 import './layout.less';
@@ -301,8 +302,16 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
   render() {
     const { mode, title, desc, logo, repository, locales, algolia, children } = this.props;
     const { url: repoUrl, branch } = repository;
-    const { navs, menus, menuCollapsed, currentLocale, currentSlug, currentRouteMeta } = this.state;
+    const {
+      navs,
+      menus,
+      menuCollapsed,
+      currentLocale,
+      currentSlug,
+      currentRouteMeta = {},
+    } = this.state;
     const siteMode = this.props.mode === 'site';
+    const showMobileDemo = !!currentRouteMeta.demoUrl;
     const showHero = siteMode && currentRouteMeta.hero;
     const showFeatures = siteMode && currentRouteMeta.features;
     const showSideMenu =
@@ -313,6 +322,7 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
     const showSlugs =
       !showHero &&
       !showFeatures &&
+      !showMobileDemo &&
       Boolean(currentRouteMeta.slugs?.length) &&
       (currentRouteMeta.toc === 'content' || currentRouteMeta.toc === undefined) &&
       !currentRouteMeta.gapless;
@@ -371,7 +381,12 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
           {showHero && this.renderHero(currentRouteMeta.hero)}
           {showFeatures && this.renderFeatures(currentRouteMeta.features)}
           <div className="__dumi-default-layout-content">
-            {children}
+            <div className="__dumi-default-layout-col">
+              <div className="__dumi-default-layout-article">{children}</div>
+              {showMobileDemo && (
+                <Device url={currentRouteMeta.demoUrl} source={currentRouteMeta.demoSourceUrl} />
+              )}
+            </div>
             {!showHero && !showFeatures && currentRouteMeta.filePath && !currentRouteMeta.gapless && (
               <div className="__dumi-default-layout-footer-meta">
                 {repoPlatform && (

--- a/packages/preset-dumi/src/themes/default/variables.less
+++ b/packages/preset-dumi/src/themes/default/variables.less
@@ -11,7 +11,7 @@
 @s-nav-height: 64px;
 @s-mobile-nav-height: 50px;
 @s-menu-width: 260px;
-@s-site-menu-width: 300px;
+@s-site-menu-width: 239px;
 @s-menu-mobile-width: 240px;
 @s-content-margin: 58px;
 


### PR DESCRIPTION
只需要在 yaml 中写明 demoUrl 和 demoSourceUrl 即可，demoUrl 用于展示页面，demoSourceUrl 一般为 demo 的源码地址。
展示 demo 的时候，不展示导航。

还改了一下菜单的宽度，从300px 改成 239px。为右边预留更多的位置。

![image](https://user-images.githubusercontent.com/11746742/88250972-e16ad300-ccdb-11ea-881c-9e66c0529002.png)

相关issues：https://github.com/ant-design/ant-design-mobile/issues/3671