### PR TITLE
fix: losing query params while scrolling

### DIFF
--- a/packages/preset-dumi/src/themes/default/layout.tsx
+++ b/packages/preset-dumi/src/themes/default/layout.tsx
@@ -254,7 +254,7 @@ export default class Layout extends Component<ILayoutProps & RouteProps> {
     // clear heading if scroll top than first section
     if (document.documentElement.scrollTop === 0) {
       if (location.hash) {
-        history.replace(location.pathname);
+        history.replace(location.href.split('#')[0]);
       }
       return;
     }


### PR DESCRIPTION
fix: query params get cleared when scroll all the way up to top.


![image](https://gw.alipayobjects.com/mdn/rms_b8ab33/afts/img/A*UufIT4RzLS4AAAAAAAAAAABkARQnAQ)
