### PR TITLE
fix(transformer): use slash for path to compatible with windows

### DIFF
--- a/packages/preset-dumi/src/plugins/features/demos.ts
+++ b/packages/preset-dumi/src/plugins/features/demos.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import slash from 'slash2';
 import { IApi } from '@umijs/types';
 import getTheme from '../../theme/loader';
 
@@ -44,7 +45,7 @@ export default {
   api.register({
     key: 'dumi.detectDemo',
     fn({ uuid, code, previewerProps }) {
-      demos[uuid] = {
+      demos[slash(uuid)] = {
         previewerProps,
         component: `React.memo(${code})`,
       };
@@ -64,9 +65,10 @@ export default {
         component: `(props) => {
           const react = require('react');
           const demos = require('@@/dumi/demos').default;
+          const slash = require('slash2');
           const uuid = props.match.params.uuid;
           const inline = props.location.query.wrapper === undefined;
-          const demo = demos[uuid];
+          const demo = demos[slash(uuid)];
 
           if (demo) {
             if (inline) {

--- a/packages/preset-dumi/src/transformer/remark/previewer.ts
+++ b/packages/preset-dumi/src/transformer/remark/previewer.ts
@@ -1,5 +1,6 @@
 import { Node } from 'unist';
 import visit from 'unist-util-visit';
+import slash from 'slash2';
 import ctx from '../../context';
 import demoTransformer, { DEMO_COMPONENT_NAME, getDepsForDemo } from '../demo';
 import { IPreviewerComponentProps } from '../../theme';
@@ -184,7 +185,7 @@ function visitor(node, i, parent: Node) {
       `const ${DEMO_COMPONENT_NAME}${(this.vFile.data.demos?.length || 0) +
         1} = require('@@/dumi/demos').default['${
         // render demo from the common demo module: @@/dumi/demos
-        previewerProps.identifier
+        slash(previewerProps.identifier)
       }'].component;`,
     );
 


### PR DESCRIPTION
### 简介
- windows 下启动在 `.umi/dumi/demos.ts` 生成的文件格式不对，因为 windows 下的路径片段分隔符是反斜杠，导致解析出问题

### 主要变更
- 用 `slash` 处理 `uuid`

### Related Issue
#279 
