### PR TITLE
fix(theme): scroller not back to top

### DIFF
--- a/packages/dumi/README.md
+++ b/packages/dumi/README.md
@@ -20,7 +20,7 @@ To check out live examples and docs, visit [dumi official site](https://d.umijs.
 
 ```bash
 $ yarn
-$ yarn build -w
+$ yarn watch
 $ yarn dev
 ```
 

--- a/packages/theme-default/src/layout.tsx
+++ b/packages/theme-default/src/layout.tsx
@@ -60,7 +60,6 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
     (repoUrl || '').match(/(github|gitlab)/)?.[1] || 'nothing'
   ];
 
-  console.log('location.pathname:', location);
   // set scroller to top while change url
   useEffect(() => {
     window.scrollTo({

--- a/packages/theme-default/src/layout.tsx
+++ b/packages/theme-default/src/layout.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { IRouteComponentProps } from '@umijs/types';
 import { context, Link } from 'dumi/theme';
 import Navbar from './components/Navbar';
@@ -59,6 +59,14 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
   const repoPlatform = { github: 'GitHub', gitlab: 'GitLab' }[
     (repoUrl || '').match(/(github|gitlab)/)?.[1] || 'nothing'
   ];
+
+  console.log('location.pathname:', location);
+  // set scroller to top while change url
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+    });
+  }, [location.pathname]);
 
   return (
     <div


### PR DESCRIPTION
### 简介
- 修复切换路由滚动条没有回到顶部
- 修复 `README.md` 中关于 `Development` 的方式未更新的情况