### PR TITLE
修复 IE 兼容性问题

### DIFF
--- a/packages/preset-dumi/src/theme/components/AnchorLink.test.tsx
+++ b/packages/preset-dumi/src/theme/components/AnchorLink.test.tsx
@@ -34,6 +34,12 @@ describe('theme API: AnchorLink', () => {
     // FIXME: element.offsetTop not working in jest
     Object.defineProperty(anchor, 'offsetTop', { value: 110 });
 
+    // mock a scrollTo for jest
+    // @ts-ignore
+    window.scrollTo = jest.fn((x, y) => {
+      document.documentElement.scrollTop = y;
+    });
+
     // expect scroll to anchor when click (distance 100px from top)
     expect(document.documentElement.scrollTop).toEqual(0);
     anchor.click();

--- a/packages/preset-dumi/src/theme/components/AnchorLink.test.tsx
+++ b/packages/preset-dumi/src/theme/components/AnchorLink.test.tsx
@@ -8,6 +8,7 @@ import AnchorLink from './AnchorLink';
 describe('theme API: AnchorLink', () => {
   let anchor: any;
   let stub: any;
+  let scrollTo: any;
 
   beforeAll(async () => {
     render(
@@ -28,12 +29,14 @@ describe('theme API: AnchorLink', () => {
 
   afterAll(() => {
     window.requestAnimationFrame = stub;
+    window.scrollTo = scrollTo;
   });
 
   it('should scroll to anchor after click', async () => {
     // FIXME: element.offsetTop not working in jest
     Object.defineProperty(anchor, 'offsetTop', { value: 110 });
 
+    scrollTo = window.scrollTo;
     // mock a scrollTo for jest
     // @ts-ignore
     window.scrollTo = jest.fn((x, y) => {

--- a/packages/preset-dumi/src/theme/components/AnchorLink.tsx
+++ b/packages/preset-dumi/src/theme/components/AnchorLink.tsx
@@ -20,7 +20,8 @@ AnchorLink.scrollToAnchor = (anchor: string) => {
     const elm = document.getElementById(decodeURIComponent(anchor));
 
     if (elm) {
-      document.documentElement.scrollTop = elm.offsetTop - 100;
+      // compatible in Edge
+      window.scrollTo(0, elm.offsetTop - 100);
     }
   });
 };


### PR DESCRIPTION
### 简介
- 修复锚点在 Edge 无效的问题

### 主要变更
- 锚点滚动用 `window.scrollTo` 来实现，查了一下 兼容性还可以，只不过 `Edge` 貌似不支持 `smooth` 滚动
- [scrollTo的MDN](https://developer.mozilla.org/zh-CN/docs/Web/API/Window/scrollTo)