### PR TITLE
fix: demo dynamic route in bmw

### DIFF
--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -139,4 +139,28 @@ describe('preset-dumi', () => {
 
     expect(await findByText('local theme layout')).not.toBeNull();
   });
+
+  it('platform env', async () => {
+    const oType = process.env.PLATFORM_TYPE;
+
+    process.env.PLATFORM_TYPE = 'TESTING';
+
+    const service = new Service({
+      cwd: fixtures,
+      presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
+    });
+    const defines = (await service.run({
+      name: 'webpack',
+      args: {
+        _: ['webpack'],
+        plugin: 'define',
+      },
+    })) as any;
+
+    // expect define PLATFORM_TYPE
+    expect(defines.definitions['process.env.PLATFORM_TYPE'] === process.env.PLATFORM_TYPE);
+
+    // restore env
+    process.env.PLATFORM_TYPE = oType;
+  });
 });

--- a/packages/preset-dumi/src/plugins/features/demos.ts
+++ b/packages/preset-dumi/src/plugins/features/demos.ts
@@ -13,6 +13,17 @@ interface ISingleRoutetDemos {
 export default (api: IApi) => {
   const demos: ISingleRoutetDemos = {};
 
+  // pass platform env
+  if (process.env.PLATFORM_TYPE) {
+    api.modifyDefaultConfig(memo => {
+      memo.define = Object.assign(memo.define || {}, {
+        'process.env.PLATFORM_TYPE': process.env.PLATFORM_TYPE,
+      });
+
+      return memo;
+    });
+  }
+
   // write all demos into .umi dir
   api.onGenerateFiles(async () => {
     const items = Object.keys(demos).map(

--- a/packages/preset-dumi/src/theme/hooks/useDemoUrl.test.ts
+++ b/packages/preset-dumi/src/theme/hooks/useDemoUrl.test.ts
@@ -15,6 +15,6 @@ describe('theme API: useDemoUrl', () => {
     const { result } = renderHook(() => useDemoUrl('test'));
     process.env.PLATFORM_TYPE = oType;
 
-    expect(result.current).toEqual('http://localhost/_demos/test');
+    expect(result.current).toEqual('http://localhost/_demos/test/index.html');
   });
 });

--- a/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
+++ b/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
@@ -1,11 +1,16 @@
 import { useState, useEffect } from 'react';
 
+// functional for testing
+function isBMW() {
+  return process.env.PLATFORM_TYPE === 'BASEMENT';
+}
+
 export const getDemoRoutePrefix = () => {
-  return process.env.PLATFORM_TYPE === 'BASEMENT' ? '/_demos/' : '/~demos/';
+  return isBMW() ? '/_demos/' : '/~demos/';
 };
 
 export const getDemoUrl = (demoId: string) => {
-  return `${window.location.origin}${getDemoRoutePrefix()}${demoId}`;
+  return `${window.location.origin}${getDemoRoutePrefix()}${demoId}${isBMW() ? '/index.html' : ''}`;
 };
 
 /**


### PR DESCRIPTION
## 修改内容
- 为 runtime 的代码注入 `PLATFORM_TYPE` 用于在运行时判断构建平台
- 修复 basement 构建动态路由的访问路径