### PR TITLE
feat: support docs in lerna private packages

### DIFF
--- a/packages/preset-dumi/src/utils/getHostPkgAlias.ts
+++ b/packages/preset-dumi/src/utils/getHostPkgAlias.ts
@@ -27,7 +27,7 @@ export default (paths: IApi['paths']) => {
 
     if (lernaVersion.startsWith('3')) {
       JSON.parse(
-        execSync(`${path.join(paths.cwd, 'node_modules/.bin/lerna')} ls --json`, {
+        execSync(`${path.join(paths.cwd, 'node_modules/.bin/lerna')} ls --json --all`, {
           stdio: 'pipe',
         }).toString(),
       ).forEach(pkg => {


### PR DESCRIPTION
## 现状

在基于 lerna 的项目实践中，当 lerna 所管辖的一个 package 为 private，即私有包时，其中的所有文档将不会自动纳入到 dumi 的路由中，除非通过 .umirc.ts 等类似 [配置](https://d.umijs.org/zh-CN/config#includes) 强制指定 .md 所在的私有包路径（存在后期配置繁琐的问题）。

因为根据 `lerna list --json` 文档，其仅打印 public packages。

## why

### 需求侧

存在在私有包中 **应该仍可书写文档** 这样的需求。

### 使用侧

> 生成均以 resolve.includes 配置项的值作为基础检测路径，倘若我们不配置该值，则会默认探测 docs 目录、src 目录（普通项目）、packages/pkg/src 目录（lerna 项目）。

在上文对文档引用中，并未提及对于 lerna 项目的处理是否涉及私有包，那么就会出现一种使用现象就是，如论如何自己在私有包中定义的文档都不会被 dumi 纳入到私有路由中，但是又不知道为什么。

### 添加缘由

1. 并不影响原有功能，且只是对原有 lerna package 探测功能的拓展

1. 尽可能避免用户去额外定义 [config](https://d.umijs.org/zh-CN/config#includes) 来实现私有包中的文档书写