### PR TITLE
feat: umi integrate mode

### DIFF
--- a/docs/lab/index.md
+++ b/docs/lab/index.md
@@ -9,6 +9,19 @@ sidemenu: false
 The functions of the laboratory are only works in the <code>next</code> version, you can use <code>npm i dumi@next</code> to install the experimental version for experience; The experimental functions are unstable, please do not use it in production; If you have any suggestions, welcome to feedback and exchanges in the discussion group ❤
 </Alert>
 
+## Umi inregrated mode
+
+**Dependent version:**`dumi@1.1.0-beta.28+`
+
+When we are working a business project, it is a big headache for us to manage the components within project, because these components no need to release a npm package, but also need to be iterated, updated, documented, and handed over; The Umi interagted mode was born for this scene, it includes:
+
+- **Auto-detecting**: The integrated mode will be activated when the `dependencies` or `devDependencies` includes `umi` & `@umijs/preset-dumi` (`dumi` pacakge no longer needed)
+- **Routes isolation**: All the dumi docs will be created under the `/~docs` route, it is isolated from the original project, just like prefix a specific path for all the dumi routes, user's menus and user's navs
+- **Only development**: The Integrated moode only activate when the `NODE_ENV` is `development`, does not includes in the production bundle
+- **Solo support**: We can get the non-integrated docs bundle for deployment via `umi build --dumi`, also available in `umi dev`
+
+To use the integrated mode, we can install the `@umijs/preset-dumi` into `devDependencies`, and configure `resolve.includes` as project needed (for example, use `src/components` as project's components directory).
+
 ## Auto-gen component API
 
 **Dependent version:**`dumi@1.1.0-beta.27+`

--- a/docs/lab/index.zh-CN.md
+++ b/docs/lab/index.zh-CN.md
@@ -9,6 +9,19 @@ sidemenu: false
 实验室的功能仅在 <code>next</code> 版本中提供，可以使用 <code>npm i dumi@next</code> 安装实验版本进行体验；实验性质的功能可能不稳定，请谨慎用于生产；如果体验后有任何建议，欢迎在讨论群中进行反馈和交流 ❤
 </Alert>
 
+## Umi 项目集成模式
+
+**依赖版本：**`dumi@1.1.0-beta.28+`
+
+在进行项目研发时，项目内部的组件库管理通常是一个很头疼的问题，既不需要发布单独的 npm 包，又需要进行迭代、更新、说明、交接；为了让项目内部组件库管理这件事变得更加轻松，dumi 推出了 Umi 项目集成模式：
+
+- **自动探测**：当 `dependencies` 或 `devDependencies` 中包含 `umi` 和 `@umijs/preset-dumi` 时，进入集成模式（不再需要单独安装 `dumi` 这个包）
+- **相互隔离**：所有 dumi 文档都会集中在 `/~docs` 路由下，与原项目相互隔离、互不干扰，可以理解为标准 dumi 文档都加了一个特定路由前缀，也包括用户的导航和菜单路由配置
+- **不影响生产**：仅在 `NODE_ENV` 是 `development` 时集成，不影响项目的生产构建
+- **可单独构建**：如果需要单独构建文档做部署，可执行 `umi build --dumi`，即可得到一份非集成模式的 dumi 站点产物，`--dumi` 在 `umi dev` 命令下也是可用的
+
+使用方式很简单：在已有 Umi 项目中安装 `@umijs/preset-dumi` 到 `devDependencies` 中，再根据需要配置 `resolve.includes` 即可（比如约定 `src/components` 目录下为业务组件库和组件库对应的文档）。
+
 ## 组件 API 自动生成
 
 **依赖版本：**`dumi@1.1.0-beta.27+`

--- a/packages/preset-dumi/src/context.ts
+++ b/packages/preset-dumi/src/context.ts
@@ -66,6 +66,11 @@ export interface IDumiOpts {
     indexName: string;
     debug?: boolean;
   };
+  /**
+   * is integrate mode
+   * @note  if enter interate mode, doc site will append in /~components route in development
+   */
+  isIntegrate: boolean;
 }
 
 const context: { umi?: IApi; opts?: IDumiOpts } = {};
@@ -86,7 +91,7 @@ export function init(umi: IApi, opts: IDumiOpts) {
  * @param value config value
  */
 export function setOptions(key: keyof IDumiOpts, value: any) {
-  context.opts[key] = value;
+  (context.opts[key] as any) = value;
 }
 
 export default context;

--- a/packages/preset-dumi/src/context.ts
+++ b/packages/preset-dumi/src/context.ts
@@ -68,7 +68,7 @@ export interface IDumiOpts {
   };
   /**
    * is integrate mode
-   * @note  if enter interate mode, doc site will append in /~components route in development
+   * @note  if enter interate mode, doc site will append in /~docs route in development
    */
   isIntegrate: boolean;
 }

--- a/packages/preset-dumi/src/fixtures/integrate/.umirc.ts
+++ b/packages/preset-dumi/src/fixtures/integrate/.umirc.ts
@@ -1,0 +1,6 @@
+export default {
+  mode: 'site',
+  resolve: {
+    includes: ['src/components'],
+  },
+}

--- a/packages/preset-dumi/src/fixtures/integrate/.umirc.ts
+++ b/packages/preset-dumi/src/fixtures/integrate/.umirc.ts
@@ -3,4 +3,25 @@ export default {
   resolve: {
     includes: ['src/components'],
   },
+  menus: {
+    '/hello': [
+      {
+        title: 'Hello',
+        children: ['src/components/Hello'],
+      },
+    ],
+  },
+  navs: {
+    'zh-CN': [
+      null,
+      {
+        title: 'Test',
+        path: '/hello',
+      },
+      {
+        title: 'External',
+        path: 'https://d.umijs.org',
+      },
+    ],
+  },
 }

--- a/packages/preset-dumi/src/fixtures/integrate/package.json
+++ b/packages/preset-dumi/src/fixtures/integrate/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@umijs/preset-dumi": "*",
+    "umi": "*"
+  }
+}

--- a/packages/preset-dumi/src/fixtures/integrate/src/components/Hello/index.md
+++ b/packages/preset-dumi/src/fixtures/integrate/src/components/Hello/index.md
@@ -1,0 +1,8 @@
+---
+nav:
+  path: /components
+---
+
+## Hello
+
+The `Hello` component.

--- a/packages/preset-dumi/src/fixtures/integrate/src/components/index.md
+++ b/packages/preset-dumi/src/fixtures/integrate/src/components/index.md
@@ -1,0 +1,3 @@
+## Internal Components
+
+balabala...

--- a/packages/preset-dumi/src/fixtures/integrate/src/pages/A/index.tsx
+++ b/packages/preset-dumi/src/fixtures/integrate/src/pages/A/index.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <>Page A</>;

--- a/packages/preset-dumi/src/fixtures/integrate/src/pages/index.tsx
+++ b/packages/preset-dumi/src/fixtures/integrate/src/pages/index.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <>Home</>;

--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -10,7 +10,7 @@ describe('preset-dumi', () => {
 
   afterAll(() => {
     // clear all node_modules
-    ['', 'basic', 'algolia', 'demos', 'assets', 'local-theme'].forEach(dir => {
+    ['', 'basic', 'algolia', 'demos', 'assets', 'local-theme', 'integrate'].forEach(dir => {
       rimraf.sync(path.join(fixtures, dir, 'node_modules'));
     });
   });
@@ -163,5 +163,61 @@ describe('preset-dumi', () => {
 
     // restore env
     process.env.PLATFORM_TYPE = oType;
+  });
+
+  it('integrate mode', async () => {
+    const cwd = path.join(fixtures, 'integrate');
+    const service = new Service({
+      cwd,
+      env: 'development',
+      presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
+    });
+
+    // alias dumi-theme-default
+    symlink(
+      path.join(__dirname, '../../theme-default'),
+      path.join(service.paths.absNodeModulesPath, 'dumi-theme-default'),
+    );
+
+    // remove @umijs/preset-dumi from package.json to use the source code from ./index.ts
+    service.initialPresets = service.initialPresets.filter(({ id }) => id !== '@umijs/preset-dumi');
+    await service.init();
+
+    const api = service.getPluginAPI({
+      service,
+      key: 'test',
+      id: 'test',
+    });
+
+    // expect all docs inside /~components route path and keep original umi routes
+    expect((await (api as any).getRoutes()).map(route => route.path)).toEqual([
+      '/~demos/:uuid',
+      '/_demos/:uuid',
+      '/~components',
+      '/A',
+      '/',
+    ]);
+  });
+
+  it('integrate mode with production', async () => {
+    const cwd = path.join(fixtures, 'integrate');
+    const service = new Service({
+      cwd,
+      env: 'production',
+      presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
+    });
+
+    // remove @umijs/preset-dumi from package.json to use the source code from ./index.ts
+    service.initialPresets = service.initialPresets.filter(({ id }) => id !== '@umijs/preset-dumi');
+    await service.init();
+
+    const api = service.getPluginAPI({
+      service,
+      key: 'test',
+      id: 'test',
+    });
+
+    // expect dumi disabled in integrate with production
+    expect((await (api as any).getRoutes()).map(route => route.path)).toEqual(['/A', '/']);
   });
 });

--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -189,11 +189,11 @@ describe('preset-dumi', () => {
       id: 'test',
     });
 
-    // expect all docs inside /~components route path and keep original umi routes
+    // expect all docs inside /~docs route path and keep original umi routes
     expect((await (api as any).getRoutes()).map(route => route.path)).toEqual([
       '/~demos/:uuid',
       '/_demos/:uuid',
-      '/~components',
+      '/~docs',
       '/A',
       '/',
     ]);

--- a/packages/preset-dumi/src/index.ts
+++ b/packages/preset-dumi/src/index.ts
@@ -33,6 +33,9 @@ export default () => {
 
       // commands
       require.resolve('./plugins/commands/assets'),
+
+      // for disable dumi
+      require.resolve('./plugins/features/disable'),
     ],
   };
 };

--- a/packages/preset-dumi/src/plugins/features/config.ts
+++ b/packages/preset-dumi/src/plugins/features/config.ts
@@ -11,7 +11,7 @@ import ctx from '../../context';
 export default (api: IApi) => {
   // write config.json when generating temp files
   api.onGenerateFiles(async () => {
-    const root = (await api.getRoutes()).find(route => route.path === '/');
+    const root = (await api.getRoutes()).find(route => route._dumiRoot);
     const childRoutes = root.routes;
     const config = {
       menus: getMenuFromRoutes(childRoutes, ctx.opts, api.paths),

--- a/packages/preset-dumi/src/plugins/features/disable.ts
+++ b/packages/preset-dumi/src/plugins/features/disable.ts
@@ -1,0 +1,18 @@
+import { IApi } from '@umijs/types';
+import ctx from '../../context';
+
+/**
+ * plugin for disable all dumi plugins
+ */
+export default (api: IApi) => {
+  // disable dumi in interate mode and non-development mode
+  const isDisableDumi = ctx.opts.isIntegrate && api.env !== 'development';
+
+  if (isDisableDumi) {
+    const dumiPlugins = Object.values(api.service.plugins)
+      .filter(({ id }) => /preset-dumi\/(lib|src)\/plugins/.test(id))
+      .map(({ id }) => id);
+
+    api.skipPlugins(dumiPlugins);
+  }
+};

--- a/packages/preset-dumi/src/plugins/features/init.ts
+++ b/packages/preset-dumi/src/plugins/features/init.ts
@@ -10,7 +10,11 @@ const UMI_LIKE_PKGS = ['umi', '@alipay/bigfish'];
 export default (api: IApi) => {
   const deps = Object.assign({}, api.pkg.devDependencies);
   // enable ingetrate mode if dumi was registered as a umi preset on a umi like project
-  const isIntegrateUmi = UMI_LIKE_PKGS.some(pkg => deps[pkg]) && deps['@umijs/preset-dumi'];
+  const isIntegrateUmi =
+    UMI_LIKE_PKGS.some(pkg => deps[pkg]) &&
+    deps['@umijs/preset-dumi'] &&
+    // also can force disable integrate mode by umi build --dumi
+    api.args?.dumi === undefined;
 
   // init context & share umi api with other source module
   init(api, { isIntegrate: isIntegrateUmi } as any);

--- a/packages/preset-dumi/src/plugins/features/init.ts
+++ b/packages/preset-dumi/src/plugins/features/init.ts
@@ -2,12 +2,18 @@ import fs from 'fs';
 import { IApi } from '@umijs/types';
 import { init, setOptions } from '../../context';
 
+const UMI_LIKE_PKGS = ['umi', '@alipay/bigfish'];
+
 /**
  * dumi prepare plugin
  */
 export default (api: IApi) => {
+  const deps = Object.assign({}, api.pkg.devDependencies);
+  // enable ingetrate mode if dumi was registered as a umi preset on a umi like project
+  const isIntegrateUmi = UMI_LIKE_PKGS.some(pkg => deps[pkg]) && deps['@umijs/preset-dumi'];
+
   // init context & share umi api with other source module
-  init(api, {} as any);
+  init(api, { isIntegrate: isIntegrateUmi } as any);
 
   // use modifyConfig api for update context
   // because both of the umi service init & user config changed will trigger this plugin key

--- a/packages/preset-dumi/src/plugins/features/init.ts
+++ b/packages/preset-dumi/src/plugins/features/init.ts
@@ -8,7 +8,7 @@ const UMI_LIKE_PKGS = ['umi', '@alipay/bigfish'];
  * dumi prepare plugin
  */
 export default (api: IApi) => {
-  const deps = Object.assign({}, api.pkg.devDependencies);
+  const deps = Object.assign({}, api.pkg.dependencies, api.pkg.devDependencies);
   // enable ingetrate mode if dumi was registered as a umi preset on a umi like project
   const isIntegrateUmi =
     UMI_LIKE_PKGS.some(pkg => deps[pkg]) &&

--- a/packages/preset-dumi/src/plugins/features/menus.ts
+++ b/packages/preset-dumi/src/plugins/features/menus.ts
@@ -1,5 +1,6 @@
 import { IApi } from '@umijs/types';
-import { setOptions } from '../../context';
+import ctx, { setOptions, IDumiOpts } from '../../context';
+import { prefix } from '../../routes/decorator/integrate';
 
 export default (api: IApi) => {
   api.describe({
@@ -14,7 +15,19 @@ export default (api: IApi) => {
 
   // share config with other source module via context
   api.modifyConfig(memo => {
-    setOptions('menus', memo.menus);
+    let menus: IDumiOpts['menus'];
+
+    if (ctx.opts.isIntegrate && memo.menus) {
+      // add integrate route prefix
+      menus = {};
+      Object.keys(memo.menus).forEach(key => {
+        menus[prefix(key)] = memo.menus[key];
+      });
+    } else {
+      // use user config
+      menus = memo.menus;
+    }
+    setOptions('menus', menus);
 
     return memo;
   });

--- a/packages/preset-dumi/src/plugins/features/navs.ts
+++ b/packages/preset-dumi/src/plugins/features/navs.ts
@@ -1,5 +1,7 @@
 import { IApi } from '@umijs/types';
-import { setOptions } from '../../context';
+import ctx, { setOptions, IDumiOpts } from '../../context';
+import { prefix } from '../../routes/decorator/integrate';
+import { INavItem } from '../../routes/getNavFromRoutes';
 
 export default (api: IApi) => {
   api.describe({
@@ -14,7 +16,38 @@ export default (api: IApi) => {
 
   // share config with other source module via context
   api.modifyConfig(memo => {
-    setOptions('navs', memo.navs);
+    let navs: IDumiOpts['navs'];
+
+    function navPrefix(items: INavItem[]) {
+      return items.map(item =>
+        // compatible with null item
+        item
+          ? {
+              ...item,
+              path: /^(\w+:)?\/\//.test(item.path) ? item.path : prefix(item.path),
+              children: item.children ? navPrefix(item.children) : item.children,
+            }
+          : item,
+      );
+    }
+
+    if (ctx.opts.isIntegrate && memo.navs) {
+      // add integrate route prefix
+      if (Array.isArray(memo.navs)) {
+        // process single locale navs
+        navs = navPrefix(memo.navs);
+      } else {
+        // process multiple locales navs
+        navs = {};
+        Object.keys(memo.navs).forEach(locale => {
+          navs[locale] = navPrefix(memo.navs[locale]);
+        });
+      }
+    } else {
+      // use user config
+      navs = memo.navs;
+    }
+    setOptions('navs', navs);
 
     return memo;
   });

--- a/packages/preset-dumi/src/plugins/features/routes.ts
+++ b/packages/preset-dumi/src/plugins/features/routes.ts
@@ -6,31 +6,36 @@ import getRouteConfig from '../../routes/getRouteConfig';
  * plugin for generate routes
  */
 export default (api: IApi) => {
-  // repalce default routes with generated routes
+  // generate docs routes
   api.onPatchRoutesBefore(async ({ routes, parentRoute }) => {
     // only deal with the top level routes
     if (!parentRoute) {
       const result = await getRouteConfig(api, ctx.opts);
 
-      // clear original routes
-      routes.splice(0, routes.length);
+      if (ctx.opts.isIntegrate) {
+        // unshit docs routes in integrate mode
+        routes.unshift(...result);
+      } else {
+        // clear original routes
+        routes.splice(0, routes.length);
 
-      // append new routes
-      routes.push(...result);
+        // append new routes
+        routes.push(...result);
+      }
     }
   });
 
   // add empty component for root layout
   // TODO: move this logic into getRouteConfig and make sure tests passed
   api.modifyRoutes(routes => {
-    routes.find(route => route.path === '/').component = '(props) => props.children';
+    routes.find(route => route._dumiRoot).component = '(props) => props.children';
 
     return routes;
   });
 
   // remove useless /index.html from exportStatic feature
   api.onPatchRoutes(({ routes, parentRoute }) => {
-    if (api.config.exportStatic && parentRoute?.path === '/') {
+    if (api.config.exportStatic && parentRoute?._dumiRoot) {
       const rootHtmlIndex = routes.findIndex(route => route.path === '/index.html');
 
       routes.splice(rootHtmlIndex, 1);

--- a/packages/preset-dumi/src/routes/decorator/index.ts
+++ b/packages/preset-dumi/src/routes/decorator/index.ts
@@ -9,6 +9,7 @@ import group from './group';
 import fallback from './fallback';
 import redirect from './redirect';
 import relative from './relative';
+import integrate from './integrate';
 
 export type RouteProcessor = (
   this: { options: IDumiOpts; umi: IApi; data: { [key: string]: any } },
@@ -67,6 +68,7 @@ export default (routes: IRoute[], opts: IDumiOpts, umi: IApi) => {
     .use(nav)
     .use(group)
     .use(fallback)
+    .use(integrate)
     .use(redirect)
     .use(relative);
 

--- a/packages/preset-dumi/src/routes/decorator/integrate.ts
+++ b/packages/preset-dumi/src/routes/decorator/integrate.ts
@@ -3,7 +3,7 @@ import { RouteProcessor } from '.';
 /**
  * global route prefix in integrate mode
  */
-const INTEGRATE_ROUTE_PREFIX = '/~components';
+const INTEGRATE_ROUTE_PREFIX = '/~docs';
 
 export function prefix(oPath: string) {
   return `${INTEGRATE_ROUTE_PREFIX}${oPath}`.replace(/\/$/, '');

--- a/packages/preset-dumi/src/routes/decorator/integrate.ts
+++ b/packages/preset-dumi/src/routes/decorator/integrate.ts
@@ -1,0 +1,26 @@
+import { RouteProcessor } from '.';
+
+function prefix(oPath: string) {
+  return `/~components${oPath}`.replace(/\/$/, '');
+}
+
+/**
+ * add route prefix when integrate dumi in a Umi project
+ */
+export default (function integrate(routes) {
+  if (this.options.isIntegrate) {
+    routes.forEach(route => {
+      route.path = prefix(route.path);
+
+      if (this.options.mode === 'site' && route.meta?.nav) {
+        route.meta.nav.path = prefix(route.meta.nav.path);
+      }
+
+      if (route.meta?.group) {
+        route.meta.group.path = prefix(route.meta.group.path);
+      }
+    });
+  }
+
+  return routes;
+} as RouteProcessor);

--- a/packages/preset-dumi/src/routes/decorator/integrate.ts
+++ b/packages/preset-dumi/src/routes/decorator/integrate.ts
@@ -1,7 +1,12 @@
 import { RouteProcessor } from '.';
 
-function prefix(oPath: string) {
-  return `/~components${oPath}`.replace(/\/$/, '');
+/**
+ * global route prefix in integrate mode
+ */
+const INTEGRATE_ROUTE_PREFIX = '/~components';
+
+export function prefix(oPath: string) {
+  return `${INTEGRATE_ROUTE_PREFIX}${oPath}`.replace(/\/$/, '');
 }
 
 /**

--- a/packages/preset-dumi/src/routes/getRouteConfig.ts
+++ b/packages/preset-dumi/src/routes/getRouteConfig.ts
@@ -5,6 +5,7 @@ import { IApi, IRoute } from '@umijs/types';
 import getRouteConfigFromDir from './getRouteConfigFromDir';
 import getTheme from '../theme/loader';
 import decorateRoutes from './decorator';
+import { prefix } from './decorator/integrate';
 import { IDumiOpts } from '../index';
 
 export default async (api: IApi, opts: IDumiOpts): Promise<IRoute[]> => {
@@ -39,7 +40,7 @@ export default async (api: IApi, opts: IDumiOpts): Promise<IRoute[]> => {
   // add main routes
   config.push({
     _dumiRoot: true,
-    path: opts.isIntegrate ? '/~components' : '/',
+    path: opts.isIntegrate ? prefix('/') : '/',
     wrappers: [
       // builtin outer layout
       slash(path.relative(api.paths.absPagesPath, path.join(__dirname, '../theme/layout'))),

--- a/packages/preset-dumi/src/routes/getRouteConfig.ts
+++ b/packages/preset-dumi/src/routes/getRouteConfig.ts
@@ -38,7 +38,8 @@ export default async (api: IApi, opts: IDumiOpts): Promise<IRoute[]> => {
 
   // add main routes
   config.push({
-    path: '/',
+    _dumiRoot: true,
+    path: opts.isIntegrate ? '/~components' : '/',
     wrappers: [
       // builtin outer layout
       slash(path.relative(api.paths.absPagesPath, path.join(__dirname, '../theme/layout'))),

--- a/packages/preset-dumi/src/theme/layout.tsx
+++ b/packages/preset-dumi/src/theme/layout.tsx
@@ -103,7 +103,7 @@ const useCurrentMenu = (ctxConfig: IThemeContext['config'], locale: string, path
  * @param route     layout route configurations
  * @note  handle these points:
  *          1. locale prefix, such as empty or /zh-CN
- *          2. integrate mode route prefix, such as /~components or /~components/zh-CN
+ *          2. integrate mode route prefix, such as /~docs or /~docs/zh-CN
  */
 const useCurrentBase = (
   locale: string,
@@ -135,7 +135,7 @@ const OuterLayout: React.FC<IOuterLayoutProps & IRouteComponentProps> = props =>
   const { location, route, children } = props;
   const pathWithoutPrefix = location.pathname.replace(route.path, '');
   const meta = useCurrentRouteMeta(route.routes, location.pathname);
-  // use non-prefix for detect current locale, such as /~components/en-US -> /en-US
+  // use non-prefix for detect current locale, such as /~docs/en-US -> /en-US
   const locale = useCurrentLocale(config.locales, pathWithoutPrefix);
   const menu = useCurrentMenu(config, locale, location.pathname);
   const base = useCurrentBase(locale, config.locales, route);

--- a/packages/preset-dumi/src/theme/layout.tsx
+++ b/packages/preset-dumi/src/theme/layout.tsx
@@ -97,13 +97,48 @@ const useCurrentMenu = (ctxConfig: IThemeContext['config'], locale: string, path
 };
 
 /**
+ * hooks for doc base route path
+ * @param locale    current locale
+ * @param locales   project locale configurations
+ * @param route     layout route configurations
+ * @note  handle these points:
+ *          1. locale prefix, such as empty or /zh-CN
+ *          2. integrate mode route prefix, such as /~components or /~components/zh-CN
+ */
+const useCurrentBase = (
+  locale: string,
+  locales: IThemeContext['config']['locales'],
+  route: IRouteProps,
+) => {
+  const handler = (...args: [string, IThemeContext['config']['locales'], IRouteProps]) => {
+    if (args[0] === args[1][0].name) {
+      // use layout route path as base in default locale
+      return args[2].path;
+    }
+
+    // join layout route path & locale prefix in other locale
+    return `${route.path}/${locale}`.replace(/\/\//, '/');
+  };
+  const [base, setBase] = useState<string>(handler(locale, locales, route));
+
+  useLayoutEffect(() => {
+    setBase(handler(locale, locales, route));
+  }, [locale]);
+
+  return base;
+};
+
+/**
  * outer theme layout
  */
 const OuterLayout: React.FC<IOuterLayoutProps & IRouteComponentProps> = props => {
   const { location, route, children } = props;
+  const pathWithoutPrefix = location.pathname.replace(route.path, '');
   const meta = useCurrentRouteMeta(route.routes, location.pathname);
-  const locale = useCurrentLocale(config.locales, location.pathname);
+  // use non-prefix for detect current locale, such as /~components/en-US -> /en-US
+  const locale = useCurrentLocale(config.locales, pathWithoutPrefix);
   const menu = useCurrentMenu(config, locale, location.pathname);
+  const base = useCurrentBase(locale, config.locales, route);
 
   // scroll to anchor if hash exists
   useEffect(() => {
@@ -120,7 +155,7 @@ const OuterLayout: React.FC<IOuterLayoutProps & IRouteComponentProps> = props =>
         locale,
         nav: config.navs[locale] || [],
         menu,
-        base: !config.locales.length || locale === config.locales[0].name ? '/' : `/${locale}`,
+        base,
         routes: (route.routes as unknown) as IThemeContext['routes'],
       }}
     >

--- a/packages/theme-default/src/components/LocaleSelect.tsx
+++ b/packages/theme-default/src/components/LocaleSelect.tsx
@@ -18,7 +18,7 @@ const LocaleSelect: FC<{ location: any }> = ({ location }) => {
 
     // append locale prefix to path if it is not the default locale
     if (target !== locales[0].name) {
-      // compatiable with integrate route prefix /~components
+      // compatiable with integrate route prefix /~docs
       const routePrefix = `${baseWithoutLocale}/${target}`.replace(/\/\//, '/');
       const pathnameWithoutBase = location.pathname.replace(base, '');
 

--- a/packages/theme-default/src/components/LocaleSelect.tsx
+++ b/packages/theme-default/src/components/LocaleSelect.tsx
@@ -6,20 +6,26 @@ import './LocaleSelect.less';
 
 const LocaleSelect: FC<{ location: any }> = ({ location }) => {
   const {
+    base,
     locale,
     config: { locales },
   } = useContext(context);
   const firstDiffLocale = locales.find(({ name }) => name !== locale);
 
   function getLocaleTogglePath(target: string) {
-    let newPathname = location.pathname.replace(`/${locale}`, '') || '/';
+    const baseWithoutLocale = base.replace(`/${locale}`, '');
+    const pathnameWithoutLocale = location.pathname.replace(base, baseWithoutLocale) || '/';
 
     // append locale prefix to path if it is not the default locale
     if (target !== locales[0].name) {
-      newPathname = `/${target}${newPathname}`.replace(/\/$/, '');
+      // compatiable with integrate route prefix /~components
+      const routePrefix = `${baseWithoutLocale}/${target}`.replace(/\/\//, '/');
+      const pathnameWithoutBase = location.pathname.replace(base, '');
+
+      return `${routePrefix}${pathnameWithoutBase}`.replace(/\/$/, '');
     }
 
-    return newPathname;
+    return pathnameWithoutLocale;
   }
 
   return firstDiffLocale ? (

--- a/packages/theme-default/src/test/index.test.tsx
+++ b/packages/theme-default/src/test/index.test.tsx
@@ -81,7 +81,7 @@ describe('default theme', () => {
     history,
     location: { ...history.location, query: {} },
     match: { params: {}, isExact: true, path: '/', url: '/' },
-    route: { routes: baseCtx.routes },
+    route: { path: '/', routes: baseCtx.routes },
   };
 
   it('should render site home page', () => {
@@ -179,7 +179,8 @@ describe('default theme', () => {
         {children}
       </Context.Provider>
     );
-    const { getByText, getByTitle, getAllByTitle, container } = render(
+
+    const { getByText, getByTitle, getAllByTitle } = render(
       <Router history={history}>
         <Layout {...baseProps}>
           <>


### PR DESCRIPTION
## 主要变更
在 Umi 项目安装 `@umijs/preset-dumi` 会进入集成模式，在不破坏原有 Umi 项目的基础上，增加 dumi 的文档路由，适用于管理项目内部不发包的组件的场景。

## 详细变更
- 自动探测集成模式：当 `dependencies` 或 `devDependencies` 中包含 `umi` 和 `@umijs/preset-dumi` 时，进入集成模式
- dumi 生成的文档会集中在 `/~docs` 路由下，不干扰原有 Umi 项目的路由（组件 demo 的路由仍然在 `/~demos` 下）
- dumi 文档仅在 `development` 模式下集成，项目进行生产模式构建不会包含 dumi 的任何文档路由
- 自动给 `menus` 和 `navs` 配置中的路由追加 `/~docs` 前缀，意味着同一份配置能同时适用标准模式和集成模式
- 支持通过 `umi build --dumi` or `umi dev --dumi` 参数强制执行只渲染文档部分（即标准 dumi 模式，无路由前缀）
- 所有 dumi 能力在集成模式下均可用

Close #288 #349 