### PR TITLE
fix: API identifier unique

### DIFF
--- a/packages/preset-dumi/src/transformer/remark/api.ts
+++ b/packages/preset-dumi/src/transformer/remark/api.ts
@@ -107,7 +107,7 @@ export default function api(): IDumiUnifiedTransformer {
           const absPath = path.join(path.dirname(this.data('fileAbsPath')), src);
 
           definitions = parser(absPath, componentName);
-          identifier = componentName || src;
+          identifier = src;
 
           // trigger parent markdown file change after this file changed
           saveFileOnDepChange(this.data('fileAbsPath'), absPath);


### PR DESCRIPTION
Close: https://github.com/umijs/dumi/issues/388

尝试了几个方案，感觉现在的修改最理想。

1. 把 src 也过滤了，又会有什么component之类的目录
2. 使用组件 export 出来的 name 会有更多重复情况，而且较难排查。
3. 直接使用文件路径（现在用的是这个，这个可以保证唯一） 
