### PR TITLE
perf: optimize footer time show

### DIFF
--- a/packages/theme-default/src/layout.tsx
+++ b/packages/theme-default/src/layout.tsx
@@ -53,26 +53,7 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
     (meta.toc === 'content' || meta.toc === undefined) &&
     !meta.gapless;
   const isCN = /^zh|cn$/i.test(locale);
-
-  const updatedTime = () => {
-    const date = new Date(meta.updatedTime);
-    const year = date.getFullYear();
-    const month = showFormat(date.getMonth() + 1);
-    const day = showFormat(date.getDate());
-    const hour = showFormat(date.getHours());
-    const minute = showFormat(date.getMinutes());
-    const second = showFormat(date.getSeconds());
-
-    return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
-  };
-
-  const showFormat = (base: number) => {
-    if (base < 10) {
-      return `0${base}`;
-    }
-    return `${base}`;
-  };
-
+  const updatedTime: any = new Date(meta.updatedTime).toLocaleString([], { hour12: false });
   const repoPlatform = { github: 'GitHub', gitlab: 'GitLab' }[
     (repoUrl || '').match(/(github|gitlab)/)?.[1] || 'nothing'
   ];
@@ -108,7 +89,7 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
                 {isCN ? `在 ${repoPlatform} 上编辑此页` : `Edit this doc on ${repoPlatform}`}
               </Link>
             )}
-            <span data-updated-text={isCN ? '最后更新时间：' : 'Last update: '}>{updatedTime()}</span>
+            <span data-updated-text={isCN ? '最后更新时间：' : 'Last update: '}>{updatedTime}</span>
           </div>
         )}
         {(showHero || showFeatures) && meta.footer && (

--- a/packages/theme-default/src/layout.tsx
+++ b/packages/theme-default/src/layout.tsx
@@ -55,16 +55,22 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
   const isCN = /^zh|cn$/i.test(locale);
 
   const updatedTime = () => {
-    const { updatedTime } = meta;
-    const date = new Date(updatedTime).toLocaleDateString();
-    const hour = new Date(updatedTime).getHours();
-    const hourShow = hour < 10 ? `0${hour}` : hour;
-    const minute = new Date(updatedTime).getMinutes();
-    const minuteShow = minute < 10 ? `0${minute}` : minute;
-    const second = new Date(updatedTime).getSeconds();
-    const secondShow = second < 10 ? `0${second}` : second;
+    const date = new Date(meta.updatedTime);
+    const year = date.getFullYear();
+    const month = showFormat(date.getMonth());
+    const day = showFormat(date.getDate());
+    const hour = showFormat(date.getHours());
+    const minute = showFormat(date.getMinutes());
+    const second = showFormat(date.getSeconds());
 
-    return `${date} ${hourShow}:${minuteShow}:${secondShow}`;
+    return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+  };
+
+  const showFormat = (base: number) => {
+    if (base < 10) {
+      return `0${base}`;
+    }
+    return `${base}`;
   };
 
   const repoPlatform = { github: 'GitHub', gitlab: 'GitLab' }[

--- a/packages/theme-default/src/layout.tsx
+++ b/packages/theme-default/src/layout.tsx
@@ -57,7 +57,7 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
   const updatedTime = () => {
     const date = new Date(meta.updatedTime);
     const year = date.getFullYear();
-    const month = showFormat(date.getMonth());
+    const month = showFormat(date.getMonth() + 1);
     const day = showFormat(date.getDate());
     const hour = showFormat(date.getHours());
     const minute = showFormat(date.getMinutes());

--- a/packages/theme-default/src/layout.tsx
+++ b/packages/theme-default/src/layout.tsx
@@ -53,7 +53,20 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
     (meta.toc === 'content' || meta.toc === undefined) &&
     !meta.gapless;
   const isCN = /^zh|cn$/i.test(locale);
-  const updatedTime: any = new Date(meta.updatedTime).toLocaleString();
+
+  const updatedTime = () => {
+    const { updatedTime } = meta;
+    const date = new Date(updatedTime).toLocaleDateString();
+    const hour = new Date(updatedTime).getHours();
+    const hourShow = hour < 10 ? `0${hour}` : hour;
+    const minute = new Date(updatedTime).getMinutes();
+    const minuteShow = minute < 10 ? `0${minute}` : minute;
+    const second = new Date(updatedTime).getSeconds();
+    const secondShow = second < 10 ? `0${second}` : second;
+
+    return `${date} ${hourShow}:${minuteShow}:${secondShow}`;
+  };
+
   const repoPlatform = { github: 'GitHub', gitlab: 'GitLab' }[
     (repoUrl || '').match(/(github|gitlab)/)?.[1] || 'nothing'
   ];
@@ -86,10 +99,10 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
           <div className="__dumi-default-layout-footer-meta">
             {repoPlatform && (
               <Link to={`${repoUrl}/edit/${branch}/${meta.filePath}`}>
-                {isCN ? `在 ${repoPlatform} 上编辑这篇文档` : `Edit this doc on ${repoPlatform}`}
+                {isCN ? `在 ${repoPlatform} 上编辑此页` : `Edit this doc on ${repoPlatform}`}
               </Link>
             )}
-            <span data-updated-text={isCN ? '最后更新时间：' : 'Last Update: '}>{updatedTime}</span>
+            <span data-updated-text={isCN ? '最后更新时间：' : 'Last update: '}>{updatedTime()}</span>
           </div>
         )}
         {(showHero || showFeatures) && meta.footer && (

--- a/packages/theme-default/src/test/index.test.tsx
+++ b/packages/theme-default/src/test/index.test.tsx
@@ -139,6 +139,8 @@ describe('default theme', () => {
           meta: {
             title: 'test',
             slugs: [{ value: 'Slug A', heading: 'a', depth: 2 }],
+            updatedTime: 1604026996000,
+            filePath: 'temp',
           },
         }}
       >
@@ -156,6 +158,9 @@ describe('default theme', () => {
 
     // expect slugs be rendered
     expect(getByText('Slug A')).not.toBeNull();
+
+    // expect footer date show
+    expect(getByText('2020-10-30 11:03:16')).not.toBeNull();
 
     // trigger locale change
     getAllByText('English')[0].click();

--- a/packages/theme-default/src/test/index.test.tsx
+++ b/packages/theme-default/src/test/index.test.tsx
@@ -160,7 +160,7 @@ describe('default theme', () => {
     expect(getByText('Slug A')).not.toBeNull();
 
     // expect footer date show
-    expect(getByText('2020-10-30 11:03:16')).not.toBeNull();
+    expect(getByText('2020-10-30 03:03:16')).not.toBeNull();
 
     // trigger locale change
     getAllByText('English')[0].click();

--- a/packages/theme-default/src/test/index.test.tsx
+++ b/packages/theme-default/src/test/index.test.tsx
@@ -160,7 +160,7 @@ describe('default theme', () => {
     expect(getByText('Slug A')).not.toBeNull();
 
     // expect footer date show
-    expect(getByText('2020-10-30 03:03:16')).not.toBeNull();
+    expect(getByText('10/30/2020, 03:03:16')).not.toBeNull();
 
     // trigger locale change
     getAllByText('English')[0].click();


### PR DESCRIPTION
### background

- 每次 英文都一直显示 上午 下午。。。

|＃  | view|
| - | - |
| Before | ![image](https://user-images.githubusercontent.com/29775873/101487748-8e976c80-3999-11eb-81bc-8ad3660abf0d.png) |
| After |  ![image](https://user-images.githubusercontent.com/29775873/101487799-a0790f80-3999-11eb-87d8-60620d955c9c.png) |

### changelog

- 优化 footer 时间显示。
- 优化 footer 文字。

