### PR TITLE
fix(preset): useDemoUrl should work with hash router fix#445

### DIFF
--- a/packages/preset-dumi/src/theme/hooks/useDemoUrl.test.ts
+++ b/packages/preset-dumi/src/theme/hooks/useDemoUrl.test.ts
@@ -2,10 +2,25 @@ import { renderHook } from '@testing-library/react-hooks';
 import useDemoUrl from './useDemoUrl';
 
 describe('theme API: useDemoUrl', () => {
+  const saved = window.location;
+  delete window.location;
+  window.location = {
+    ...saved,
+    href: `http://localhost/`,
+  } as Window['location'];
+
+  beforeEach(() => {
+    window.location.href = `http://localhost/`;
+  });
+
   it('should return normal demo url', () => {
     const { result } = renderHook(() => useDemoUrl('test'));
 
     expect(result.current).toEqual('http://localhost/~demos/test');
+
+    window.location.href += '#/';
+    const { result: hashResult } = renderHook(() => useDemoUrl('test'));
+    expect(hashResult.current).toEqual(`http://localhost/#/~demos/test`);
   });
 
   it('should return demo url and prefix router base', () => {
@@ -14,10 +29,22 @@ describe('theme API: useDemoUrl', () => {
 
     const { result } = renderHook(() => useDemoUrl('test'));
 
+    expect(result.current).toEqual('http://localhost/hello/~demos/test');
+
+    window.location.href += '#/';
+    const { result: hashResult } = renderHook(() => useDemoUrl('test'));
+    expect(hashResult.current).toEqual(`http://localhost/#/hello/~demos/test`);
+
+    window.location.href = `http://localhost/#/123#anchor`;
+    const { result: hashResult0 } = renderHook(() => useDemoUrl('test'));
+    expect(hashResult0.current).toEqual(`http://localhost/#/hello/~demos/test`);
+
+    window.location.href = `http://localhost/prefix/path/#/123#anchor`;
+    const { result: hashResult1 } = renderHook(() => useDemoUrl('test'));
+    expect(hashResult1.current).toEqual(`http://localhost/prefix/path/#/hello/~demos/test`);
+
     // @ts-ignore
     delete window.routerBase;
-
-    expect(result.current).toEqual('http://localhost/hello/~demos/test');
   });
 
   it('should return basement-compatible demo url', () => {
@@ -25,8 +52,21 @@ describe('theme API: useDemoUrl', () => {
 
     process.env.PLATFORM_TYPE = 'BASEMENT';
     const { result } = renderHook(() => useDemoUrl('test'));
-    process.env.PLATFORM_TYPE = oType;
 
     expect(result.current).toEqual('http://localhost/_demos/test/index.html');
+
+    window.location.href += '#/';
+    const { result: hashResult } = renderHook(() => useDemoUrl('test'));
+    expect(hashResult.current).toEqual(`http://localhost/#/_demos/test/index.html`);
+
+    window.location.href = `http://localhost/#/123#anchor`;
+    const { result: hashResult0 } = renderHook(() => useDemoUrl('test'));
+    expect(hashResult0.current).toEqual(`http://localhost/#/_demos/test/index.html`);
+
+    window.location.href = `http://localhost/prefix/path/#/123#anchor`;
+    const { result: hashResult1 } = renderHook(() => useDemoUrl('test'));
+    expect(hashResult1.current).toEqual(`http://localhost/prefix/path/#/_demos/test/index.html`);
+
+    process.env.PLATFORM_TYPE = oType;
   });
 });

--- a/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
+++ b/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
@@ -18,12 +18,14 @@ export const getDemoRouteName = () => {
  * @param demoId  demo identifier
  */
 export const getDemoUrl = (demoId: string) => {
-  const { location } = window;
-  const [base, hashRoute] = location.href.split(/#\//);
+  const {
+    location: { href, origin },
+  } = window;
+  const [base, hashRoute] = href.split(/#\//);
   const isHashRoute = typeof hashRoute === 'string';
 
   return [
-    isHashRoute ? `${base}#` : window.location.origin,
+    isHashRoute ? `${base}#` : origin,
     // compatible with (empty), /base & /base/
     `${(window as any)?.routerBase || ''}/`.replace(/\/\/$/, '/'),
     getDemoRouteName(),

--- a/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
+++ b/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
@@ -18,8 +18,12 @@ export const getDemoRouteName = () => {
  * @param demoId  demo identifier
  */
 export const getDemoUrl = (demoId: string) => {
+  const { location } = window;
+  const [base, hashRoute] = location.href.split(/#\//);
+  const isHashRoute = typeof hashRoute === 'string';
+
   return [
-    window.location.origin,
+    isHashRoute ? `${base}#` : window.location.origin,
     // compatible with (empty), /base & /base/
     `${(window as any)?.routerBase || ''}/`.replace(/\/\/$/, '/'),
     getDemoRouteName(),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 包体积优化 / Package size optimization
- [ ] 性能优化 / Performance optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

#445 

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

修复 #445，问题本质是现有 useDemoUrl hook 并未对 hash route 做处理，本 pr 新增 useDemoUrl hook 对 hash route 的处理，且不含 break changes.

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    support demo url creation in the hash router    |
| 🇨🇳 Chinese |   支持 hash 路由下的 demo url 生成   |
