### PR TITLE
fix: 修复windows环境lerna项目运行报JSON.parse错误的问题

### DIFF
--- a/packages/preset-dumi/src/utils/getHostPkgAlias.ts
+++ b/packages/preset-dumi/src/utils/getHostPkgAlias.ts
@@ -23,10 +23,12 @@ export default (paths: IApi['paths']) => {
     // for lerna repo
     const { version: lernaVersion } = require('lerna/package.json');
     if (lernaVersion.startsWith('3')) {
-      JSON.parse(execSync(`${path.join(paths.cwd, 'node_modules/.bin/lerna')} ls --json --all`, {
-        stdio: 'pipe',
-        // fix: 修复windows环境下有多余输出导致JSON.parse报错的问题
-      }).toString().replace(/([\r\n]\])[^]*$/, '$1')).forEach(pkg => {
+      JSON.parse(
+        execSync(`${path.join(paths.cwd, 'node_modules/.bin/lerna')} ls --json --all`, {
+          stdio: 'pipe',
+          // fix: 修复windows环境下有多余输出导致JSON.parse报错的问题
+        }).toString().replace(/([\r\n]\])[^]*$/, '$1'),
+      ).forEach(pkg => {
         pkgs.push([pkg.name, pkg.location]);
       });
     } else if (require.resolve('lerna/lib/PackageUtilities', { paths: [paths.cwd] })) {

--- a/packages/preset-dumi/src/utils/getHostPkgAlias.ts
+++ b/packages/preset-dumi/src/utils/getHostPkgAlias.ts
@@ -16,25 +16,21 @@ function getPkgAliasForPath(absPath: string) {
 }
 
 export default (paths: IApi['paths']) => {
-  const catalogPattern = /EnumerateProviders (catalog|totalPro)=\d+/g;
   const isLerna = fs.existsSync(path.join(paths.cwd, 'lerna.json'));
   const pkgs: [string, string][] = [];
 
   if (isLerna) {
     // for lerna repo
     const { version: lernaVersion } = require('lerna/package.json');
-
     if (lernaVersion.startsWith('3')) {
-      let res = execSync(`${path.join(paths.cwd, 'node_modules/.bin/lerna')} ls --json --all`, {
+      JSON.parse(execSync(`${path.join(paths.cwd, 'node_modules/.bin/lerna')} ls --json --all`, {
         stdio: 'pipe',
-      }).toString();
-      // 修复windows环境下出现的 EnumerateProviders log导致的parse错误
-      if (catalogPattern.test(res)) {
-        res = res.replace(catalogPattern, "").trim()
-      }
-      JSON.parse(res).forEach(pkg => {
-        pkgs.push([pkg.name, pkg.location]);
-      });
+      })
+        .toString()
+        // fix: 修复windows环境下有多余输出导致JSON.parse报错的问题
+        .replace(/([\r\n]\])[^]*$/, '$1')).forEach(pkg => {
+          pkgs.push([pkg.name, pkg.location]);
+        });
     } else if (require.resolve('lerna/lib/PackageUtilities', { paths: [paths.cwd] })) {
       // reference: https://github.com/azz/lerna-get-packages/blob/master/index.js
       const PackageUtilities = require(require.resolve('lerna/lib/PackageUtilities', {

--- a/packages/preset-dumi/src/utils/getHostPkgAlias.ts
+++ b/packages/preset-dumi/src/utils/getHostPkgAlias.ts
@@ -25,12 +25,10 @@ export default (paths: IApi['paths']) => {
     if (lernaVersion.startsWith('3')) {
       JSON.parse(execSync(`${path.join(paths.cwd, 'node_modules/.bin/lerna')} ls --json --all`, {
         stdio: 'pipe',
-      })
-        .toString()
         // fix: 修复windows环境下有多余输出导致JSON.parse报错的问题
-        .replace(/([\r\n]\])[^]*$/, '$1')).forEach(pkg => {
-          pkgs.push([pkg.name, pkg.location]);
-        });
+      }).toString().replace(/([\r\n]\])[^]*$/, '$1')).forEach(pkg => {
+        pkgs.push([pkg.name, pkg.location]);
+      });
     } else if (require.resolve('lerna/lib/PackageUtilities', { paths: [paths.cwd] })) {
       // reference: https://github.com/azz/lerna-get-packages/blob/master/index.js
       const PackageUtilities = require(require.resolve('lerna/lib/PackageUtilities', {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 包体积优化 / Package size optimization
- [ ] 性能优化 / Performance optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
https://github.com/umijs/dumi/issues/470
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
之前排查以为是路径问题导致，仔细排查发现是windows环境下在执行lerna  ls --json --all 命令时会多出两行日志
```
EnumerateProviders catalog=0
EnumerateProviders totalPro=19
```
从而导致JSON.parse报错


< !--
解决的具体问题。
The specific problem solved.
-->

故采用正则的方式将这两行日志进行替换清除

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
