### PR TITLE
fix(preset): clean warning when use API && embed

### DIFF
--- a/packages/preset-dumi/src/transformer/remark/api.ts
+++ b/packages/preset-dumi/src/transformer/remark/api.ts
@@ -134,6 +134,7 @@ function watchComponentUpdate(absPath: string, componentName: string, identifier
  */
 export default function api(): IDumiUnifiedTransformer {
   return (ast, vFile) => {
+    let extraReplacement = false;
     visit<IDumiElmNode>(ast, 'element', (node, i, parent) => {
       if (is(node, 'API') && !node._dumi_parsed) {
         let identifier: string;
@@ -175,7 +176,23 @@ export default function api(): IDumiUnifiedTransformer {
           // apply api data
           applyApiData(identifier, definitions);
         }
+
+        if (parent.tagName === 'p') {
+          extraReplacement = true;
+        }
       }
     });
+
+    if (extraReplacement) {
+      visit<IDumiElmNode>(ast, 'element', (node, i, parent) => {
+        if (is(node, 'p')) {
+          parent.children.splice(
+            i,
+            1,
+            ...node.children
+          )
+        }
+      })
+    }
   };
 }

--- a/packages/preset-dumi/src/transformer/remark/api.ts
+++ b/packages/preset-dumi/src/transformer/remark/api.ts
@@ -185,7 +185,10 @@ export default function api(): IDumiUnifiedTransformer {
 
     if (extraReplacement) {
       visit<IDumiElmNode>(ast, 'element', (node, i, parent) => {
-        if (is(node, 'p')) {
+        if (
+          is(node, 'p') &&
+          node.children?.some(child => is(child, 'h2'))
+        ) {
           parent.children.splice(
             i,
             1,

--- a/packages/preset-dumi/src/transformer/remark/embed.ts
+++ b/packages/preset-dumi/src/transformer/remark/embed.ts
@@ -79,7 +79,10 @@ export default function embed(): IDumiUnifiedTransformer {
 
     if (extraReplacement) {
       visit<IDumiElmNode>(ast, 'element', (node, i, parent) => {
-        if (is(node, 'p')) {
+        if (
+          is(node, 'p') &&
+          node.children.length == 1 
+        ) {
           parent.children.splice(
             i,
             1,

--- a/packages/preset-dumi/src/transformer/remark/embed.ts
+++ b/packages/preset-dumi/src/transformer/remark/embed.ts
@@ -16,6 +16,7 @@ export const EMBED_SLUGS = 'dumi-embed-file-slugs';
  */
 export default function embed(): IDumiUnifiedTransformer {
   return ast => {
+    let extraReplacement = false;
     visit<IDumiElmNode>(ast, 'element', (node, i, parent) => {
       if (is(node, 'embed') && has(node, 'src')) {
         const { src } = node.properties;
@@ -69,7 +70,23 @@ export default function embed(): IDumiUnifiedTransformer {
               });
           }
         }
+
+        if (parent.tagName === 'p') {
+          extraReplacement = true;
+        }
       }
     });
+
+    if (extraReplacement) {
+      visit<IDumiElmNode>(ast, 'element', (node, i, parent) => {
+        if (is(node, 'p')) {
+          parent.children.splice(
+            i,
+            1,
+            ...node.children
+          )
+        }
+      })
+    }
   };
 }

--- a/packages/preset-dumi/src/transformer/test/remark-api.test.ts
+++ b/packages/preset-dumi/src/transformer/test/remark-api.test.ts
@@ -48,8 +48,8 @@ describe('component api example', () => {
 
     // compare transform content
     expect(result).toEqual(
-      `<div className="markdown"><p><h2 id="api"><AnchorLink to="#api" aria-hidden="true" tabIndex={-1}><span className={["icon","icon-link"]} /></AnchorLink>API</h2>
-<API src="./Hello/index.tsx" identifier="Hello" export="default" /></p></div>`,
+      `<div className="markdown"><h2 id="api"><AnchorLink to="#api" aria-hidden="true" tabIndex={-1}><span className={["icon","icon-link"]} /></AnchorLink>API</h2>
+<API src="./Hello/index.tsx" identifier="Hello" export="default" /></div>`,
     );
   });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
close https://github.com/umijs/dumi/issues/524
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

#### API 结构

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/29775873/106546828-01ab0280-6547-11eb-8b3c-5adbb1cbbf24.png) | ![image](https://user-images.githubusercontent.com/29775873/106555459-95d19580-6558-11eb-97d7-f0bd718d8641.png) |

API 内部层级为 h2 + table ，原有是放到了 p 标签内，所以会有 warning 。这里是将这 2 个 拿到了 父层结构，同时可以保持 父层结构上 标题结构。

#### embed

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/29775873/106555485-a2ee8480-6558-11eb-85a2-77f352c2a4ab.png)|  ![image](https://user-images.githubusercontent.com/29775873/106555573-cd404200-6558-11eb-852d-afbd9c4ac0f3.png) |

p 标签拿去了，但是这个 引的 md 外层有一个 div class="markdown" 没去掉

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
