### PR TITLE
feat: usePrefersColor theme API

### DIFF
--- a/docs/theme/api.md
+++ b/docs/theme/api.md
@@ -109,3 +109,50 @@ To get the API metadata of the specified component, please refer to the [API com
 - **return:** `String`. The url go to TypeScript Playground
 
 Get the link to the Playground of the current TypeScript official website to submit the TSX code to the Playground to display the JSX code.
+
+## usePrefersColor
+
+- **props:** none
+- **return:**
+  - color: `'dark' | 'light'`. Current prefers color, can only be `dark` or `light`
+  - toggleColor: `() => void`. A function to reverse current prefers color for site
+
+This API will be useful if we want to implement dark/light mode for our theme.
+
+For theme developer:
+
+- Can write dark mode styles incrementally with `[data-prefers-color=dark]` CSS attribute selector, for example:
+
+```less
+.navbar { /* light styles */ }
+[data-prefers-color=dark] .navbar { /* dark styles */ }
+
+// or
+.navbar {
+  /* light styles */
+  [data-prefers-color-dark] & {
+    /* dark styles */
+  }
+}
+```
+
+- Get current prefers color & toggle function via this react hook, to provide a button to toggle dark/light mode for user, for example:
+
+```tsx | pure
+import React from 'react';
+import { usePrefersColor } from 'dumi/theme';
+
+export default props => {
+  const [color, toggleColor] = usePrefersColor();
+
+  return (
+    <button onClick={toggleColor}>
+      Enable
+      {color === 'light' ? 'dark' : 'light'}
+      mode
+    </button>
+  );
+};
+```
+
+More informations in [#543](https://github.com/umijs/dumi/pull/543)。

--- a/docs/theme/api.zh-CN.md
+++ b/docs/theme/api.zh-CN.md
@@ -103,3 +103,50 @@ export default props => {
 - **返回：** `String`。前往 TypeScript Playground 的 url
 
 获取当前 TypeScript 官网 Playground 的链接，用于将 TSX 代码提交到 Playground 中展示 JSX 代码。
+
+## usePrefersColor
+
+- **参数：** 无
+- **返回：**
+  - color: `'dark' | 'light'`。当前的 color 值，只可能为 `dark` 或 `light`
+  - toggleColor: `() => void`。反转当前 color 的函数，执行后 color 会进行反转
+
+当我们需要为主题增加暗黑/明亮模式的切换能力时，需要用到该 API。
+
+对于开发者而言：
+
+- 可以通过 `[data-prefers-color=dark]` 的属性选择器，在主题 Less 中增量编写暗黑模式的样式，例如
+
+```less
+.navbar { /* 明亮样式 */ }
+[data-prefers-color=dark] .navbar { /* 暗黑样式 */ }
+
+// 或者
+.navbar {
+  /* 明亮样式 */
+  [data-prefers-color-dark] & {
+    /* 暗黑样式 */
+  }
+}
+```
+
+- 可以通过该 hook，可以拿到当前色彩偏好的值以及切换函数，以便为用户提供开关来切换暗黑/明亮模式，例如：
+
+```tsx | pure
+import React from 'react';
+import { usePrefersColor } from 'dumi/theme';
+
+export default props => {
+  const [color, toggleColor] = usePrefersColor();
+
+  return (
+    <button onClick={toggleColor}>
+      切换到
+      {color === 'light' ? '暗黑' : '明亮'}
+      模式
+    </button>
+  );
+};
+```
+
+更多信息可参考 [#543](https://github.com/umijs/dumi/pull/543)。

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  setupFiles: ['<rootDir>/scripts/jest-setup.js'],
   coveragePathIgnorePatterns: [
     '/packages/dumi/src/index.ts',
     '/packages/create-dumi-lib/src/cli.ts',

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^7.0.0",
     "father-build": "^1.14.2",
     "husky": "^4.2.5",
+    "jest-matchmedia-mock": "^1.1.0",
     "lerna": "^3.6.0",
     "lerna-changelog": "^0.8.2",
     "prettier": "^1.19.1",

--- a/packages/preset-dumi/package.json
+++ b/packages/preset-dumi/package.json
@@ -74,7 +74,8 @@
     "@types/unist": "^2.0.3",
     "@umijs/core": "^3.2.6",
     "react-test-renderer": "^16.13.1",
-    "sitemap": "^6.3.3"
+    "sitemap": "^6.3.3",
+    "terser": "^5.5.1"
   },
   "license": "MIT"
 }

--- a/packages/preset-dumi/package.json
+++ b/packages/preset-dumi/package.json
@@ -56,6 +56,7 @@
     "remark-rehype": "^8.0.0",
     "remark-stringify": "^9.0.0",
     "slash2": "^2.0.0",
+    "terser": "^5.5.1",
     "unified": "^8.4.1",
     "unist-util-visit": "^2.0.1",
     "unist-util-visit-parents": "^3.0.1"
@@ -74,8 +75,7 @@
     "@types/unist": "^2.0.3",
     "@umijs/core": "^3.2.6",
     "react-test-renderer": "^16.13.1",
-    "sitemap": "^6.3.3",
-    "terser": "^5.5.1"
+    "sitemap": "^6.3.3"
   },
   "license": "MIT"
 }

--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -4,16 +4,23 @@ import type { IApi } from '@umijs/types';
 import { rimraf } from '@umijs/utils';
 import { Service } from '@umijs/core';
 import { render } from '@testing-library/react';
+import MatchMediaMock from 'jest-matchmedia-mock';
 import symlink from './utils/symlink';
 
 describe('preset-dumi', () => {
+  let matchMedia: MatchMediaMock;
   const fixtures = path.join(__dirname, 'fixtures');
+
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
 
   afterAll(() => {
     // clear all node_modules
     ['', 'basic', 'algolia', 'demos', 'assets', 'integrate', 'local-theme', 'progressive-theme', 'side-effects', 'sitemap'].forEach(dir => {
       rimraf.sync(path.join(fixtures, dir, 'node_modules'));
     });
+    matchMedia.clear();
   });
 
   it('init', async () => {

--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -4,23 +4,16 @@ import type { IApi } from '@umijs/types';
 import { rimraf } from '@umijs/utils';
 import { Service } from '@umijs/core';
 import { render } from '@testing-library/react';
-import MatchMediaMock from 'jest-matchmedia-mock';
 import symlink from './utils/symlink';
 
 describe('preset-dumi', () => {
-  let matchMedia: MatchMediaMock;
   const fixtures = path.join(__dirname, 'fixtures');
-
-  beforeAll(() => {
-    matchMedia = new MatchMediaMock();
-  });
 
   afterAll(() => {
     // clear all node_modules
     ['', 'basic', 'algolia', 'demos', 'assets', 'integrate', 'local-theme', 'progressive-theme', 'side-effects', 'sitemap'].forEach(dir => {
       rimraf.sync(path.join(fixtures, dir, 'node_modules'));
     });
-    matchMedia.clear();
   });
 
   it('init', async () => {

--- a/packages/preset-dumi/src/plugins/features/theme.ts
+++ b/packages/preset-dumi/src/plugins/features/theme.ts
@@ -1,8 +1,19 @@
 import fs from 'fs';
 import path from 'path';
+import { minify } from 'terser';
 import type { IApi } from '@umijs/types';
 import getTheme from '../../theme/loader';
 import { setOptions } from '../../context';
+
+// initialize data-prefers-color attr for HTML tag
+const COLOR_HEAD_SCP = `
+(function () {
+  var cache = localStorage.getItem('dumi:prefers-color');
+  var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  document.documentElement.setAttribute('data-prefers-color', cache || (isDark ? 'dark' : 'light'));
+})();
+`;
 
 /**
  * plugin for alias dumi/theme module for export theme API
@@ -39,4 +50,7 @@ export default (api: IApi) => {
 
     return memo;
   });
+
+  // add head script to initialize prefers-color-schema for HTML tag
+  api.addHTMLHeadScripts(async () => [{ content: (await minify(COLOR_HEAD_SCP, { ecma: 5 })).code }]);
 };

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.test.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.test.ts
@@ -1,0 +1,65 @@
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+describe('theme API: usePrefersColor', () => {
+  let matchMedia: MatchMediaMock;
+  let usePrefersColor: any;
+  const attrName = 'data-prefers-color';
+  const originalColor = document.documentElement.getAttribute(attrName);
+
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+    document.documentElement.setAttribute(attrName, 'light');
+    usePrefersColor = require('./usePrefersColor').default;
+  });
+
+  afterAll(() => {
+    document.documentElement.setAttribute(attrName, originalColor);
+    matchMedia.clear();
+  });
+
+  it('should works both initial value & toggle action', () => {
+    const { result } = renderHook(() => usePrefersColor());
+
+    // expect to equal initial value from html tag
+    expect(result.current[0]).toEqual('light');
+
+    // change media query to dark
+    act(() => {
+      matchMedia.useMediaQuery('(prefers-color-scheme: dark)');
+    });
+
+    // expect response media query change
+    expect(result.current[0]).toEqual('dark');
+
+    // detect local storage value be empty
+    expect(localStorage.getItem('dumi:prefers-color')).toBeNull();
+
+    // toggle color manually
+    act(() => {
+      result.current[1]();
+    });
+
+    // expect color changed
+    expect(result.current[0]).toEqual('light');
+
+    // expect save to local storage if current color was not matched prefers-color-schema
+    expect(localStorage.getItem('dumi:prefers-color')).toEqual('light');
+
+    // trigger dark media query again
+    act(() => {
+      matchMedia.useMediaQuery('(prefers-color-scheme: dark)');
+    });
+
+    // expect color not be changed by media query if user toggle color manually
+    expect(result.current[0]).toEqual('light');
+
+    // toggle color manually
+    act(() => {
+      result.current[1]();
+    });
+
+    // detect local storage value be empty if current color matched prefers-color-schema
+    expect(localStorage.getItem('dumi:prefers-color')).toBeNull();
+  });
+});

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -1,0 +1,111 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const COLOR_ATTR_NAME = 'data-prefers-color';
+const COLOR_LS_NAME = 'dumi:prefers-color';
+const COLOR_MAPPING = {
+  light: 'dark',
+  dark: 'light',
+};
+const colorChanger = new (class {
+  /**
+   * current color
+   * @note  initial value from head script in src/plugins/theme.ts
+   */
+  color = document.documentElement.getAttribute(COLOR_ATTR_NAME);
+
+  /**
+   * color change callbacks
+   */
+  private callbacks: ((color: string) => void)[] = [];
+
+  constructor() {
+    // listen prefers color change
+    Object.keys(COLOR_MAPPING).forEach(color => {
+      this.getColorMedia(color).addEventListener('change', (ev) => {
+        // only apply media prefers color when user did not configure theme
+        if (ev.matches && !localStorage.getItem(COLOR_LS_NAME)) {
+          this.color = color;
+          document.documentElement.setAttribute(COLOR_ATTR_NAME, color);
+          this.applyCallbacks();
+        }
+      });
+    });
+  }
+
+  /**
+   * get media instance for prefers color
+   * @param color   prefers color
+   */
+  getColorMedia(color: string) {
+    return window.matchMedia(`(prefers-color-scheme: ${color})`);
+  }
+
+  /**
+   * detect color whether matches current color mode
+   * @param color   expected color
+   */
+  isColorMode(color: string) {
+    return this.getColorMedia(color).matches;
+  }
+
+  /**
+   * apply all event change callbacks
+   */
+  applyCallbacks() {
+    this.callbacks.forEach(cb => cb(this.color));
+  }
+
+  /**
+   * listen color change
+   * @param cb  callback
+   */
+  listen(cb: (color: string) => void) {
+    this.callbacks.push(cb);
+  }
+
+  /**
+   * unlisten color change
+   * @param cb  callback
+   */
+  unlisten(cb: (color: string) => void) {
+    this.callbacks.splice(this.callbacks.indexOf(cb), 1);
+  }
+
+  /**
+   * change prefers color
+   */
+  toggle() {
+    const targetColor = COLOR_MAPPING[this.color];
+
+    document.documentElement.setAttribute(COLOR_ATTR_NAME, targetColor);
+    this.color = targetColor;
+
+    // save prefers color to local storage if it is different with media rule
+    if (!this.isColorMode(targetColor)) {
+      localStorage.setItem(COLOR_LS_NAME, targetColor);
+    } else {
+      localStorage.removeItem(COLOR_LS_NAME);
+    }
+
+    return targetColor;
+  }
+})();
+
+/**
+ * hook for get/toggle prefers-color-schema, use to control color mode for theme package
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
+ */
+export default (): [string, () => void] => {
+  const [color, setColor] = useState(colorChanger.color);
+  const toggleColor = useCallback(() => {
+    setColor(colorChanger.toggle());
+  }, []);
+
+  useEffect(() => {
+    colorChanger.listen(setColor);
+
+    return () => colorChanger.unlisten(setColor);
+  }, []);
+
+  return [color, toggleColor];
+};

--- a/packages/preset-dumi/src/theme/index.ts
+++ b/packages/preset-dumi/src/theme/index.ts
@@ -13,6 +13,7 @@ export { default as useLocaleProps } from './hooks/useLocaleProps';
 export { default as useDemoUrl } from './hooks/useDemoUrl';
 export { default as useApiData } from './hooks/useApiData';
 export { default as useTSPlaygroundUrl } from './hooks/useTSPlaygroundUrl';
+export { default as usePrefersColor } from './hooks/usePrefersColor';
 
 export interface IPreviewerComponentProps {
   title?: string;

--- a/packages/preset-dumi/src/theme/layout.tsx
+++ b/packages/preset-dumi/src/theme/layout.tsx
@@ -6,6 +6,8 @@ import AnchorLink from './components/AnchorLink';
 import type { IThemeContext } from './context';
 import Context from './context';
 import type { IMenu } from '../routes/getMenuFromRoutes';
+// for listen prefers-color-schema media change
+import './hooks/usePrefersColor';
 
 export interface IOuterLayoutProps {
   mode: IThemeContext['config']['mode'];

--- a/scripts/jest-setup.js
+++ b/scripts/jest-setup.js
@@ -1,0 +1,4 @@
+const MatchMedia = require('jest-matchmedia-mock').default;
+
+// mock window.matchMedia
+module.exports = new MatchMedia();


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature

### 🔗 相关 Issue / Related Issue

#490 

### 💡 需求背景和解决方案 / Background or solution

为了解决暗黑主题的『自动跟随系统』及『手动切换』，新增如下特性：
- 通过 Plugin API 给输出的 HTML 的 `head` 区域添加脚本，用于
  1. 初始化 `data-prefers-color` 属性到 HTML 标签上
  2. 初始化值的取值顺序：LocalStorage 的存储值 > matchMedia 匹配 'dark' > 默认 'light'
  3. 放在 head 内是为了确保 body 的内容被解析时，`data-prefers-color` 的属性选择器就已经生效，避免样式闪动
- 新增 `usePrefersColor` 主题 API，可从 `dumi/theme` 中 import，hook 的返回值为数组
  1. 第一个返回值为当前的 `color` **值**，默认值为上一步中 `head` 脚本初始化的 HTML 标签上的值
  2. 第二个返回值为反转当前 `color` 的**函数**，执行后 `color` 会进行反转
  3. 当反转后的 `color` 值与系统值**不匹配**时，会自动写入 LocalStorage，以便下次载入页面时恢复切换状态
  4. 当反转后的 `color` 值与系统值**匹配**时，会清空 LocalStorage 的内容，以便恢复为自动跟随系统的色彩偏好
 - dumi 会监听 `prefers-color-scheme` 的 media 规则变化（例如在操作系统的设置中修改了色彩偏好会触发规则变化），并在规则变化的同时更新 HTML 标签上的 `data-prefers-color` 属性值

对于主题开发者：
- 通过 `[data-prefers-color=dark]` 的属性选择器，可以增量编写暗黑模式的主题样式
- 通过 `usePrefersColor` hook，可以完成暗黑模式的功能切换，例如提供一个切换按钮给用户

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  --       |
| 🇨🇳 Chinese | --        |
