### PR TITLE
feat: split auto mode for usePrefersColor

### DIFF
--- a/docs/theme/api.md
+++ b/docs/theme/api.md
@@ -114,8 +114,8 @@ Get the link to the Playground of the current TypeScript official website to sub
 
 - **props:** none
 - **return:**
-  - color: `'dark' | 'light'`. Current prefers color, can only be `dark` or `light`
-  - toggleColor: `() => void`. A function to reverse current prefers color for site
+  - color: `'light' | 'dark' | 'auto'`. Current prefers color
+  - toggleColor: `(color: 'light' | 'dark' | 'auto') => void`. A function to change current prefers color for site, the prefers color will follow OS preferences if set `auto`
 
 This API will be useful if we want to implement dark/light mode for our theme.
 
@@ -130,7 +130,7 @@ For theme developer:
 // or
 .navbar {
   /* light styles */
-  [data-prefers-color-dark] & {
+  [data-prefers-color=dark] & {
     /* dark styles */
   }
 }
@@ -143,14 +143,13 @@ import React from 'react';
 import { usePrefersColor } from 'dumi/theme';
 
 export default props => {
-  const [color, toggleColor] = usePrefersColor();
+  const [color, setColor] = usePrefersColor();
 
   return (
-    <button onClick={toggleColor}>
-      Enable
-      {color === 'light' ? 'dark' : 'light'}
-      mode
-    </button>
+    <>
+      <button onClick={() => setColor('auto')}>Enable auto prefers color</button>
+      Current prefers color: {color}
+    </>
   );
 };
 ```

--- a/docs/theme/api.zh-CN.md
+++ b/docs/theme/api.zh-CN.md
@@ -108,8 +108,8 @@ export default props => {
 
 - **参数：** 无
 - **返回：**
-  - color: `'dark' | 'light'`。当前的 color 值，只可能为 `dark` 或 `light`
-  - toggleColor: `() => void`。反转当前 color 的函数，执行后 color 会进行反转
+  - color: `'light' | 'dark' | 'auto'`。当前的 color 值
+  - setColor: `(color: 'light' | 'dark' | 'auto') => void`。设置当前 color 的函数，设置为 `auto` 时意味着跟随操作系统的偏好设置
 
 当我们需要为主题增加暗黑/明亮模式的切换能力时，需要用到该 API。
 
@@ -124,7 +124,7 @@ export default props => {
 // 或者
 .navbar {
   /* 明亮样式 */
-  [data-prefers-color-dark] & {
+  [data-prefers-color=dark] & {
     /* 暗黑样式 */
   }
 }
@@ -137,14 +137,13 @@ import React from 'react';
 import { usePrefersColor } from 'dumi/theme';
 
 export default props => {
-  const [color, toggleColor] = usePrefersColor();
+  const [color, setColor] = usePrefersColor();
 
   return (
-    <button onClick={toggleColor}>
-      切换到
-      {color === 'light' ? '暗黑' : '明亮'}
-      模式
-    </button>
+    <>
+      <button onClick={() => setColor('auto')}>启用自动主题色</button>
+      当前主题色配置为：{color}
+    </>
   );
 };
 ```

--- a/packages/preset-dumi/src/plugins/features/theme.ts
+++ b/packages/preset-dumi/src/plugins/features/theme.ts
@@ -10,8 +10,14 @@ const COLOR_HEAD_SCP = `
 (function () {
   var cache = localStorage.getItem('dumi:prefers-color');
   var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var enums = ['light', 'dark', 'auto'];
 
-  document.documentElement.setAttribute('data-prefers-color', cache || (isDark ? 'dark' : 'light'));
+  document.documentElement.setAttribute(
+    'data-prefers-color',
+    cache === enums[2]
+      ? (isDark ? enums[1] : enums[0])
+      : (enums.includes(cache) ? cache : enums[0])
+  );
 })();
 `;
 

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.test.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.test.ts
@@ -24,42 +24,46 @@ describe('theme API: usePrefersColor', () => {
     // expect to equal initial value from html tag
     expect(result.current[0]).toEqual('light');
 
-    // change media query to dark
+    // set color to dark
     act(() => {
-      matchMedia.useMediaQuery('(prefers-color-scheme: dark)');
+      result.current[1]('dark');
     });
 
-    // expect response media query change
+    // expect response color change
     expect(result.current[0]).toEqual('dark');
 
-    // detect local storage value be empty
-    expect(localStorage.getItem('dumi:prefers-color')).toBeNull();
+    // expect save to local storage
+    expect(localStorage.getItem('dumi:prefers-color')).toEqual('dark');
 
-    // toggle color manually
+    // trigger media change
     act(() => {
-      result.current[1]();
+      matchMedia.useMediaQuery('(prefers-color-scheme: light)');
     });
 
-    // expect color changed
-    expect(result.current[0]).toEqual('light');
+    // expect not response media change if color mode not be auto
+    expect(result.current[0]).toEqual('dark');
+    expect(document.documentElement.getAttribute(attrName)).toEqual('dark');
 
-    // expect save to local storage if current color was not matched prefers-color-schema
-    expect(localStorage.getItem('dumi:prefers-color')).toEqual('light');
+    // set color to auto then trigger media change
+    act(() => {
+      result.current[1]('auto');
+      matchMedia.useMediaQuery('(prefers-color-scheme: light)');
+    });
 
-    // trigger dark media query again
+    // expect real attribute color be light but color changer still be auto
+    expect(result.current[0]).toEqual('auto');
+    expect(document.documentElement.getAttribute(attrName)).toEqual('light');
+
+    // expect local storage value be auto
+    expect(localStorage.getItem('dumi:prefers-color')).toEqual('auto');
+
+    // trigger media change to dark then set color to auto
     act(() => {
       matchMedia.useMediaQuery('(prefers-color-scheme: dark)');
+      result.current[1]('auto');
     });
 
-    // expect color not be changed by media query if user toggle color manually
-    expect(result.current[0]).toEqual('light');
-
-    // toggle color manually
-    act(() => {
-      result.current[1]();
-    });
-
-    // detect local storage value be empty if current color matched prefers-color-schema
-    expect(localStorage.getItem('dumi:prefers-color')).toBeNull();
+    // expect real attribute color be dark
+    expect(document.documentElement.getAttribute(attrName)).toEqual('dark');
   });
 });

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -92,8 +92,7 @@ const colorChanger = new (class {
 export default () => {
   const [color, setColor] = useState<PrefersColorValue>(colorChanger.color);
   const changeColor = useCallback((val: PrefersColorValue) => {
-    setColor(val);
-    colorChanger.set(val);
+    setColor(colorChanger.set(val));
   }, []);
 
   useEffect(() => {

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -2,29 +2,26 @@ import { useState, useEffect, useCallback } from 'react';
 
 const COLOR_ATTR_NAME = 'data-prefers-color';
 const COLOR_LS_NAME = 'dumi:prefers-color';
-const COLOR_MAPPING = {
-  light: 'dark',
-  dark: 'light',
-};
+
+export type PrefersColorValue = 'dark' | 'light' | 'auto';
 const colorChanger = new (class {
   /**
    * current color
    * @note  initial value from head script in src/plugins/theme.ts
    */
-  color = document.documentElement.getAttribute(COLOR_ATTR_NAME);
+  color = document.documentElement.getAttribute(COLOR_ATTR_NAME) as PrefersColorValue;
 
   /**
    * color change callbacks
    */
-  private callbacks: ((color: string) => void)[] = [];
+  private callbacks: ((color: PrefersColorValue) => void)[] = [];
 
   constructor() {
     // listen prefers color change
-    Object.keys(COLOR_MAPPING).forEach(color => {
+    (['light', 'dark'] as PrefersColorValue[]).forEach(color => {
       this.getColorMedia(color).addEventListener('change', (ev) => {
-        // only apply media prefers color when user did not configure theme
-        if (ev.matches && !localStorage.getItem(COLOR_LS_NAME)) {
-          this.color = color;
+        // only apply media prefers color in auto mode
+        if (ev.matches && this.color === 'auto') {
           document.documentElement.setAttribute(COLOR_ATTR_NAME, color);
           this.applyCallbacks();
         }
@@ -36,7 +33,7 @@ const colorChanger = new (class {
    * get media instance for prefers color
    * @param color   prefers color
    */
-  getColorMedia(color: string) {
+  getColorMedia(color: PrefersColorValue) {
     return window.matchMedia(`(prefers-color-scheme: ${color})`);
   }
 
@@ -44,7 +41,7 @@ const colorChanger = new (class {
    * detect color whether matches current color mode
    * @param color   expected color
    */
-  isColorMode(color: string) {
+  isColorMode(color: PrefersColorValue) {
     return this.getColorMedia(color).matches;
   }
 
@@ -59,7 +56,7 @@ const colorChanger = new (class {
    * listen color change
    * @param cb  callback
    */
-  listen(cb: (color: string) => void) {
+  listen(cb: (color: PrefersColorValue) => void) {
     this.callbacks.push(cb);
   }
 
@@ -67,38 +64,36 @@ const colorChanger = new (class {
    * unlisten color change
    * @param cb  callback
    */
-  unlisten(cb: (color: string) => void) {
+  unlisten(cb: (color: PrefersColorValue) => void) {
     this.callbacks.splice(this.callbacks.indexOf(cb), 1);
   }
 
   /**
-   * change prefers color
+   * set prefers color
    */
-  toggle() {
-    const targetColor = COLOR_MAPPING[this.color];
+  set(color: PrefersColorValue) {
+    this.color = color;
+    localStorage.setItem(COLOR_LS_NAME, color);
 
-    document.documentElement.setAttribute(COLOR_ATTR_NAME, targetColor);
-    this.color = targetColor;
-
-    // save prefers color to local storage if it is different with media rule
-    if (!this.isColorMode(targetColor)) {
-      localStorage.setItem(COLOR_LS_NAME, targetColor);
+    if (color === 'auto') {
+      document.documentElement.setAttribute(COLOR_ATTR_NAME, this.isColorMode('dark') ? 'dark' : 'light');
     } else {
-      localStorage.removeItem(COLOR_LS_NAME);
+      document.documentElement.setAttribute(COLOR_ATTR_NAME, color);
     }
 
-    return targetColor;
+    return color;
   }
 })();
 
 /**
- * hook for get/toggle prefers-color-schema, use to control color mode for theme package
+ * hook for get/set prefers-color-schema, use to control color mode for theme package
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
  */
-export default (): [string, () => void] => {
-  const [color, setColor] = useState(colorChanger.color);
-  const toggleColor = useCallback(() => {
-    setColor(colorChanger.toggle());
+export default () => {
+  const [color, setColor] = useState<PrefersColorValue>(colorChanger.color);
+  const changeColor = useCallback((val: PrefersColorValue) => {
+    setColor(val);
+    colorChanger.set(val);
   }, []);
 
   useEffect(() => {
@@ -107,5 +102,5 @@ export default (): [string, () => void] => {
     return () => colorChanger.unlisten(setColor);
   }, []);
 
-  return [color, toggleColor];
+  return [color, changeColor] as [PrefersColorValue, typeof changeColor];
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature

### 🔗 相关 Issue / Related Issue

#490 #543 

### 💡 需求背景和解决方案 / Background or solution

此 PR 是 #543 的完善，修改 `usePrefersColor` 主题 API：
- 显式增加 `auto` 的主题色偏好配置，便于开发者向用户开放 `light/dark/auto` 三种配置方式
- hook 返回值从 `[string, () => void]` 变成 `[string, (color: 'light' | 'dark' | 'auto') => void]`，第二参数从切换明亮/黑暗变成设置明亮/黑暗/自动
- 当设置为 `auto` 时主题色偏好将跟随操作系统设置
- 其他逻辑与 #543 中保持一致

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
