### PR TITLE
fix: react dom warnings from embed, api & code

### DIFF
--- a/packages/preset-dumi/src/api-parser/fixtures/expect/forwardRef.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/forwardRef.json
@@ -23,7 +23,7 @@
     },
     {
       "identifier": "key",
-      "type": "ReactText"
+      "type": "Key"
     }
   ]
 }

--- a/packages/preset-dumi/src/transformer/remark/domWarn.ts
+++ b/packages/preset-dumi/src/transformer/remark/domWarn.ts
@@ -1,0 +1,69 @@
+import visit from 'unist-util-visit-parents';
+import is from 'hast-util-is-element';
+import type { IDumiElmNode, IDumiUnifiedTransformer } from '.';
+
+const NO_PARAGRAPH_RULES: { type: string; tagName: string; [key: string]: any }[] = [
+  { type: 'element', tagName: 'code', properties: { src: Boolean } },
+  { type: 'element', tagName: 'embed', properties: { src: Boolean } },
+  { type: 'element', tagName: 'API' },
+];
+
+/**
+ * loose compare node properties for check matching
+ * @param oProps  original properties
+ * @param eProps  equal properties
+ */
+function looseCompareProps(oProps: Record<string, any>, eProps: Record<string, any>) {
+  return Object.entries(eProps).every(([name, value]) => {
+    if (typeof value !== 'object') {
+      return typeof value === 'function' ? value(oProps[name]) : oProps[name] === value;
+    }
+
+    return looseCompareProps(oProps[name], value);
+  });
+}
+
+/**
+ * rehype plugin for prevent DOM validation warnings from React
+ * @note  semantic DOM nesting relationship
+ */
+export default function domWarn(): IDumiUnifiedTransformer {
+  return ast => {
+    visit(ast, 'element', (node: IDumiElmNode, ancestors) => {
+      // only process the p elements below the root
+      if (
+        is(node, 'p') &&
+        ancestors[0].type === 'root' &&
+        ancestors.length === 1
+      ) {
+        const nodes: IDumiElmNode[] = [];
+
+        // visit all children for p element
+        node.children.forEach(child => {
+          if (NO_PARAGRAPH_RULES.some(rule => looseCompareProps(child, rule))) {
+            // hoist to parent level for matched node
+            nodes.push(child);
+          } else {
+            // push empty p element if there has not valid p element
+            if (!nodes.length || !is(nodes[nodes.length - 1], 'p')) {
+              // FIXME: make sure the position data correctly
+              nodes.push({ ...node, children: [] });
+            }
+
+            // push child into p element
+            nodes[nodes.length - 1].children.push(child);
+          }
+        });
+
+        // replace original p element if there has matched node(s)
+        if (nodes.length > 1 || !is(nodes[0], 'p')) {
+          const parent = ancestors[ancestors.length - 1] as IDumiElmNode;
+
+          parent.children.splice(parent.children.indexOf(node), 1, ...nodes);
+        }
+
+        return visit.SKIP;
+      }
+    });
+  };
+}

--- a/packages/preset-dumi/src/transformer/remark/index.ts
+++ b/packages/preset-dumi/src/transformer/remark/index.ts
@@ -23,6 +23,7 @@ import previewer from './previewer';
 import raw from './raw';
 import jsxify from './jsxify';
 import isolation from './isolation';
+import domWarn from './domWarn';
 import sourceCode from './sourceCode';
 
 const log = createDebug('dumi:remark');
@@ -114,6 +115,8 @@ export default (source: string, fileAbsPath: string, type: 'jsx' | 'html') => {
     .use(debug('sourceCode'))
     .use(raw)
     .use(debug('raw'))
+    .use(domWarn)
+    .use(debug('domWarn'))
     .use(comments, { removeConditional: true })
     .use(debug('comments'))
     .use(img)

--- a/packages/preset-dumi/src/transformer/test/remark-api.test.ts
+++ b/packages/preset-dumi/src/transformer/test/remark-api.test.ts
@@ -48,8 +48,8 @@ describe('component api example', () => {
 
     // compare transform content
     expect(result).toEqual(
-      `<div className="markdown"><p><h2 id="api"><AnchorLink to="#api" aria-hidden="true" tabIndex={-1}><span className={["icon","icon-link"]} /></AnchorLink>API</h2>
-<API src="./Hello/index.tsx" identifier="Hello" export="default" /></p></div>`,
+      `<div className="markdown"><h2 id="api"><AnchorLink to="#api" aria-hidden="true" tabIndex={-1}><span className={["icon","icon-link"]} /></AnchorLink>API</h2>
+<API src="./Hello/index.tsx" identifier="Hello" export="default" /></div>`,
     );
   });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] bug 修复 / Fix bug

### 🔗 相关 Issue / Related Issue

issues: #524 #418 
PRs: #536 #427 

close #524 

### 💡 需求背景和解决方案 / Background or solution

由于 Markdown 语法依赖换行进行段落拆分形成 `p` 标签，但 dumi 扩展的 Markdown 语法会被进一步解析形成新的 DOM 结构，导致部分语法解析后会出现 `p` 嵌套 `h`、`table` 等标签的情况，使得 React 在运行时抛出 `validateDOMNesting(...)` 的警告，不影响功能运行但输出信息会干扰开发者调试组件

解法：
1. 创建通用的 `domWarn` rehype 插件，遍历所有顶层 `p` 下面的扩展 Markdown 语法，并进行位置提升、到父级 `p` 同级
2. 目前会处理的扩展语法包括 `code`、`API`、`embed`

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  --       |
| 🇨🇳 Chinese |  --       |
