### PR TITLE
fix(preset): avoid overriding duplicated import

### DIFF
--- a/packages/preset-dumi/src/plugins/features/demo/index.ts
+++ b/packages/preset-dumi/src/plugins/features/demo/index.ts
@@ -25,7 +25,7 @@ export default (api: IApi) => {
   const demos: ISingleRoutetDemos = {};
   const generateDemosFile = api.utils.lodash.debounce(async () => {
     let hoistImportCount = 0;
-    const hoistImports: Record<string, number> = {};
+    const hoistImports: Record<string, number[]> = {};
     const tpl = fs.readFileSync(path.join(__dirname, 'demos.mst'), 'utf8');
     const items = Object.keys(demos).map(uuid => {
       const { componentName } = demos[uuid].previewerProps;
@@ -48,16 +48,16 @@ export default (api: IApi) => {
         const content = file === '_' ? Object.values(oContent)[0] : oContent.content;
 
         if (isHoistImport(content)) {
-          if (!hoistImports[content]) {
-            hoistImports[content] = hoistImportCount;
-            hoistImportCount += 1;
+          if (!itemHoistImports[content]) {
+            itemHoistImports[content] = hoistImportCount
+            hoistImports[content] = (hoistImports[content] || []).concat(itemHoistImports[content])
+            hoistImportCount+=1
           }
 
-          itemHoistImports[content] = hoistImports[content];
         }
       });
-
-      // replace collected import statments to rawCode var
+ 
+      // replace collected import statements to rawCode var
       const previewerPropsStr = Object.entries(itemHoistImports).reduce(
         (str, [stmt, no]) => str.replace(new RegExp(`"${stmt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`, 'g'), `rawCode${no}`),
         JSON.stringify(demos[uuid].previewerProps),
@@ -75,8 +75,9 @@ export default (api: IApi) => {
       path: 'dumi/demos/index.ts',
       content: api.utils.Mustache.render(tpl, {
         demos: items,
-        rawCodes: Object.entries(hoistImports).map(([stmt, no]) =>
-          decodeHoistImport(stmt, `rawCode${no}`),
+        rawCodes: Object.entries(hoistImports).reduce((statements, [stmt, nos]) =>
+          statements.concat(nos.map(no => decodeHoistImport(stmt, `rawCode${no}`))),
+          []
         ),
       }),
     });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] bug 修复 / Fix bug

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

在 v1.1.9 中，当 **第一个**  markdown 中和后续 markdown 中各自的 demo 导入同一个文件时，会报 rawCodeX（X 表示数字）未定义的错误。

以 dumi 仓库为示例

1. 在 docs/config/frontmetter.md 和 docs/config/index.md 中任意正文位置加入：

    <pre>
   ```tsx
    import React from 'react';
    import '../.demos/modal/modal.less';
    
    export default function Button() {
      // ...
    }
    ```
    </pre>

1. 打开浏览器出现 ReferenceError: rawCode0 is not defined

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   should avoid override duplicated importation        |
| 🇨🇳 Chinese |        在不同 markdown 中导入同一文件时，不应该覆盖之前的导入   |
