### PR TITLE
feat: repourl support other protocol

### DIFF
--- a/packages/preset-dumi/src/utils/getRepoUrl.test.ts
+++ b/packages/preset-dumi/src/utils/getRepoUrl.test.ts
@@ -20,4 +20,10 @@ describe('getRepoUrl', () => {
       'https://some.other.com/umijs/dumi',
     );
   });
+
+  it('for other protocol', () => {
+    expect(getRepoUrl('git@http://self.gitlab.com:umijs/dumi.git')).toEqual(
+      'http://self.gitlab.com/umijs/dumi',
+    );
+  });
 });

--- a/packages/preset-dumi/src/utils/getRepoUrl.ts
+++ b/packages/preset-dumi/src/utils/getRepoUrl.ts
@@ -23,8 +23,9 @@ export default (url: string, platform?: 'gitlab') => {
     }
 
     // process other case, protocol://domain/group/repo{discard remaining paths}
+    const protocol = url.includes('http://') ? 'http' : 'https';
     repoUrl =
-      repoUrl || url.replace(/^.*?((?:[\w-]+\.?)+)+[:/]([\w-]+)\/([\w-]+).*$/, 'https://$1/$2/$3');
+      repoUrl || url.replace(/^.*?((?:[\w-]+\.?)+)+[:/]([\w-]+)\/([\w-]+).*$/, `${protocol}://$1/$2/$3`);
   }
 
   return repoUrl;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature

### 🔗 相关 Issue / Related Issue
fix https://github.com/umijs/dumi/issues/562
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

本来想用正则，后来考虑到有的 url 不填 `http` 或 `https`的。

这里默认不填的还是 https，若用户填写了 http，则 跳转 URL 协议走 http

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 跳转 URL 链接新增 `http` 协议。         |
