### PR TITLE
fix(preset): compatible with addEventListener of matchMedia

### DIFF
--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -21,13 +21,19 @@ class ColorChanger {
   constructor() {
     // listen prefers color change
     (['light', 'dark'] as PrefersColorValue[]).forEach(color => {
-      this.getColorMedia(color).addEventListener('change', ev => {
+      const mediaQueryList = this.getColorMedia(color);
+      const handler = (ev: any) => {
         // only apply media prefers color in auto mode
         if (ev.matches && this.color === 'auto') {
           document.documentElement.setAttribute(COLOR_ATTR_NAME, color);
           this.applyCallbacks();
         }
-      });
+      };
+      if (mediaQueryList.addEventListener) {
+        mediaQueryList.addEventListener('change', handler);
+        return;
+      }
+      mediaQueryList.addListener(handler);
     });
   }
 

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -29,11 +29,13 @@ class ColorChanger {
           this.applyCallbacks();
         }
       };
+      // compatible with Safari 13-
+      /* istanbul ignore else */
       if (mediaQueryList.addEventListener) {
         mediaQueryList.addEventListener('change', handler);
-        return;
+      } else if (mediaQueryList.addListener) {
+        mediaQueryList.addListener(handler);
       }
-      mediaQueryList.addListener(handler);
     });
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

Safari 上 matchMedia 设置监听器的方法还是 addListener，没有 addEventListener

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

没有 addEventListener 时使用 addListener。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix preset compatible with addEventListener of matchMedia.           |
| 🇨🇳 Chinese | 修复预设 matchMedia 的 `addEventListener` 方法兼容性。          |
