### PR TITLE
fix ssr

### DIFF
--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -11,7 +11,7 @@ class ColorChanger {
    * current color
    * @note  initial value from head script in src/plugins/theme.ts
    */
-  color = document.documentElement.getAttribute(COLOR_ATTR_NAME) as PrefersColorValue;
+  color:PrefersColorValue = "auto"
 
   /**
    * color change callbacks
@@ -19,6 +19,9 @@ class ColorChanger {
   private callbacks: ((color: PrefersColorValue) => void)[] = [];
 
   constructor() {
+    if(typeof document === undefined) return
+
+    this.color = document.documentElement.getAttribute(COLOR_ATTR_NAME) as PrefersColorValue;
     // listen prefers color change
     (['light', 'dark'] as PrefersColorValue[]).forEach(color => {
       this.getColorMedia(color).addEventListener('change', ev => {

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -12,7 +12,7 @@ class ColorChanger {
    * current color
    * @note  initial value from head script in src/plugins/theme.ts
    */
-  color:PrefersColorValue = "auto"
+  color:PrefersColorValue = 'light'
 
   /**
    * color change callbacks

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { isBrowser } from 'umi'
+import { isBrowser } from 'dumi';
 
 const COLOR_ATTR_NAME = 'data-prefers-color';
 const COLOR_LS_NAME = 'dumi:prefers-color';

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { isBrowser } from 'umi'
 
 const COLOR_ATTR_NAME = 'data-prefers-color';
 const COLOR_LS_NAME = 'dumi:prefers-color';
@@ -19,7 +20,7 @@ class ColorChanger {
   private callbacks: ((color: PrefersColorValue) => void)[] = [];
 
   constructor() {
-    if(typeof document === undefined) return
+    if(!isBrowser()) return
 
     this.color = document.documentElement.getAttribute(COLOR_ATTR_NAME) as PrefersColorValue;
     // listen prefers color change

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { isBrowser } from 'dumi';
+import { isBrowser } from 'umi';
 
 const COLOR_ATTR_NAME = 'data-prefers-color';
 const COLOR_LS_NAME = 'dumi:prefers-color';

--- a/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
+++ b/packages/preset-dumi/src/theme/hooks/usePrefersColor.ts
@@ -20,7 +20,7 @@ class ColorChanger {
   private callbacks: ((color: PrefersColorValue) => void)[] = [];
 
   constructor() {
-    if(!isBrowser()) return
+    if (!isBrowser()) return;
 
     this.color = document.documentElement.getAttribute(COLOR_ATTR_NAME) as PrefersColorValue;
     // listen prefers color change


### PR DESCRIPTION
`color = document.documentElement.getAttribute(COLOR_ATTR_NAME) as PrefersColorValue;`
ColorChanger 类在给 color 赋值的时候使用了 document ，如果在SSR环境下 document 是undefined，导致渲染错误

解决：
在构造函数内  `if(typeof document === undefined) return` 判断，并把 color的 赋值放在判断后面

<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

| Language   | Changelog |
| ---------- | --------- |
| 🇨🇳 Chinese |           |
