### PR TITLE
[WIP]feat(parser): api parser support to parse types

### DIFF
--- a/packages/preset-dumi/package.json
+++ b/packages/preset-dumi/package.json
@@ -63,7 +63,8 @@
     "unist-util-visit-parents": "^3.0.1"
   },
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": "3.x",
+    "typescript": ">= 3.x"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.3",

--- a/packages/preset-dumi/src/api-parser/fixtures/expect/class.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/class.json
@@ -1,21 +1,24 @@
-{
-  "A": [
-    {
-      "identifier": "className",
-      "description": "extra CSS className for this component",
-      "type": "string"
-    },
-    {
-      "identifier": "style",
-      "description": "inline styles",
-      "type": "CSSProperties"
-    },
-    {
-      "identifier": "size",
-      "description": "component size",
-      "type": "\"small\" | \"large\"",
-      "default": "small",
-      "required": true
-    }
-  ]
-}
+[
+  {
+    "A": [
+      {
+        "identifier": "className",
+        "description": "extra CSS className for this component",
+        "type": "string"
+      },
+      {
+        "identifier": "style",
+        "description": "inline styles",
+        "type": "CSSProperties"
+      },
+      {
+        "identifier": "size",
+        "description": "component size",
+        "type": "\"small\" | \"large\"",
+        "default": "small",
+        "required": true
+      }
+    ]
+  },
+  {}
+]

--- a/packages/preset-dumi/src/api-parser/fixtures/expect/extends.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/extends.json
@@ -1,27 +1,30 @@
-{
-  "B": [
-    {
-      "identifier": "isB",
-      "type": "boolean",
-      "default": "true",
-      "required": true
-    },
-    {
-      "identifier": "className",
-      "description": "extra CSS className for this component",
-      "type": "string"
-    },
-    {
-      "identifier": "style",
-      "description": "inline styles",
-      "type": "CSSProperties"
-    },
-    {
-      "identifier": "size",
-      "description": "component size",
-      "type": "\"small\" | \"large\"",
-      "default": "small",
-      "required": true
-    }
-  ]
-}
+[
+  {
+    "B": [
+      {
+        "identifier": "isB",
+        "type": "boolean",
+        "default": "true",
+        "required": true
+      },
+      {
+        "identifier": "className",
+        "description": "extra CSS className for this component",
+        "type": "string"
+      },
+      {
+        "identifier": "style",
+        "description": "inline styles",
+        "type": "CSSProperties"
+      },
+      {
+        "identifier": "size",
+        "description": "component size",
+        "type": "\"small\" | \"large\"",
+        "default": "small",
+        "required": true
+      }
+    ]
+  },
+  {}
+]

--- a/packages/preset-dumi/src/api-parser/fixtures/expect/fc.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/fc.json
@@ -1,21 +1,24 @@
-{
-  "fc": [
-    {
-      "identifier": "className",
-      "description": "extra CSS className for this component",
-      "type": "string"
-    },
-    {
-      "identifier": "style",
-      "description": "inline styles",
-      "type": "CSSProperties"
-    },
-    {
-      "identifier": "size",
-      "description": "component size",
-      "type": "\"small\" | \"large\"",
-      "default": "small",
-      "required": true
-    }
-  ]
-}
+[
+  {
+    "fc": [
+      {
+        "identifier": "className",
+        "description": "extra CSS className for this component",
+        "type": "string"
+      },
+      {
+        "identifier": "style",
+        "description": "inline styles",
+        "type": "CSSProperties"
+      },
+      {
+        "identifier": "size",
+        "description": "component size",
+        "type": "\"small\" | \"large\"",
+        "default": "small",
+        "required": true
+      }
+    ]
+  },
+  {}
+]

--- a/packages/preset-dumi/src/api-parser/fixtures/expect/forwardRef.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/forwardRef.json
@@ -1,29 +1,37 @@
-{
-  "forwardRef": [
-    {
-      "identifier": "className",
-      "description": "extra CSS className for this component",
-      "type": "string"
-    },
-    {
-      "identifier": "style",
-      "description": "inline styles",
-      "type": "CSSProperties"
-    },
-    {
-      "identifier": "size",
-      "description": "component size",
-      "type": "\"small\" | \"large\"",
-      "default": "small",
-      "required": true
-    },
-    {
-      "identifier": "ref",
-      "type": "Ref<HTMLDivElement>"
-    },
-    {
-      "identifier": "key",
-      "type": "Key"
-    }
-  ]
-}
+[
+  {
+    "forwardRef": [
+      {
+        "identifier": "id",
+        "description": "this is id",
+        "type": "string"
+      },
+      {
+        "identifier": "className",
+        "description": "extra CSS className for this component",
+        "type": "string"
+      },
+      {
+        "identifier": "style",
+        "description": "inline styles",
+        "type": "CSSProperties"
+      },
+      {
+        "identifier": "size",
+        "description": "component size",
+        "type": "\"small\" | \"large\"",
+        "default": "small",
+        "required": true
+      },
+      {
+        "identifier": "ref",
+        "type": "Ref<HTMLDivElement>"
+      },
+      {
+        "identifier": "key",
+        "type": "Key"
+      }
+    ]
+  },
+  {}
+]

--- a/packages/preset-dumi/src/api-parser/fixtures/expect/localeDescription.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/localeDescription.json
@@ -1,11 +1,14 @@
-{
-  "localeDescription": [
-    {
-      "identifier": "className",
-      "description": "default version",
-      "description.zh-CN": "中文说明",
-      "type": "string",
-      "default": "{ type: 'A', value: [{ name: 'B' }] }"
-    }
-  ]
-}
+[
+  {
+    "localeDescription": [
+      {
+        "identifier": "className",
+        "description": "default version",
+        "description.zh-CN": "中文说明",
+        "type": "string",
+        "default": "{ type: 'A', value: [{ name: 'B' }] }"
+      }
+    ]
+  },
+  {}
+]

--- a/packages/preset-dumi/src/api-parser/fixtures/expect/multiple.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/multiple.json
@@ -1,28 +1,31 @@
-{
-  "A": [
-    {
-      "identifier": "className",
-      "description": "extra CSS className for this component",
-      "type": "string"
-    },
-    {
-      "identifier": "style",
-      "description": "inline styles",
-      "type": "CSSProperties"
-    },
-    {
-      "identifier": "size",
-      "description": "component size",
-      "type": "\"small\" | \"large\"",
-      "default": "small",
-      "required": true
-    }
-  ],
-  "multiple": [
-    {
-      "identifier": "isHello",
-      "type": "boolean",
-      "required": true
-    }
-  ]
-}
+[
+  {
+    "A": [
+      {
+        "identifier": "className",
+        "description": "extra CSS className for this component",
+        "type": "string"
+      },
+      {
+        "identifier": "style",
+        "description": "inline styles",
+        "type": "CSSProperties"
+      },
+      {
+        "identifier": "size",
+        "description": "component size",
+        "type": "\"small\" | \"large\"",
+        "default": "small",
+        "required": true
+      }
+    ],
+    "multiple": [
+      {
+        "identifier": "isHello",
+        "type": "boolean",
+        "required": true
+      }
+    ]
+  },
+  {}
+]

--- a/packages/preset-dumi/src/api-parser/fixtures/expect/union.json
+++ b/packages/preset-dumi/src/api-parser/fixtures/expect/union.json
@@ -1,18 +1,21 @@
-{
-  "union": [
-    {
-      "identifier": "type",
-      "type": "\"primary\" | \"link\"",
-      "required": true
-    },
-    {
-      "identifier": "className",
-      "type": "string"
-    },
-    {
-      "identifier": "href",
-      "type": "string",
-      "required": true
-    }
-  ]
-}
+[
+  {
+    "union": [
+      {
+        "identifier": "type",
+        "type": "\"primary\" | \"link\"",
+        "required": true
+      },
+      {
+        "identifier": "className",
+        "type": "string"
+      },
+      {
+        "identifier": "href",
+        "type": "string",
+        "required": true
+      }
+    ]
+  },
+  {}
+]

--- a/packages/preset-dumi/src/api-parser/fixtures/raw/forwardRef.tsx
+++ b/packages/preset-dumi/src/api-parser/fixtures/raw/forwardRef.tsx
@@ -4,6 +4,10 @@ import A from './class';
 
 export interface IBProps extends IAProps {
   ref?: React.LegacyRef<HTMLDivElement>,
+  /**
+   * this is id
+   */
+  id?: string;
 }
 
 class B extends React.Component<IBProps> {

--- a/packages/preset-dumi/src/api-parser/index.test.ts
+++ b/packages/preset-dumi/src/api-parser/index.test.ts
@@ -46,9 +46,13 @@ describe('api parser', () => {
   });
 
   it('should guess component name correctly', () => {
-    expect(parser(path.join(rawPath, 'guess', 'FileName.tsx'))).toHaveProperty('FileName');
-    expect(
-      parser(path.join(rawPath, 'guess', 'NestSrc', 'src', 'index.tsx'), 'NestSrc'),
-    ).toHaveProperty('default');
+    const FileNameRes = parser(path.join(rawPath, 'guess', 'FileName.tsx'));
+    const NestSrcRes = parser(path.join(rawPath, 'guess', 'NestSrc', 'src', 'index.tsx'), 'NestSrc');
+    // to be sure result is a tuple
+    expect(FileNameRes).toHaveLength(2);
+    expect(NestSrcRes).toHaveLength(2);
+
+    expect(FileNameRes[0]).toHaveProperty('FileName');
+    expect(NestSrcRes[0]).toHaveProperty('default');
   });
 });

--- a/packages/preset-dumi/src/api-parser/parser.ts
+++ b/packages/preset-dumi/src/api-parser/parser.ts
@@ -45,7 +45,7 @@ function getAllPropsParent(docs: ModuleDoc[]) {
                 propsSet.add(parentName);
             }
         })
-    })
+    });
     return Array.from(propsSet);
 }
 

--- a/packages/preset-dumi/src/api-parser/parser.ts
+++ b/packages/preset-dumi/src/api-parser/parser.ts
@@ -1,0 +1,135 @@
+import { ComponentDoc, Parser, ParserOptions, withCompilerOptions } from "react-docgen-typescript";
+import { Props } from "react-docgen-typescript/lib/parser";
+import ts from 'typescript';
+
+const defaultParserOpts = {
+    savePropValueAsString: true,
+    shouldExtractLiteralValuesFromEnum: true,
+    shouldRemoveUndefinedFromOptional: true,
+}
+
+interface ModuleDoc extends ComponentDoc {
+    // distinguish component and interface from modules
+    type: 'component' | 'interface';
+    interfaceName?: string;
+}
+
+// reference by https://github.com/styleguidist/react-docgen-typescript/blob/master/src/parser.ts#L196
+const isOptional = (prop: ts.Symbol) => (prop.getFlags() & ts.SymbolFlags.Optional) !== 0;
+
+function getModuleDocFromProps(props: Props, interfaceName: string): ModuleDoc[] {
+    const docs: ModuleDoc[] = [];
+
+    docs.push({
+        type: 'interface',
+        tags: {},
+        description: '',
+        displayName: '',
+        interfaceName,
+        methods: [],
+        props
+    });
+
+    return docs;
+}
+
+/**
+ * get all type names of component props
+ */
+function getAllPropsParent(docs: ModuleDoc[]) {
+    const propsSet = new Set();
+    docs.forEach(doc => {
+        Object.keys(doc.props).forEach(key => {
+            const parentName = doc.props[key].parent?.name;
+            if (parentName) {
+                propsSet.add(parentName);
+            }
+        })
+    })
+    return Array.from(propsSet);
+}
+
+
+export default (filePath: string, options: ts.CompilerOptions, parserOpts?: ParserOptions) => {
+
+    const opts = Object.assign(defaultParserOpts, parserOpts);
+
+    const program = ts.createProgram([filePath], options);
+    const parser = new Parser(program, opts);
+    const checker = program.getTypeChecker();
+
+    const sourceFile = program.getSourceFile(filePath);
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+
+    if (moduleSymbol) {
+        // get all export modules
+        const modules = checker.getExportsOfModule(moduleSymbol);
+
+        const duplicatedInfos: ModuleDoc[] = [];
+
+        // get all type modules
+        modules.forEach(module => {
+            const declaration = module.valueDeclaration || module.declarations![0];
+
+            // getTypeOfSymbolAtLocation can only get types of values
+            let type = checker.getTypeOfSymbolAtLocation(module, declaration);
+            const typeSymbol = type.symbol || type.aliasSymbol;
+            if (!typeSymbol) {
+                // getDeclaredTypeOfSymbol can get types of types
+                type = checker.getDeclaredTypeOfSymbol(module);
+
+                const props = type.getApparentProperties();
+
+                const result: Props = {};
+                props.forEach(prop => {
+                    const propName = prop.getName();
+                    const jsDocComment = parser.findDocComment(prop);
+                    const defaultValue = { value: jsDocComment.tags.default };
+                    const description = jsDocComment.fullComment.replace(/\r\n/g, '\n');
+
+                    const declarations = prop.declarations || [];
+                    const baseProp = props.find(p => p.getName() === propName);
+
+
+                    const required =
+                        !isOptional(prop) &&
+                        // If in a intersection or union check original declaration for "?"
+                        declarations.every(d => !(d as any).questionToken) &&
+                        (!baseProp || !isOptional(baseProp));
+
+                    const propType = jsDocComment.tags.type
+                        ? {
+                            name: jsDocComment.tags.type
+                        }
+                        : parser.getDocgenType(checker.getTypeOfSymbolAtLocation(prop, declaration), required);
+
+                    result[propName] = {
+                        defaultValue,
+                        description,
+                        name: propName,
+                        parent: null,
+                        required,
+                        type: propType,
+                    };
+                });
+                const docs = getModuleDocFromProps(result, module.getName());
+                duplicatedInfos.push(...docs);
+            }
+        });
+
+        // get all component modules
+        const docs: ModuleDoc[] = withCompilerOptions(options, opts).parse(filePath).map(i => ({ type: 'component', ...i }));
+
+        // to get component props name for eliminating of duplication
+        const componentPropsName = getAllPropsParent(docs);
+
+        duplicatedInfos.push(...docs);
+
+        const exportsInfo = duplicatedInfos.filter(info => {
+            return !componentPropsName.includes(info.interfaceName)
+        })
+
+        return exportsInfo;
+    }
+    return [];
+}

--- a/packages/preset-dumi/src/theme/hooks/useApiData.ts
+++ b/packages/preset-dumi/src/theme/hooks/useApiData.ts
@@ -11,7 +11,7 @@ import type { IApiDefinition } from '../../api-parser';
  * @param isDefaultLocale default locale flag
  */
 function getApiData(identifier: string, locale: string, isDefaultLocale: boolean) {
-  return Object.entries(apis[identifier] as IApiDefinition).reduce<IApiDefinition>(
+  return Object.entries(apis[identifier] as IApiDefinition[number]).reduce<IApiDefinition[number]>(
     (expts, [expt, rows]) => {
       expts[expt] = rows.map(props => {
         // copy original data
@@ -49,7 +49,7 @@ export default (identifier: string) => {
     config: { locales },
   } = useContext(context);
   const isDefaultLocale = !locales.length || locales[0].name === locale;
-  const [data, setData] = useState<IApiDefinition>(getApiData(identifier, locale, isDefaultLocale));
+  const [data, setData] = useState<IApiDefinition[number]>(getApiData(identifier, locale, isDefaultLocale));
 
   useEffect(() => {
     setData(getApiData(identifier, locale, isDefaultLocale));

--- a/packages/preset-dumi/src/transformer/remark/index.ts
+++ b/packages/preset-dumi/src/transformer/remark/index.ts
@@ -73,6 +73,7 @@ export interface IDumiElmNode extends Node {
   properties: {
     id?: string;
     href?: string;
+    types?: string;
     [key: string]: any;
   };
   tagName: string;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
- API 组件解析组件库的接口参数原先考虑逻辑为通过解析 `.tsx` 文件导出的 component 的 props 解析出该组件的 types，但是目前来看，有需要去解析非 component 的 types，故考虑 API 新增 `types` 属性

### 主要变更
- `preset-dumi` 需要新增 typescript 的依赖以及指定 peerDep
- api-parser 导出的类型改变，原先为 `AtomPropsDefinition` ，现改为元组类型，具体见代码
- paser 的逻辑大幅改动，主要逻辑大致为  
1. 获取文件 export 的全部模块
2.  判断模块的类型，如果是 component 则走老方法处理，如果是 types 则走新方法处理
3. 把 component 和 types 处理后的结果去重放入元组中给 transformer 消费
- transformer 中对 api 处理逻辑小幅改动，主要在于对 parser 返回的类型修改，以及对新增 types 属性的支持

### 遗留问题

- [ ] 测试用例
- [ ] 该属性是否叫 `types`
- [ ] 是否支持除了 `.tsx` 文件外的其他文件，如 `.d.ts`
- [ ] 还是没有把 `react-docgen` 的配置暴露出去

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  API component support to specify the types |
| 🇨🇳 Chinese |   API 组件支持 types 属性        |
