### PR TITLE
feat(preset): suppport passive preview

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -188,6 +188,14 @@ Configure the document directory for dumi sniffing. Dumi will try to recursively
 
 The configuration dumi will be converted to the code block rendered by the ReactComponent component by default. If you don't want to do any conversion, such as a pure site like Umi's official website, then set this item to an empty array.
 
+#### passivePreview
+
+- Type：`Boolean`
+- Default：`false`
+- Details：
+
+Passive preview mode. Only codeblocks belonging to `resolve.previewLangs` and having the `preview` modifier are rendered as ReactComponent. Generally used to render only a few code blocks in `resolve.previewLangs`, but not all of them.
+
 ### sitemap
 
 - Type: `{ hostname: string, excludes?: string[] }`

--- a/docs/config/index.zh-CN.md
+++ b/docs/config/index.zh-CN.md
@@ -188,6 +188,14 @@ export default {
 
 配置 dumi 默认会转换为 ReactComponent 组件渲染的代码块，如果不希望做任何转换，例如类似 Umi 官网的纯站点，那么将该项设置为空数组即可。
 
+#### passivePreview
+
+- 类型：`Boolean`
+- 默认值：`false`
+- 详细：
+
+代码块被动渲染模式，当为 true 时，仅将属于 `resolve.previewLangs` 且具有 `preview` 修饰符的代码块渲染为 ReactComponent 代码块。一般用于仅希望渲染 `resolve.previewLangs` 中的少部分代码块，而不是全部。
+
 ### sitemap
 
 - Type: `{ hostname: string, excludes?: string[] }`

--- a/docs/guide/basic.md
+++ b/docs/guide/basic.md
@@ -265,7 +265,7 @@ dumi has a very important principle: **developers should use components like use
 
 How to explain? If we are developing a library called `hello-dumi`, and we are wrting a demo for `Button` component in it, the following are examples of the correct way and errors:
 
-``` jsx | pure
+```jsx | pure
 // Correct
 import { Button } from 'hello-dumi';
 
@@ -285,6 +285,19 @@ If we want a block of `jsx`/`tsx` code to be rendered as source code, we can use
 <pre lang="markdown">
 ```jsx | pure
 // I will not be rendered as a React component
+```
+</pre>
+
+Also, we can use the `preview` modifier with [Configuration Item-resolve.passivePreview](/config#passivepreview) to render a part of `jsx`/`tsx` codeblocks as React components, not all of them. This approach is used to avoid to add many `pure` modifiers to most of `jsx`/`tsx` codeblocks.
+
+<pre lang="markdown">
+```jsx | preview
+// I will be rendered as a React component
+```
+
+```jsx
+// I will be rendered as a React component by default
+// I will not be rendered as React component in the passive preview mode
 ```
 </pre>
 

--- a/docs/guide/basic.zh-CN.md
+++ b/docs/guide/basic.zh-CN.md
@@ -255,7 +255,7 @@ dumi 有一个非常重要的原则——**开发者应该像用户一样使用�
 
 如何理解？假设我们正在研发的组件库 NPM 包名叫做 `hello-dumi`，我们正在为其中的 `Button` 组件编写 demo，下面列举出引入组件的正确方式及错误示例：
 
-``` jsx | pure
+```jsx | pure
 // 正确示例
 import { Button } from 'hello-dumi';
 
@@ -275,6 +275,14 @@ import Button from '@/Button/index.tsx';
 <pre lang="markdown">
 ```jsx | pure
 // 我不会被渲染为 React 组件
+```
+</pre>
+
+相似地，如果我们在众多符合 `resolve.previewLangs` 的代码块中，仅仅希望渲染 `previewLangs` 中的一小部分，并且想避免给大部分 `resolve.previewLangs` 代码块手动添加 `pure` 时，我们可以通过配置 `resolve.passivePreview` 为 true 来开启被动渲染 `previewLangs` 代码块。此时对我们想要渲染的 `previewLangs` 代码块使用 `preview` 修饰符即可：
+
+<pre lang="markdown">
+```jsx | preview
+// 当开启 resolve.passivePreview 时，仅有添加了 preview 修饰符的 previewLangs 代码块才会被渲染为 React 组件，反之，仅为常规代码块。
 ```
 </pre>
 

--- a/docs/guide/basic.zh-CN.md
+++ b/docs/guide/basic.zh-CN.md
@@ -223,7 +223,7 @@ group:
 <!-- 其他 Markdown 内容 -->
 ```
 
-在 site 模式下，我们也可以通过配置项对导航和左侧菜单进行增量自定义，请参考 [配置项 - navs]() 以及 [配置项 - menus]()。
+在 site 模式下，我们也可以通过配置项对导航和左侧菜单进行增量自定义，请参考 [配置项 - navs](/zh-CN/config#navs) 以及 [配置项 - menus](/zh-CN/config#menus)。
 
 ## 写组件 demo
 
@@ -278,11 +278,15 @@ import Button from '@/Button/index.tsx';
 ```
 </pre>
 
-相似地，如果我们在众多符合 `resolve.previewLangs` 的代码块中，仅仅希望渲染 `previewLangs` 中的一小部分，并且想避免给大部分 `resolve.previewLangs` 代码块手动添加 `pure` 时，我们可以通过配置 `resolve.passivePreview` 为 true 来开启被动渲染 `previewLangs` 代码块。此时对我们想要渲染的 `previewLangs` 代码块使用 `preview` 修饰符即可：
+相似地，我们可以搭配 [配置项 - resolve.passivePreview](/zh-CN/config#passivepreview) 和 `preview` 修饰符来开启代码块的被动渲染模式，该模式用于仅将具有 `preview` 修饰符的 `jsx`/`tsx` 代码块渲染为 React 组件，而不再是全部 `jsx`/`tsx` 代码块。该方案一般用于避免给过多的 `jsx`/`tsx` 代码块手动添加 `pure` 修饰符。
 
 <pre lang="markdown">
 ```jsx | preview
-// 当开启 resolve.passivePreview 时，仅有添加了 preview 修饰符的 previewLangs 代码块才会被渲染为 React 组件，反之，仅为常规代码块。
+// 我会被渲染为 React 组件
+```
+```jsx
+// 在默认情况下，我会被渲染为 React 组件
+// 在开启代码块被动渲染的情况下，我不会被主动渲染为 React 组件，除非添加 preview 修饰符
 ```
 </pre>
 

--- a/packages/preset-dumi/src/context.ts
+++ b/packages/preset-dumi/src/context.ts
@@ -47,6 +47,10 @@ export interface IDumiOpts {
      * TBD
      */
     examples: string[];
+    /**
+     * Should we treat previewLangs codeblock as demo component
+     */
+    passivePreview: boolean
   };
   /**
    * customize the side menu

--- a/packages/preset-dumi/src/loader/fixtures/passive.md
+++ b/packages/preset-dumi/src/loader/fixtures/passive.md
@@ -1,0 +1,21 @@
+---
+translateHelp: true
+---
+
+## Hello World!
+
+```jsx
+export default () => null;
+```
+
+```tsx
+export default () => null;
+```
+
+```jsx | preview
+export default () => null;
+```
+
+```tsx | preview
+export default () => null;
+```

--- a/packages/preset-dumi/src/loader/fixtures/passive.md
+++ b/packages/preset-dumi/src/loader/fixtures/passive.md
@@ -12,6 +12,10 @@ export default () => null;
 export default () => null;
 ```
 
+```js
+export default () => null;
+```
+
 ```jsx | preview
 export default () => null;
 ```

--- a/packages/preset-dumi/src/loader/index.test.ts
+++ b/packages/preset-dumi/src/loader/index.test.ts
@@ -62,7 +62,7 @@ describe('loader', () => {
     expect(result).toContain('const DumiDemo2 = React.memo(DUMI_ALL_DEMOS');
     expect(result).not.toContain('const DumiDemo3 = React.memo(DUMI_ALL_DEMOS');
     expect(result).not.toContain('const DumiDemo4 = React.memo(DUMI_ALL_DEMOS');
-    expect(result).toMatchSnapshot();
+    expect(result).not.toContain('const DumiDemo5 = React.memo(DUMI_ALL_DEMOS');
 
     // expect import components from theme package
     expect(result).toContain("from 'dumi-theme-default");

--- a/packages/preset-dumi/src/loader/index.test.ts
+++ b/packages/preset-dumi/src/loader/index.test.ts
@@ -27,7 +27,7 @@ describe('loader', () => {
     );
 
     // expect prepend demos
-    expect(result).toContain("const DumiDemo1 = React.memo(DUMI_ALL_DEMOS");
+    expect(result).toContain('const DumiDemo1 = React.memo(DUMI_ALL_DEMOS');
 
     // expect import components from theme package
     expect(result).toContain("from 'dumi-theme-default");
@@ -47,6 +47,32 @@ describe('loader', () => {
 
     // show customize translateHelp
     expect(result).toContain('Customize Help!');
+  });
+
+  it('should load passive md', async () => {
+    ctx.opts.resolve.passivePreview = true;
+
+    const filePath = path.join(fixture, 'passive.md');
+    const result = await loader.call(
+      { resource: filePath, resourcePath: filePath },
+      fs.readFileSync(filePath, 'utf8').toString(),
+    );
+
+    expect(result).toContain('const DumiDemo1 = React.memo(DUMI_ALL_DEMOS');
+    expect(result).toContain('const DumiDemo2 = React.memo(DUMI_ALL_DEMOS');
+    expect(result).not.toContain('const DumiDemo3 = React.memo(DUMI_ALL_DEMOS');
+    expect(result).not.toContain('const DumiDemo4 = React.memo(DUMI_ALL_DEMOS');
+    expect(result).toMatchSnapshot();
+
+    // expect import components from theme package
+    expect(result).toContain("from 'dumi-theme-default");
+
+    // show default translateHelp
+    expect(result).toContain(
+      'This article has not been translated yet. Want to help us out? Click the Edit this doc on GitHub at the end of the page.',
+    );
+
+    ctx.opts.resolve.passivePreview = false;
   });
 
   it('should load part of md by range', async () => {

--- a/packages/preset-dumi/src/plugins/features/compile.ts
+++ b/packages/preset-dumi/src/plugins/features/compile.ts
@@ -40,7 +40,10 @@ export default (api: IApi) => {
       .end()
       .use('dumi-loader')
       .loader(require.resolve('../../loader'))
-      .options({ previewLangs: ctx.opts.resolve.previewLangs });
+      .options({
+        previewLangs: ctx.opts.resolve.previewLangs,
+        passivePreview: ctx.opts.resolve.passivePreview
+      });
 
     // set asset type to javascript/auto to skip webpack internal json loader
     // refer: https://webpack.js.org/guides/asset-modules/

--- a/packages/preset-dumi/src/plugins/features/resolve.ts
+++ b/packages/preset-dumi/src/plugins/features/resolve.ts
@@ -28,6 +28,7 @@ export default (api: IApi) => {
           .map(([_, pkgPath]) => path.relative(api.paths.cwd, path.join(pkgPath, 'src')))
           .concat(['docs']),
       examples: memo.resolve.examples || ['examples'],
+      passivePreview: memo.resolve.passivePreview || false
     });
 
     return memo;

--- a/packages/preset-dumi/src/transformer/remark/codeBlock.ts
+++ b/packages/preset-dumi/src/transformer/remark/codeBlock.ts
@@ -28,8 +28,12 @@ export default function codeBlock(): IDumiUnifiedTransformer {
   return ast => {
     // handle md code block syntax
     visit<Code>(ast, 'code', node => {
-      if (ctx.opts?.resolve.previewLangs.includes(node.lang)) {
-        const modifier = codeBlockModifierParser(node.meta);
+      const { passivePreview, previewLangs } = ctx.opts?.resolve
+      const modifier = codeBlockModifierParser(node.meta);
+      if (
+        (!passivePreview && previewLangs.includes(node.lang)) ||
+        (passivePreview && modifier.preview)
+      ) {
         // extract frontmatters for embedded demo
         const { content, meta } = transformer.code(winEOL(node.value));
 

--- a/packages/preset-dumi/src/transformer/remark/codeBlock.ts
+++ b/packages/preset-dumi/src/transformer/remark/codeBlock.ts
@@ -28,11 +28,14 @@ export default function codeBlock(): IDumiUnifiedTransformer {
   return ast => {
     // handle md code block syntax
     visit<Code>(ast, 'code', node => {
-      const { passivePreview, previewLangs } = ctx.opts?.resolve
+      const resolve = ctx.opts?.resolve
       const modifier = codeBlockModifierParser(node.meta);
       if (
-        (!passivePreview && previewLangs.includes(node.lang)) ||
-        (passivePreview && modifier.preview)
+        resolve?.previewLangs.includes(node.lang) &&
+        (
+          !resolve?.passivePreview ||
+          (resolve.passivePreview && modifier.preview)
+        )
       ) {
         // extract frontmatters for embedded demo
         const { content, meta } = transformer.code(winEOL(node.value));


### PR DESCRIPTION
resolve #637

<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

#637 

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

解决的核心需求：不希望渲染所有的 previewLangs，但 pure 不足以满足需求，例如在众多的 tsx 中，我们仅想渲染特定的几个 tsx 为组件，而不是全部，而给每个不想渲染的 tsx 都添加 pure 势必极大增加文档初期工作量

方案：
- 新增 resolve.passivePreview 选项，来支持开启被动渲染，默认为 false，故不存在非兼容性更新
- 在 true 条件下，仅当代码块具有 preview modifier 且属于 previewLangs 时才会被渲染为 demo 组件，否则为常规代码块

效果：
假定有 ```jsx 代码块 A，且 previewLangs 中包含 jsx，那么当
1. resolve.passivePreivew 为 true 时，且A 需要手动添加 preview modifier（即 ```jsx | preview ）时，且 previewLangs 中包含 jsx 时，才会被渲染为组件，而不是常规代码块；
2. resolve.passivePreivew 为 false（默认）时，因 jsx 包含在 previewLangs 中，故走以前的组件代码逻辑，故渲染为代码组件。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      add resolve.passivePreview option and preview codeblock modifier     |
| 🇨🇳 Chinese |      新增 resolve.passivePreview 选项，和代码块 preview     |
