### PR TITLE
fix: mobile theme page mode switch

### DIFF
--- a/packages/theme-mobile/src/components/Device.less
+++ b/packages/theme-mobile/src/components/Device.less
@@ -38,6 +38,10 @@
     top: @s-nav-height + @s-device-shell-width + @s-device-gap-top;
   }
 
+  &.hidden {
+    display: none;
+  }
+
   &-status,
   &-action {
     display: flex;

--- a/packages/theme-mobile/src/layouts/index.tsx
+++ b/packages/theme-mobile/src/layouts/index.tsx
@@ -11,9 +11,7 @@ import '../style/layout.less';
 const MobileLayout: React.FC<IRouteComponentProps> = ({ children, ...props }) => {
   const [demo, setDemo] = useState<IPreviewerComponentProps>(null);
   const builtinDemoUrl = useDemoUrl(demo?.identifier);
-    const {
-    meta: { mobile },
-  } = useContext(context);
+  const { meta: { mobile } } = useContext(context);
 
   useEffect(() => {
     const handler = (ev: any) => {

--- a/packages/theme-mobile/src/layouts/index.tsx
+++ b/packages/theme-mobile/src/layouts/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import type { IPreviewerComponentProps } from 'dumi/theme';
 import { useDemoUrl } from 'dumi/theme';
 import Layout from 'dumi-theme-default/src/layout';
+import { context } from 'dumi/theme';
 import type { IRouteComponentProps } from '@umijs/types';
 import Device from '../components/Device';
 import { ACTIVE_MSG_TYPE } from '../builtins/Previewer';
@@ -10,6 +11,9 @@ import '../style/layout.less';
 const MobileLayout: React.FC<IRouteComponentProps> = ({ children, ...props }) => {
   const [demo, setDemo] = useState<IPreviewerComponentProps>(null);
   const builtinDemoUrl = useDemoUrl(demo?.identifier);
+    const {
+    meta: { mobile },
+  } = useContext(context);
 
   useEffect(() => {
     const handler = (ev: any) => {
@@ -28,11 +32,18 @@ const MobileLayout: React.FC<IRouteComponentProps> = ({ children, ...props }) =>
     setDemo(null);
   }, [props.location.pathname]);
 
+  const showMobileDevice = typeof mobile === 'boolean' ? mobile : true;
+
   return (
     <Layout {...props}>
       <div className="__dumi-default-mobile-content">
         <article>{children}</article>
-        {demo && <Device className="__dumi-default-mobile-content-device" url={demo.demoUrl || builtinDemoUrl} />}
+        {demo && (
+          <Device
+            className={`__dumi-default-mobile-content-device ${!showMobileDevice ? 'hidden' : ''}`}
+            url={demo.demoUrl || builtinDemoUrl}
+          />
+        )}
       </div>
     </Layout>
   );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue


### 💡 需求背景和解决方案 / Background or solution

解决的问题是，mobile theme 下，从 mobile theme page 切换到 mobile false page， mobile device component 未消失的情况.

![image](https://user-images.githubusercontent.com/20502762/115980471-93af2e00-a5bf-11eb-91a1-91007b74dca2.png)


### 📝 更新日志 / Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix the mobile theme of in switch problem |
| 🇨🇳 Chinese |     修复移动端皮肤样式问题      |
