### PR TITLE
fix: when navItems is void, locale util repeat render

### DIFF
--- a/packages/theme-default/src/components/LocaleSelect.less
+++ b/packages/theme-default/src/components/LocaleSelect.less
@@ -11,6 +11,10 @@
     border: 1px solid @c-btn-border-dark;
   }
 
+  @media @mobile {
+    margin-top: 6px;
+  }
+
   &:hover {
     background-color: #fafafa;
     [data-prefers-color=dark] & {

--- a/packages/theme-default/src/components/SideMenu.less
+++ b/packages/theme-default/src/components/SideMenu.less
@@ -250,7 +250,7 @@
 
     // mobile nav list
     .@{prefix}-menu-nav-list {
-      padding: 16px 0;
+      padding: 16px 0 0 0;
 
       > li,
       > li > a {

--- a/packages/theme-default/src/components/SideMenu.tsx
+++ b/packages/theme-default/src/components/SideMenu.tsx
@@ -53,16 +53,16 @@ const SideMenu: FC<INavbarProps> = ({ mobileMenuCollapsed, location, darkPrefix 
             <p>
               <object
                 type="image/svg+xml"
-                data={`https://img.shields.io/github/stars${
-                  repoUrl.match(/((\/[^\/]+){2})$/)[1]
-                }?style=social`}
+                data={`https://img.shields.io/github/stars${repoUrl.match(/((\/[^\/]+){2})$/)[1]
+                  }?style=social`}
               />
             </p>
           )}
         </div>
         {/* mobile nav list */}
-        {navItems.length ? (
-          <div className="__dumi-default-menu-mobile-area">
+
+        <div className="__dumi-default-menu-mobile-area">
+          {!!navItems.length && (
             <ul className="__dumi-default-menu-nav-list">
               {navItems.map(nav => {
                 const child = Boolean(nav.children?.length) && (
@@ -83,17 +83,11 @@ const SideMenu: FC<INavbarProps> = ({ mobileMenuCollapsed, location, darkPrefix 
                 );
               })}
             </ul>
-            {/* site mode locale select */}
-            <LocaleSelect location={location} />
-            {darkPrefix}
-          </div>
-        ) : (
-          <div className="__dumi-default-menu-doc-locale">
-            {darkPrefix}
-            {/* doc mode locale select */}
-            <LocaleSelect location={location} />
-          </div>
-        )}
+          )}
+          {/* site mode locale select */}
+          <LocaleSelect location={location} />
+          {darkPrefix}
+        </div>
         {/* menu list */}
         <ul className="__dumi-default-menu-list">
           {!isHiddenMenus &&
@@ -120,9 +114,9 @@ const SideMenu: FC<INavbarProps> = ({ mobileMenuCollapsed, location, darkPrefix 
                           {/* group children slugs */}
                           {Boolean(
                             meta.toc === 'menu' &&
-                              typeof window !== 'undefined' &&
-                              child.path === location.pathname &&
-                              hasSlugs,
+                            typeof window !== 'undefined' &&
+                            child.path === location.pathname &&
+                            hasSlugs,
                           ) && <SlugList slugs={meta.slugs} />}
                         </li>
                       ))}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->
当 navItems 为空的时候，有一些样式错误。
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [x] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->
![image](https://user-images.githubusercontent.com/11746742/118428188-7a525b00-b701-11eb-96f1-d28949b3205a.png)

![image](https://user-images.githubusercontent.com/11746742/118428194-7de5e200-b701-11eb-81e7-fd11f2f0c03f.png)

修改后，上面的重复渲染去掉了，下面的修改后如下图
![image](https://user-images.githubusercontent.com/11746742/118428274-ad94ea00-b701-11eb-8416-947c4afc7aab.png)

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
