### PR TITLE
feat: make dynamic route static when dumi build

### DIFF
--- a/packages/preset-dumi/src/plugins/features/demo/index.ts
+++ b/packages/preset-dumi/src/plugins/features/demo/index.ts
@@ -125,6 +125,11 @@ export default (api: IApi) => {
         // use to disable pro-layout in integrated mode
         layout: false,
       },
+      ...Object.keys(demos).map(uuid => ({
+        path: `/${getDemoRouteName()}/${uuid}`,
+        // use to disable pro-layout in integrated mode
+        layout: false,
+      })),
     ];
     const Previewer = theme.builtins
       .concat(theme.fallbacks)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [x] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

close #715

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

背景：现阶段 dumi build 后的 demo 静态文件会存放在 ～/demo/:uuid 目录里，静态文件服务器不专门配置的话找不到对应的demo 文件

解决方案：build 的时候，针对每个 demo 单独生成一个目录

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

build 后的静态文件支持正确展示 demo

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
