### PR TITLE
fix(routes): cannot remove includes prefix when using an absolute path

### DIFF
--- a/packages/preset-dumi/src/routes/decorator/nav.ts
+++ b/packages/preset-dumi/src/routes/decorator/nav.ts
@@ -9,7 +9,10 @@ import type { RouteProcessor } from '.';
  */
 export function getRouteComponentDirs(component: string, ctx: ThisParameterType<RouteProcessor>) {
   // remove ./ for include paths & component path
-  const clearIncludes = ctx.options.resolve.includes.map(item => `${winPath(path.join(item))}/`);
+  const clearIncludes = ctx.options.resolve.includes.map(item => {
+    const relativePath = path.isAbsolute(item) ? path.relative(ctx.umi?.cwd || process.cwd(), item) : item;
+    return `${winPath(path.join(relativePath))}/`;
+  });
   const clearComponentPath = winPath(path.join(component));
 
   // find include path for current component path

--- a/packages/preset-dumi/src/routes/test/site.test.js
+++ b/packages/preset-dumi/src/routes/test/site.test.js
@@ -54,6 +54,183 @@ describe('routes & menu: site mode', () => {
     ]);
   });
 
+  const expectedSiteRoutes = [
+    {
+      path: '/api',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/api.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/api.md',
+        updatedTime: 1582794297000,
+        slugs: [
+          { depth: 2, value: 'config.a', heading: 'configa' },
+          { depth: 2, value: 'config.b', heading: 'configb' },
+        ],
+        title: 'config.a',
+        nav: { path: '/api', title: 'Api' },
+      },
+      title: 'config.a',
+    },
+    {
+      path: '/',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/index.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/index.md',
+        updatedTime: 1582794297000,
+        slugs: [],
+        title: 'Index',
+      },
+      title: 'Index',
+    },
+    {
+      path: '/zh-CN',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
+        updatedTime: 1582794297000,
+        slugs: [],
+        locale: 'zh-CN',
+        title: 'Index',
+      },
+      title: 'Index',
+    },
+    {
+      path: '/config',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+        updatedTime: 1582794297000,
+        slugs: [],
+        title: 'Config',
+        nav: { path: '/config', title: 'Config' },
+      },
+      title: 'Config',
+    },
+    {
+      path: '/config/others',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+        updatedTime: 1582794297000,
+        slugs: [],
+        title: 'Others',
+        nav: { path: '/config', title: 'Config' },
+      },
+      title: 'Others',
+    },
+    {
+      path: '/test-rewrite/rewrite',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+        updatedTime: 1582794297000,
+        nav: { path: '/test-rewrite', title: 'Rewrite' },
+        slugs: [],
+        title: 'Rewrite',
+        group: { path: '/test-rewrite/rewrite', title: 'Rewrite' },
+      },
+      title: 'Rewrite',
+    },
+    {
+      path: '/zh-CN/api',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/api.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/api.md',
+        updatedTime: 1582794297000,
+        slugs: [
+          { depth: 2, value: 'config.a', heading: 'configa' },
+          { depth: 2, value: 'config.b', heading: 'configb' },
+        ],
+        title: 'config.a',
+        nav: { path: '/zh-CN/api', title: 'Api' },
+        locale: 'zh-CN',
+      },
+      title: 'config.a',
+    },
+    {
+      path: '/zh-CN/config',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+        updatedTime: 1582794297000,
+        slugs: [],
+        title: 'Config',
+        nav: { path: '/zh-CN/config', title: 'Config' },
+        locale: 'zh-CN',
+      },
+      title: 'Config',
+    },
+    {
+      path: '/zh-CN/config/others',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/others.md',
+        updatedTime: 1582794297000,
+        slugs: [],
+        title: 'Others',
+        nav: { path: '/zh-CN/config', title: 'Config' },
+        locale: 'zh-CN',
+      },
+      title: 'Others',
+    },
+    {
+      path: '/zh-CN/test-rewrite/rewrite',
+      component: '../../../packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+      exact: true,
+      meta: {
+        filePath: 'packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
+        updatedTime: 1582794297000,
+        nav: { path: '/zh-CN/test-rewrite', title: 'Rewrite' },
+        slugs: [],
+        title: 'Rewrite',
+        group: { path: '/zh-CN/test-rewrite/rewrite', title: 'Rewrite' },
+        locale: 'zh-CN',
+      },
+      title: 'Rewrite',
+    },
+    {
+      path: '/test-rewrite',
+      meta: {},
+      exact: true,
+      redirect: '/test-rewrite/rewrite',
+    },
+    {
+      path: '/zh-CN/test-rewrite',
+      meta: {},
+      exact: true,
+      redirect: '/zh-CN/test-rewrite/rewrite',
+    },
+  ];
+
+  it('route decorator with absolute included paths', () => {
+    const decoratedRoutes = decorateRoute(
+      routes,
+      {
+        locales: DEFAULT_LOCALES,
+        mode: 'site',
+        resolve: {
+          includes: [path.resolve(__dirname, '../fixtures/site')],
+        },
+      },
+      {
+        paths: {
+          cwd: process.cwd(),
+          absTmpPath: path.join(process.cwd(), 'src/.umi'),
+        },
+      },
+    );
+
+    expect(decoratedRoutes).toEqual(expectedSiteRoutes);
+  });
+
   it('route decorator', () => {
     routes = decorateRoute(
       routes,
@@ -72,161 +249,7 @@ describe('routes & menu: site mode', () => {
       },
     );
 
-    expect(routes).toEqual([
-      {
-        path: '/api',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/api.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/api.md',
-          updatedTime: 1582794297000,
-          slugs: [
-            { depth: 2, value: 'config.a', heading: 'configa' },
-            { depth: 2, value: 'config.b', heading: 'configb' },
-          ],
-          title: 'config.a',
-          nav: { path: '/api', title: 'Api' },
-        },
-        title: 'config.a',
-      },
-      {
-        path: '/',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/index.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/index.md',
-          updatedTime: 1582794297000,
-          slugs: [],
-          title: 'Index',
-        },
-        title: 'Index',
-      },
-      {
-        path: '/zh-CN',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
-          updatedTime: 1582794297000,
-          slugs: [],
-          locale: 'zh-CN',
-          title: 'Index',
-        },
-        title: 'Index',
-      },
-      {
-        path: '/config',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/index.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/index.md',
-          updatedTime: 1582794297000,
-          slugs: [],
-          title: 'Config',
-          nav: { path: '/config', title: 'Config' },
-        },
-        title: 'Config',
-      },
-      {
-        path: '/config/others',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/others.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/others.md',
-          updatedTime: 1582794297000,
-          slugs: [],
-          title: 'Others',
-          nav: { path: '/config', title: 'Config' },
-        },
-        title: 'Others',
-      },
-      {
-        path: '/test-rewrite/rewrite',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
-          updatedTime: 1582794297000,
-          nav: { path: '/test-rewrite', title: 'Rewrite' },
-          slugs: [],
-          title: 'Rewrite',
-          group: { path: '/test-rewrite/rewrite', title: 'Rewrite' },
-        },
-        title: 'Rewrite',
-      },
-      {
-        path: '/zh-CN/api',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/api.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/api.md',
-          updatedTime: 1582794297000,
-          slugs: [
-            { depth: 2, value: 'config.a', heading: 'configa' },
-            { depth: 2, value: 'config.b', heading: 'configb' },
-          ],
-          title: 'config.a',
-          nav: { path: '/zh-CN/api', title: 'Api' },
-          locale: 'zh-CN',
-        },
-        title: 'config.a',
-      },
-      {
-        path: '/zh-CN/config',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/index.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/index.md',
-          updatedTime: 1582794297000,
-          slugs: [],
-          title: 'Config',
-          nav: { path: '/zh-CN/config', title: 'Config' },
-          locale: 'zh-CN',
-        },
-        title: 'Config',
-      },
-      {
-        path: '/zh-CN/config/others',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/config/others.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/config/others.md',
-          updatedTime: 1582794297000,
-          slugs: [],
-          title: 'Others',
-          nav: { path: '/zh-CN/config', title: 'Config' },
-          locale: 'zh-CN',
-        },
-        title: 'Others',
-      },
-      {
-        path: '/zh-CN/test-rewrite/rewrite',
-        component: '../../../packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
-        exact: true,
-        meta: {
-          filePath: 'packages/preset-dumi/src/routes/fixtures/site/rewrite/index.md',
-          updatedTime: 1582794297000,
-          nav: { path: '/zh-CN/test-rewrite', title: 'Rewrite' },
-          slugs: [],
-          title: 'Rewrite',
-          group: { path: '/zh-CN/test-rewrite/rewrite', title: 'Rewrite' },
-          locale: 'zh-CN',
-        },
-        title: 'Rewrite',
-      },
-      {
-        path: '/test-rewrite',
-        meta: {},
-        exact: true,
-        redirect: '/test-rewrite/rewrite',
-      },
-      {
-        path: '/zh-CN/test-rewrite',
-        meta: {},
-        exact: true,
-        redirect: '/zh-CN/test-rewrite/rewrite',
-      },
-    ]);
+    expect(routes).toEqual(expectedSiteRoutes);
   });
 
   it('getNavFromRoutes', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix that navigation and menu cannot be generated correctly when using absolute path  |
| 🇨🇳 Chinese |  修复 resolve.includes 使用绝对路径时无法正确生成导航与菜单  |
