### PR TITLE
feat(routes): resolve supports excludes

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -180,6 +180,14 @@ export default {
 
 Configure the document directory for dumi sniffing. Dumi will try to recursively find markdown files in the configured directory. The default values are the `docs` directory and the `src` directory (common projects). If the environment is the lerna project, the `src` directory will change It is the `packages/pkg/src` directory, and usually does not need to be configured, unless the automatic sniffing appears 『injuryed』.
 
+#### excludes
+
+- Type：`Array<String>`
+- Default：`[]`
+- Details：
+
+The directories or files that need to be excluded. The rules are the same as the configuration of `gitignore`.
+
 #### previewLangs
 
 - Type: `Array<String>`

--- a/docs/config/index.zh-CN.md
+++ b/docs/config/index.zh-CN.md
@@ -180,6 +180,14 @@ export default {
 
 配置 dumi 嗅探的文档目录，dumi 会尝试在配置的目录中递归寻找 markdown 文件，默认值为 `docs` 目录、`src` 目录（普通项目），如果环境为 lerna 项目，则 `src` 目录变为 `packages/pkg/src` 目录，通常不需要配置，除非自动嗅探出现了『误伤』。
 
+#### excludes
+
+- 类型：`Array<String>`
+- 默认值：`[]`
+- 详细：
+
+需要排除的目录，会对 `dumi` 嗅探到的目录或文件进行过滤，规则同 `gitignore` 配置。
+
 #### previewLangs
 
 - 类型：`Array<String>`

--- a/packages/preset-dumi/package.json
+++ b/packages/preset-dumi/package.json
@@ -41,6 +41,7 @@
     "hast-util-to-html": "^7.1.1",
     "hast-util-to-string": "^1.0.2",
     "hosted-git-info": "^3.0.2",
+    "ignore": "^5.1.8",
     "js-yaml": "^3.13.1",
     "lz-string": "^1.4.4",
     "react-docgen-typescript-dumi-tmp": "^1.22.1-0",

--- a/packages/preset-dumi/src/context.ts
+++ b/packages/preset-dumi/src/context.ts
@@ -44,13 +44,17 @@ export interface IDumiOpts {
      */
     includes: string[];
     /**
+     * configure the markdown directory for dumi exclude
+     */
+    excludes: string[];
+    /**
      * TBD
      */
     examples: string[];
     /**
      * Should we treat previewLangs codeblock as demo component
      */
-    passivePreview: boolean
+    passivePreview: boolean;
   };
   /**
    * customize the side menu

--- a/packages/preset-dumi/src/routes/getRouteConfigFromDir.ts
+++ b/packages/preset-dumi/src/routes/getRouteConfigFromDir.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import slash from 'slash2';
 import type { IRoute } from '@umijs/types';
+import ignore from 'ignore';
+
 import type { IDumiOpts } from '../index';
 import ctx from '../context';
 
@@ -71,10 +73,17 @@ function findChildRoutes(
   opts: IDumiOpts,
   parentRoutePath: string = '/',
 ): IRoute[] {
-  const isExampleDir = opts.resolve?.examples?.some(
-    dir => path.join(ctx.umi?.cwd || process.cwd(), dir) === absPath,
-  );
-  const mixture = fs.readdirSync(absPath).filter(isValidPath);
+  const cwd = ctx.umi?.cwd || process.cwd();
+  const isExampleDir = opts.resolve?.examples?.some(dir => path.join(cwd, dir) === absPath);
+  let mixture = fs.readdirSync(absPath).filter(isValidPath);
+  if (opts.resolve?.excludes) {
+    const ig = ignore().add(opts.resolve.excludes);
+    mixture = mixture.filter(filename => {
+      const absoluteFilepath = path.join(absPath, filename);
+      const filepath = slash(path.relative(cwd, absoluteFilepath));
+      return !ig.ignores(filepath);
+    });
+  }
   const routes: IRoute[] = [];
   // separate files & child directories
   const [files, dirs] = mixture.reduce(
@@ -112,7 +121,7 @@ function findChildRoutes(
     ) {
       const route: IRoute = {
         path: normalizePath(routePath, localePath, opts.locales),
-        component: `./${slash(path.relative(ctx.umi?.cwd || process.cwd(), filePath))}`,
+        component: `./${slash(path.relative(cwd, filePath))}`,
         exact: true,
       };
 

--- a/packages/preset-dumi/src/routes/test/site.test.js
+++ b/packages/preset-dumi/src/routes/test/site.test.js
@@ -15,6 +15,38 @@ const DEFAULT_LOCALES = [
 describe('routes & menu: site mode', () => {
   let routes;
 
+  it('getRouteConfigFromDir when has excludes', () => {
+    const includesRoutes = getRoute(path.join(FIXTURES_PATH, 'site'), {
+      locales: DEFAULT_LOCALES,
+      resolve: {
+        excludes: ['**/site/rewrite/*', '**/site/config/others.md'],
+      },
+    });
+
+    expect(includesRoutes).toEqual([
+      {
+        path: '/api',
+        component: './packages/preset-dumi/src/routes/fixtures/site/api.md',
+        exact: true,
+      },
+      {
+        path: '/',
+        component: './packages/preset-dumi/src/routes/fixtures/site/index.md',
+        exact: true,
+      },
+      {
+        path: '/zh-CN',
+        component: './packages/preset-dumi/src/routes/fixtures/site/index.zh-CN.md',
+        exact: true,
+      },
+      {
+        path: '/config',
+        component: './packages/preset-dumi/src/routes/fixtures/site/config/index.md',
+        exact: true,
+      },
+    ]);
+  });
+
   it('getRouteConfigFromDir', () => {
     routes = getRoute(path.join(FIXTURES_PATH, 'site'), {
       locales: DEFAULT_LOCALES,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#661 

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

`resolve` 除了 `includes` 外还希望支持 `excludes`，对 `dumi` 找到的目录进行排除。

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  `resolve` supports `excludes` configuration to exclude specified directories or files  |
| 🇨🇳 Chinese |  `resolve` 支持 `excludes` 配置排除指定目录或文件  |
