### PR TITLE
fix: demo build when configuring exportStatic

### DIFF
--- a/packages/preset-dumi/src/context.ts
+++ b/packages/preset-dumi/src/context.ts
@@ -1,4 +1,4 @@
-import type { IApi } from '@umijs/types';
+import type { IApi, IConfig } from '@umijs/types';
 import type { PropFilter } from 'react-docgen-typescript-dumi-tmp/lib/parser';
 import type { IMenuItem } from './routes/getMenuFromRoutes';
 import type { INav, INavItem } from './routes/getNavFromRoutes';
@@ -93,6 +93,10 @@ export interface IDumiOpts {
     skipPropsWithoutDoc?: boolean;
     propFilter?: PropFilter;
   };
+  /**
+   * configure how html is output
+   */
+  exportStatic?: IConfig['exportStatic'];
 }
 
 const context: { umi?: IApi; opts?: IDumiOpts } = {};

--- a/packages/preset-dumi/src/fixtures/demos-htmlsuffix/.umirc.ts
+++ b/packages/preset-dumi/src/fixtures/demos-htmlsuffix/.umirc.ts
@@ -1,0 +1,4 @@
+export default {
+  plugins: ['./writeTmp.js'],
+  exportStatic: { htmlSuffix: true },
+}

--- a/packages/preset-dumi/src/fixtures/demos-htmlsuffix/docs/index.md
+++ b/packages/preset-dumi/src/fixtures/demos-htmlsuffix/docs/index.md
@@ -1,0 +1,9 @@
+# test-demos-htmlsuffix
+
+```tsx
+/**
+ * identifier: test
+ */
+
+export default () => null;
+```

--- a/packages/preset-dumi/src/fixtures/demos-htmlsuffix/writeTmp.js
+++ b/packages/preset-dumi/src/fixtures/demos-htmlsuffix/writeTmp.js
@@ -1,0 +1,10 @@
+import path from 'path';
+
+export default (api) => {
+  api.chainWebpack(memo => {
+    // babel compile src folder
+    memo.module.rule('js').include.add(path.join(__dirname, '../../..'));
+
+    return memo;
+  });
+}

--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -16,6 +16,7 @@ describe('preset-dumi', () => {
       'basic',
       'algolia',
       'demos',
+      'demos-htmlsuffix',
       'assets',
       'integrate',
       'local-theme',
@@ -106,6 +107,23 @@ describe('preset-dumi', () => {
     expect(
       demos.includes('"componentName":"ForceComponent","identifier":"component-demo"'),
     ).toBeTruthy();
+  });
+
+  it('demos-htmlsuffix', async () => {
+    const cwd = path.join(fixtures, 'demos-htmlsuffix');
+    const service = new Service({
+      cwd,
+      env: 'production',
+      presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
+    });
+
+    // add UMI_DIR to avoid alias error
+    process.env.UMI_DIR = path.dirname(require.resolve('umi/package'));
+
+    await service.run({ name: 'build' });
+
+    // expect generate demo url with html suffix
+    expect(fs.existsSync(path.join(service.paths.absOutputPath, '~demos/test.html'))).toBeTruthy();
   });
 
   it('assets command', async () => {

--- a/packages/preset-dumi/src/plugins/features/config.ts
+++ b/packages/preset-dumi/src/plugins/features/config.ts
@@ -26,13 +26,17 @@ export default (api: IApi) => {
       description: ctx.opts.description,
       mode: ctx.opts.mode,
       repository: {
-        url: getRepoUrl(api.pkg.repository?.url || api.pkg.repository, api.pkg.repository?.platform),
+        url: getRepoUrl(
+          api.pkg.repository?.url || api.pkg.repository,
+          api.pkg.repository?.platform,
+        ),
         branch: api.pkg.repository?.branch || 'master',
         platform: api.pkg.repository?.platform,
       },
       algolia: ctx.opts.algolia,
       theme: ctx.opts.theme,
       apiParser: ctx.opts.apiParser,
+      exportStatic: api.config.exportStatic,
     };
 
     api.writeTmpFile({

--- a/packages/preset-dumi/src/plugins/features/demo/index.ts
+++ b/packages/preset-dumi/src/plugins/features/demo/index.ts
@@ -45,22 +45,28 @@ export default (api: IApi) => {
       demoComponent = decodeImportRequireWithAutoDynamic(demoComponent, chunkName);
 
       // hoist all raw code import statements
-      Object.entries(demos[uuid].previewerProps.sources).forEach(([file, oContent]: [string, any]) => {
-        const content = file === '_' ? Object.values(oContent)[0] : oContent.content;
+      Object.entries(demos[uuid].previewerProps.sources).forEach(
+        ([file, oContent]: [string, any]) => {
+          const content = file === '_' ? Object.values(oContent)[0] : oContent.content;
 
-        if (isHoistImport(content)) {
-          if (!hoistImports[content]) {
-            hoistImports[content] = hoistImportCount;
-            hoistImportCount += 1;
+          if (isHoistImport(content)) {
+            if (!hoistImports[content]) {
+              hoistImports[content] = hoistImportCount;
+              hoistImportCount += 1;
+            }
+
+            itemHoistImports[content] = hoistImports[content];
           }
-
-          itemHoistImports[content] = hoistImports[content];
-        }
-      });
+        },
+      );
 
       // replace collected import statments to rawCode var
       const previewerPropsStr = Object.entries(itemHoistImports).reduce(
-        (str, [stmt, no]) => str.replace(new RegExp(`"${stmt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`, 'g'), `rawCode${no}`),
+        (str, [stmt, no]) =>
+          str.replace(
+            new RegExp(`"${stmt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`, 'g'),
+            `rawCode${no}`,
+          ),
         JSON.stringify(demos[uuid].previewerProps),
       );
 
@@ -121,7 +127,9 @@ export default (api: IApi) => {
     const theme = await getTheme();
     const prependRoutes: IRoute[] = [
       {
-        path: `/${getDemoRouteName()}/:uuid`,
+        path: `/${getDemoRouteName()}/:uuid${
+          api.config.exportStatic && api.config.exportStatic.htmlSuffix ? '.html' : ''
+        }`,
         // use to disable pro-layout in integrated mode
         layout: false,
       },
@@ -169,7 +177,9 @@ export default (api: IApi) => {
             const { default: getDemoRenderArgs } = await import(/* webpackChunkName: 'dumi_demos' */ '${api.utils.winPath(
               path.join(__dirname, './getDemoRenderArgs'),
             )}');
-            const { default: Previewer } = await import(/* webpackChunkName: 'dumi_demos' */ '${Previewer.source}');
+            const { default: Previewer } = await import(/* webpackChunkName: 'dumi_demos' */ '${
+              Previewer.source
+            }');
             const { default: demos } = await import(/* webpackChunkName: 'dumi_demos' */ '@@/dumi/demos');
             const { usePrefersColor } = await import(/* webpackChunkName: 'dumi_demos' */ 'dumi/theme');
 
@@ -202,15 +212,19 @@ export default (api: IApi) => {
   });
 
   // export static for dynamic demos
-  api.modifyExportRouteMap((memo) => {
-    if (api.config.exportStatic) {
-      memo.push(...Object.keys(demos).map(uuid => {
-        const demoRoutePath = `/${getDemoRouteName()}/${uuid}`;
-
-        return ({ route: { path: demoRoutePath }, file: `${demoRoutePath}.html` });
-      }));
+  api.modifyExportRouteMap(memo => {
+    const exportStatic = api.config.exportStatic;
+    if (exportStatic) {
+      memo.push(
+        ...Object.keys(demos).map(uuid => {
+          const demoRoutePath = `/${getDemoRouteName()}/${uuid}`;
+          return {
+            route: { path: demoRoutePath },
+            file: `${demoRoutePath}${exportStatic.htmlSuffix ? '' : '/index'}.html`,
+          };
+        }),
+      );
     }
-
     return memo;
-  })
+  });
 };

--- a/packages/preset-dumi/src/theme/context.ts
+++ b/packages/preset-dumi/src/theme/context.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { IRoute } from '@umijs/types';
+import type { IConfig, IRoute } from '@umijs/types';
 import type { INav } from '../routes/getNavFromRoutes';
 import type { IMenu } from '../routes/getMenuFromRoutes';
 import type { ILocale } from '../routes/getLocaleFromRoutes';
@@ -58,6 +58,10 @@ export interface IThemeContext {
      * apiParser config
      */
     apiParser: IDumiOpts['apiParser'];
+    /**
+     * configure how html is output
+     */
+    exportStatic?: IConfig['exportStatic'];
   };
   /**
    * the meta information of current route

--- a/packages/preset-dumi/src/theme/hooks/useDemoUrl.test.tsx
+++ b/packages/preset-dumi/src/theme/hooks/useDemoUrl.test.tsx
@@ -1,4 +1,7 @@
+import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
+import type { IThemeContext } from '../context';
+import Context from '../context';
 import useDemoUrl from './useDemoUrl';
 
 describe('theme API: useDemoUrl', () => {
@@ -8,6 +11,28 @@ describe('theme API: useDemoUrl', () => {
     ...saved,
     href: `http://localhost/`,
   } as Window['location'];
+
+  const baseCtx: IThemeContext = {
+    locale: 'zh-CN',
+    routes: [],
+    config: {
+      locales: [{ name: 'zh-CN', label: '中文' }],
+      menus: {},
+      navs: {},
+      title: 'test',
+      mode: 'doc',
+      repository: { branch: 'master' },
+      exportStatic: {
+        htmlSuffix: true,
+      },
+      theme: {},
+      apiParser: {},
+    },
+    meta: { title: '' },
+    menu: [],
+    nav: [],
+    base: '/',
+  };
 
   beforeEach(() => {
     window.location.href = `http://localhost/`;
@@ -68,5 +93,19 @@ describe('theme API: useDemoUrl', () => {
     expect(hashResult1.current).toEqual(`http://localhost/prefix/path/#/_demos/test/index.html`);
 
     process.env.PLATFORM_TYPE = oType;
+  });
+
+  it('should return demo url with html suffix', () => {
+    const wrapper = ({ children }) => (
+      <Context.Provider value={baseCtx}>{children}</Context.Provider>
+    );
+
+    const { result } = renderHook(() => useDemoUrl('test'), { wrapper });
+
+    expect(result.current).toEqual('http://localhost/~demos/test.html');
+
+    window.location.href += '#/';
+    const { result: hashResult } = renderHook(() => useDemoUrl('test'), { wrapper });
+    expect(hashResult.current).toEqual(`http://localhost/#/~demos/test.html`);
   });
 });

--- a/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
+++ b/packages/preset-dumi/src/theme/hooks/useDemoUrl.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
+import context from '../context';
 
 // functional for testing
 function isBMW() {
@@ -16,8 +17,9 @@ export const getDemoRouteName = () => {
 /**
  * get single demo url
  * @param demoId  demo identifier
+ * @param htmlSuffix true when `exportStatic: { htmlSuffix: true }`
  */
-export const getDemoUrl = (demoId: string) => {
+export const getDemoUrl = (demoId: string, htmlSuffix?: boolean) => {
   const {
     location: { href, origin },
   } = window;
@@ -31,7 +33,7 @@ export const getDemoUrl = (demoId: string) => {
     getDemoRouteName(),
     '/',
     demoId,
-    isBMW() ? '/index.html' : '',
+    isBMW() ? '/index.html' : `${htmlSuffix ? '.html' : ''}`,
   ].join('');
 };
 
@@ -39,11 +41,12 @@ export const getDemoUrl = (demoId: string) => {
  * hooks for get single demo url
  */
 export default (demoId: string) => {
+  const { config } = useContext(context);
   const [url, setUrl] = useState('');
 
   useEffect(() => {
-    setUrl(getDemoUrl(demoId));
-  }, [demoId]);
+    setUrl(getDemoUrl(demoId, config.exportStatic && config.exportStatic.htmlSuffix));
+  }, [demoId, config]);
 
   return url;
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

配置 `exportStatic: {}` 或 `exportStatic: { htmlSuffix: true }` 的时候，修复生成以及访问 demo 文件的路径

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Demo build correctly when configuring exporStatic    |
| 🇨🇳 Chinese |   demo 正确的构建当配置 exportStatic 时       |
