### PR TITLE
fix(transformer): the same name MD conflict

### DIFF
--- a/packages/preset-dumi/src/transformer/remark/previewer.ts
+++ b/packages/preset-dumi/src/transformer/remark/previewer.ts
@@ -30,7 +30,7 @@ const externalIdMap = new Map<string, number>();
 /**
  * record code block demo id count
  */
-const mdCodeBlockIdMap = new Map<string, Map<string, number>>();
+const mdCodeBlockIdMap = new Map<string, number>();
 
 /**
  * get unique id for previewer
@@ -50,7 +50,7 @@ function getPreviewerId(yaml: any, mdAbsPath: string, codeAbsPath: string, compo
   if (!id) {
     if (mdAbsPath === codeAbsPath) {
       // for code block demo, format: component-demo-N
-      const idMap = mdCodeBlockIdMap.get(mdAbsPath);
+      // const idMap = mdCodeBlockIdMap.get(mdAbsPath);
       const prefix =
         componentName ||
         path.basename(slash(mdAbsPath).replace(/(?:\/(?:index|readme))?(\.[\w-]+)?\.md/i, '$1'));
@@ -58,9 +58,9 @@ function getPreviewerId(yaml: any, mdAbsPath: string, codeAbsPath: string, compo
       id = `${prefix}-demo`;
 
       // record id count
-      const currentIdCount = idMap.get(id) || 0;
+      const currentIdCount = mdCodeBlockIdMap.get(id) || 0;
 
-      idMap.set(id, currentIdCount + 1);
+      mdCodeBlockIdMap.set(id, currentIdCount + 1);
 
       // append count suffix
       id += currentIdCount ? `-${currentIdCount}` : '';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#847

### 💡 需求背景和解决方案 / Background or solution
#### 需求背景
我自己在集成dumi的时候发现这个错误，而后发现相关issue #847，这个问题是当有相同的命名的md的时候，会让生产的临时文件dumi/.umi/dumi/index.ts 中的导出对象中的key值冲突，导致显示的时候是错误的组件
#### 解决方案
我将mdCodeBlockIdMap的数据结构更新为 new Map<string, number>，解决了这个问题，这样可以吗
<!--
解决的具体问题。
The specific problem solved.
-->
### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     the same name MD preview conflict      |
| 🇨🇳 Chinese |    相同md文档的预览的组件将会冲突       |
