### PR TITLE
fix: 当使用APP_ROOT时，在github编辑此页的路径问题

### DIFF
--- a/packages/preset-dumi/src/transformer/remark/meta.ts
+++ b/packages/preset-dumi/src/transformer/remark/meta.ts
@@ -16,9 +16,7 @@ import { getModuleResolvePath } from '../../utils/moduleResolver';
 export default function meta(): IDumiUnifiedTransformer {
   return (ast, vFile) => {
     if (this.data('fileAbsPath')) {
-      const filePath = slash(
-        path.relative(ctx.umi?.cwd || process.cwd(), this.data('fileAbsPath')),
-      );
+      const filePath = slash(path.relative(process.cwd(), this.data('fileAbsPath')));
 
       // append file info
       vFile.data.filePath = filePath;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [X] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

[856](https://github.com/umijs/dumi/issues/856#issue-983383277)

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

`meta.filePath`取自`path.relative(process.cwd(), this.data('fileAbsPath')` 而不是 ` path.relative(ctx.umi?.cwd || process.cwd(), this.data('fileAbsPath'))`

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       when use `APP_ROOT`，fix `Edit this doc on GitHub` link    |
| 🇨🇳 Chinese |    修复当设定`APP_ROOT` 时，`Edit this doc on GitHub`指向问题      |
