### PR TITLE
fix:  property 'path' of undefined（#872）

### DIFF
--- a/packages/preset-dumi/src/routes/decorator/redirect.ts
+++ b/packages/preset-dumi/src/routes/decorator/redirect.ts
@@ -92,7 +92,7 @@ export default (function redirect(routes) {
         },
         exact: true,
         redirect: getFirstMenuInParent(validRoutes.concat(validGroups), this.options.menus?.[path])
-          .path,
+          ?.path,
       };
     }
 


### PR DESCRIPTION
fix:  property 'path' of undefined（#872）

<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] bug 修复 / Fix bug


### 🔗 相关 Issue / Related Issue
https://github.com/umijs/dumi/issues/872

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->
当我使用1.1.26版本的dumi的时候，yarn dev的时候产生了报错信息，不能正常启动，报错信息如下：
Cannot read property 'path' of undefined
TypeError: Cannot read property 'path' of undefined
    at /Users/chencongcong/code/web/galaxy/node_modules/@umijs/preset-dumi/lib/routes/decorator/redirect.js:133:196
    at Array.forEach (<anonymous>)
    at Object.redirect (/Users/chencongcong/code/web/galaxy/node_modules/@umijs/preset-dumi/lib/routes/decorator/redirect.js:87:10)
    at /Users/chencongcong/code/web/galaxy/node_modules/@umijs/preset-dumi/lib/routes/decorator/index.js:63:27
    at Array.reduce (<anonymous>)
    at RouteDecorator.process (/Users/chencongcong/code/web/galaxy/node_modules/@umijs/preset-dumi/lib/routes/decorator/index.js:62:28)
    at _default (/Users/chencongcong/code/web/galaxy/node_modules/@umijs/preset-dumi/lib/routes/decorator/index.js:82:20)
    at /Users/chencongcong/code/web/galaxy/node_modules/@umijs/preset-dumi/lib/routes/getRouteConfig.js:127:38
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/chencongcong/code/web/galaxy/node_modules/@umijs/preset-dumi/lib/routes/getRouteConfig.js:70:103)
✨  Done in 18.18s.


我的.umirc.js的配置如下
	menus: {
		'/docs': [
			{
				title: '通用',
				children: ['../docs/docs/common/start.md', '../docs/docs/common/changelog.md'],
			}
                 ]
         }

### 💡 需求背景和解决方案 / Background or solution
在@umijs/preset-dumi/lib/routes/decorator/redirect.js:133:196 的path前面加上判空处理，则正常启动项目

<!--
解决的具体问题。
The specific problem solved.
-->

解决了项目可以不呢正常启动的问题

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->
暂无风险，只添加了判空处理

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix property 'path' of undefined   |
| 🇨🇳 Chinese |    对path进行了判空处理       |
