### PR TITLE
fix(preset): add resolve.excludes to context

### DIFF
--- a/packages/preset-dumi/src/plugins/features/resolve.ts
+++ b/packages/preset-dumi/src/plugins/features/resolve.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import type { IApi } from '@umijs/types';
-import { setOptions } from '../../context';
+import type {IApi} from '@umijs/types';
+import {setOptions} from '../../context';
 import getHostPkgAlias from '../../utils/getHostPkgAlias';
 
 export default (api: IApi) => {
@@ -28,7 +28,8 @@ export default (api: IApi) => {
           .map(([_, pkgPath]) => path.relative(api.paths.cwd, path.join(pkgPath, 'src')))
           .concat(['docs']),
       examples: memo.resolve.examples || ['examples'],
-      passivePreview: memo.resolve.passivePreview || false
+      passivePreview: memo.resolve.passivePreview || false,
+      excludes: memo.resolve.excludes || []
     });
 
     return memo;

--- a/packages/preset-dumi/src/plugins/features/resolve.ts
+++ b/packages/preset-dumi/src/plugins/features/resolve.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import type {IApi} from '@umijs/types';
-import {setOptions} from '../../context';
+import type { IApi } from '@umijs/types';
+import { setOptions } from '../../context';
 import getHostPkgAlias from '../../utils/getHostPkgAlias';
 
 export default (api: IApi) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

+ #814
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->
`packages/preset-dumi/src/plugins/features/resolve.ts` 处理`resolve`选项时未将`resolve.excludes`赋值给`context`，导致`resolve.excludes`并未生效

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix the problem that `resolve.excludes` configuration does not take effect        |
| 🇨🇳 Chinese |  修复`resolve.excludes`不生效问题         |
