### PR TITLE
fix: getDemoRenderArgs

### DIFF
--- a/packages/preset-dumi/src/plugins/features/demo/getDemoRenderArgs.ts
+++ b/packages/preset-dumi/src/plugins/features/demo/getDemoRenderArgs.ts
@@ -1,10 +1,16 @@
 import type { ComponentProps, ReactNode } from 'react';
 import type { IRouteComponentProps } from 'dumi';
-import React from 'react';
+import React, { FC, ReactElement } from 'react';
 // @ts-ignore
 import { useMotions } from 'dumi/theme';
 
 type IGetDemoRenderArgs = [ComponentProps<any>, ReactNode] | [ReactNode] | [];
+
+const InlineRender: FC<{
+  render: () => ReactElement;
+}> = props => {
+  return props.render();
+};
 
 /**
  * return demo preview arguments for single page route
@@ -43,13 +49,15 @@ export default (
     if (inline) {
       // return demo component with motions handler
       result = [
-        React.createElement(() => {
-          useMotions(
-            previewerProps.motions || [],
-            typeof window !== 'undefined' ? document.documentElement : null,
-          );
+        React.createElement(InlineRender, {
+          render: () => {
+            useMotions(
+              previewerProps.motions || [],
+              typeof window !== 'undefined' ? document.documentElement : null,
+            );
 
-          return React.createElement('div', {}, React.createElement(demo.component));
+            return React.createElement('div', {}, React.createElement(demo.component));
+          },
         }),
       ];
     } else {


### PR DESCRIPTION
add a InlineRender component to prevent demo being destoryed when layout updates

<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
