### PR TITLE
fix: theme find component

### DIFF
--- a/packages/preset-dumi/src/fixtures/custom-components/.dumi/theme/builtins/Dir/index.tsx
+++ b/packages/preset-dumi/src/fixtures/custom-components/.dumi/theme/builtins/Dir/index.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <p id="custom-directory-component">Dir</p>;

--- a/packages/preset-dumi/src/fixtures/custom-components/.dumi/theme/builtins/Single.tsx
+++ b/packages/preset-dumi/src/fixtures/custom-components/.dumi/theme/builtins/Single.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <p id="custom-single-component">Single</p>;

--- a/packages/preset-dumi/src/fixtures/custom-components/.umirc.js
+++ b/packages/preset-dumi/src/fixtures/custom-components/.umirc.js
@@ -1,0 +1,5 @@
+export default {
+  history: { type: 'memory' },
+  mountElementId: '',
+  plugins: ['./plugin.js'],
+}

--- a/packages/preset-dumi/src/fixtures/custom-components/README.md
+++ b/packages/preset-dumi/src/fixtures/custom-components/README.md
@@ -1,0 +1,3 @@
+<Single></Single>
+
+<Dir></Dir>

--- a/packages/preset-dumi/src/fixtures/custom-components/plugin.js
+++ b/packages/preset-dumi/src/fixtures/custom-components/plugin.js
@@ -1,0 +1,10 @@
+import path from 'path';
+
+export default (api) => {
+  api.chainWebpack(memo => {
+    // babel compile src folder
+    memo.module.rule('js').include.add(path.join(__dirname, '../../..'));
+
+    return memo;
+  });
+}

--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -25,6 +25,7 @@ describe('preset-dumi', () => {
       'sitemap',
       'dynamic-import',
       'compiletime',
+      'custom-components'
     ].forEach(dir => {
       rimraf.sync(path.join(fixtures, dir, 'node_modules'));
     });
@@ -419,5 +420,27 @@ describe('preset-dumi', () => {
     expect(
       demos.includes('{"text":"World!"}'),
     ).toBeTruthy();
+  });
+
+  it('custom md components', async () => {
+    const cwd = path.join(fixtures, 'custom-components');
+    const service = new Service({
+      cwd,
+      env: 'production',
+      presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
+    });
+
+    // add UMI_DIR to avoid alias error
+    process.env.UMI_DIR = path.dirname(require.resolve('umi/package'));
+
+    await service.run({
+      name: 'build',
+    });
+
+    // expect compile custom component
+    const distContent = fs.readFileSync(path.join(service.paths.absOutputPath, 'umi.js')).toString();
+
+    expect(distContent).toContain('custom-single-component');
+    expect(distContent).toContain('custom-directory-component');
   });
 });

--- a/packages/preset-dumi/src/theme/loader.ts
+++ b/packages/preset-dumi/src/theme/loader.ts
@@ -73,7 +73,7 @@ function detectInstalledTheme() {
  * detect dumi theme in project dependencies
  */
 function detectLocalTheme() {
-  const detectPath = winPath(path.join(ctx.umi.cwd, process.env.LOCAL_THEME_PATH || LOCAL_THEME_PATH));
+  const detectPath = winPath(path.join(ctx.umi.cwd, LOCAL_THEME_PATH));
 
   return fs.existsSync(detectPath) ? detectPath : null;
 }
@@ -133,20 +133,6 @@ function getThemeEntryDir(modulePath: string) {
   return dirs.find(dir => fs.existsSync(dir));
 }
 
-const COMPONENT_FILES = [
-  'index.ts',
-  'index.js',
-  'index.tsx',
-  'index.jsx',
-];
-
-function getComponentFile(p: string): string | null {
-  const componentFile = COMPONENT_FILES.find((f) =>
-    fs.existsSync(pathJoin(p, f)),
-  );
-  return componentFile;
-}
-
 export default async () => {
   if (!cache || process.env.NODE_ENV === 'test') {
     const [theme, fb = FALLBACK_THEME] = detectTheme();
@@ -154,7 +140,7 @@ export default async () => {
     const modulePath = path.isAbsolute(theme)
       ? theme
       : // resolve real absolute path for theme package
-      winPath(path.dirname(getThemeResolvePaths(theme).resolved));
+        winPath(path.dirname(getThemeResolvePaths(theme).resolved));
     // local theme has no src directory but theme package has
     const entryDir = path.isAbsolute(theme) ? theme : getThemeEntryDir(modulePath);
     const builtinPath = pathJoin(entryDir, 'builtins');
@@ -163,37 +149,27 @@ export default async () => {
 
     const components = fs.existsSync(builtinPath)
       ? fs
-        .readdirSync(builtinPath)
-        .map(file => {
-          // filter .js/.ts/.jsx/.tsx, and exclude .d.ts
-          if (/((?<!\.d)\.ts|\.(jsx?|tsx))$/.test(file)) {
-            return ({
-              identifier: path.parse(file).name,
-              source: theme.startsWith('.')
-                ? // use abs path for relative theme folder
+          .readdirSync(builtinPath)
+          .filter(file => {
+            const absPath = path.join(builtinPath, file);
+            // filter .js/.ts/.jsx/.tsx, and exclude .d.ts
+            const isFileComponent = /((?<!\.d)\.ts|\.(jsx?|tsx))$/.test(file);
+            // filter Foo/index.(tsx|jsx|js|ts)
+            const isDirComponent =
+              fs.lstatSync(absPath).isDirectory() &&
+              fs.readdirSync(absPath).some(item => /^index.(t|j)sx?$/.test(item));
+
+            return isFileComponent || isDirComponent;
+          })
+          .map(file => ({
+            identifier: path.parse(file).name,
+            source: theme.startsWith('.')
+              ? // use abs path for relative theme folder
                 pathJoin(builtinPath, file)
-                : // still use module identifier rather than abs path for theme package and absolute theme folder
+              : // still use module identifier rather than abs path for theme package and absolute theme folder
                 pathJoin(theme, builtinPath.replace(modulePath, ''), file),
-              modulePath: pathJoin(builtinPath, file),
-            })
-          }
-          // filter XXX/index.[t|j]s[?x]
-          if (fs.statSync(pathJoin(builtinPath, file)).isDirectory()) {
-            const fileName = getComponentFile(pathJoin(builtinPath, file));
-            if (fileName && fs.existsSync(pathJoin(builtinPath, file, fileName))) {
-              return ({
-                identifier: path.parse(file).name,
-                source: theme.startsWith('.')
-                  ? // use abs path for relative theme folder
-                  pathJoin(builtinPath, fileName)
-                  : // still use module identifier rather than abs path for theme package and absolute theme folder
-                  pathJoin(theme, builtinPath.replace(modulePath, ''), file, fileName),
-                modulePath: pathJoin(builtinPath, file, fileName),
-              })
-            }
-          }
-          return null;
-        }).filter(Boolean)
+            modulePath: pathJoin(builtinPath, file),
+          }))
       : [];
     const fallbacks = REQUIRED_THEME_BUILTINS.reduce((result, bName) => {
       if (components.every(({ identifier }) => identifier !== bName)) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
1、开发中无法指定 dumi/theme 的存在文件夹，和现在的构建工具默认 src 目录有点分离，增加了环境变量`process.env.LOCAL_THEME_PATH`
```
"start": "cross-env process.env.LOCAL_THEME_PATH=src dumi dev",
```

2、修复查找theme 组件，只能是文件的问题
之前 
```
builtins
│   ├── Alert.less
│   ├── Alert.tsx
│   └── Button
│       ├── demo
│       │   └── index.tsx
│       ├── index.less
│       ├── index.md
│       └── index.tsx
```
只能找到 Alert 组件，现在可以找到文件夹下存在 index 的组件。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
