### PR TITLE
fix: fix host package dependencies problem

### DIFF
--- a/packages/preset-dumi/src/transformer/demo/dependencies.ts
+++ b/packages/preset-dumi/src/transformer/demo/dependencies.ts
@@ -8,6 +8,9 @@ import {
   getModuleResolvePkg,
   getModuleResolvePath,
   getModuleResolveContent,
+  getPackageInfo,
+  getHostPkgPath,
+  getHostModuleResolvePkg,
 } from '../../utils/moduleResolver';
 import FileCache from '../../utils/cache';
 import type { IDemoOpts } from './options';
@@ -52,6 +55,8 @@ export const LOCAL_MODULE_EXT = [...LOCAL_DEP_EXT, '.json'];
 
 // local dependency extensions which will be collected
 export const PLAIN_TEXT_EXT = [...LOCAL_MODULE_EXT, '.less', '.css', '.scss', '.sass', '.styl'];
+
+export const isHostPackage = (packageName: string) => getHostPkgPath(packageName);
 
 function analyzeDeps(
   raw: string,
@@ -99,9 +104,10 @@ function analyzeDeps(
           });
           const resolvePathParsed = path.parse(resolvePath);
 
-          if (resolvePath.includes('node_modules')) {
+          const isHostPkg = isHostPackage(requireStr);
+          if (resolvePath.includes('node_modules') || isHostPkg) {
             // save external deps
-            const pkg = getModuleResolvePkg({
+            const pkg = isHostPkg ? getHostModuleResolvePkg(requireStr) : getModuleResolvePkg({
               basePath: fileAbsPath,
               sourcePath: resolvePath,
               extensions: LOCAL_MODULE_EXT,

--- a/packages/preset-dumi/src/utils/moduleResolver.test.ts
+++ b/packages/preset-dumi/src/utils/moduleResolver.test.ts
@@ -5,6 +5,7 @@ import {
   getModuleResolvePath,
   getModuleResolvePkg,
   getModuleResolveContent,
+  getHostModuleResolvePkg,
 } from './moduleResolver';
 import ctx from '../context';
 
@@ -53,5 +54,12 @@ describe('moduleResolver', () => {
       .toString();
 
     expect(content).toEqual(expectedContent);
+  });
+
+  it('get expected host module version', () => {
+    const { version } = getHostModuleResolvePkg('@umijs/preset-dumi');
+    const { version: expectedVersion } = require(path.join(__dirname, '../../package.json'));
+
+    expect(version).toEqual(expectedVersion);
   });
 });

--- a/packages/preset-dumi/src/utils/moduleResolver.ts
+++ b/packages/preset-dumi/src/utils/moduleResolver.ts
@@ -33,7 +33,7 @@ const getPkgPathsFromPath = (identifier: string) => {
  * get package root path if it is a local package
  * @param pkg   package name
  */
-const getHostPkgPath = (() => {
+export const getHostPkgPath = (() => {
   let cache: ReturnType<typeof getHostPkgAlias>;
 
   return (pkg: string) => {
@@ -78,20 +78,12 @@ export const getModuleResolvePath = ({
 };
 
 /**
- * resolve module version
+ * get package info by modulePath
  */
-export const getModuleResolvePkg = ({
-  basePath,
-  sourcePath,
-  extensions = DEFAULT_EXT,
-}: IModuleResolverOpts) => {
+export const getPackageInfo = (modulePath: string) => {
   let version: string | null;
   let name: string | null;
   let peerDependencies: any | null;
-  const resolvePath = getModuleResolvePath({ basePath, sourcePath, extensions });
-  const { pkgName, absPkgModulePath } = getPkgPathsFromPath(resolvePath);
-  // use project path as module path for local packages
-  const modulePath = getHostPkgPath(pkgName) || absPkgModulePath;
   const pkgPath = path.join(modulePath, 'package.json');
 
   if (modulePath && fs.existsSync(pkgPath)) {
@@ -108,6 +100,22 @@ export const getModuleResolvePkg = ({
 };
 
 /**
+ * resolve module version
+ */
+export const getModuleResolvePkg = ({
+  basePath,
+  sourcePath,
+  extensions = DEFAULT_EXT,
+}: IModuleResolverOpts) => {
+  const resolvePath = getModuleResolvePath({ basePath, sourcePath, extensions });
+  const { pkgName, absPkgModulePath } = getPkgPathsFromPath(resolvePath);
+  // use project path as module path for local packages
+  const  modulePath = getHostPkgPath(pkgName) || absPkgModulePath;
+
+  return getPackageInfo(modulePath);
+};
+
+/**
  * resolve module content
  */
 export const getModuleResolveContent = ({
@@ -118,4 +126,11 @@ export const getModuleResolveContent = ({
   const resolvePath = getModuleResolvePath({ basePath, sourcePath, extensions });
 
   return resolvePath ? fs.readFileSync(resolvePath, 'utf8').toString() : '';
+};
+
+/**
+ * resolve host module version
+ */
+ export const getHostModuleResolvePkg = (requireStr: string) => {
+  return getPackageInfo(getHostPkgPath(requireStr));
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
https://github.com/umijs/dumi/issues/1105

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
在lerna场景下codeSandbox的dependencies依赖解析错误，导致在线demo打开都报错
[报错demo链接](https://codesandbox.io/s/swsnsf?file=/App.tsx)
[其他pro-components的在线demo都会报错](https://procomponents.ant.design/components/form)
已在pro-components下npm link测试通过

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed the dependency parsing error of codeSandbox in the lerna scenario, resulting in the lack of dependencies in the online demo opening report     |
| 🇨🇳 Chinese |      修复在lerna场景下codeSandbox的dependencies依赖解析错误，导致在线demo打开报缺少依赖问题     |
