### PR TITLE
fix: default theme invalid time error

### DIFF
--- a/packages/theme-default/src/layout.tsx
+++ b/packages/theme-default/src/layout.tsx
@@ -62,8 +62,13 @@ const Layout: React.FC<IRouteComponentProps> = ({ children, location }) => {
     (meta.toc === 'content' || meta.toc === undefined) &&
     !meta.gapless;
   const isCN = /^zh|cn$/i.test(locale);
-  const updatedTimeIns = new Date(meta.updatedTime);
-  const updatedTime: any = `${updatedTimeIns.toLocaleDateString([], { hour12: false })} ${updatedTimeIns.toLocaleTimeString([], { hour12: false })}`;
+
+  let updatedTime: any;
+  if (meta.updatedTime) {
+    const updatedTimeIns = new Date(meta.updatedTime);
+    updatedTime = `${updatedTimeIns.toLocaleDateString([], { hour12: false })} ${updatedTimeIns.toLocaleTimeString([], { hour12: false })}`;
+  }
+
   const repoPlatform =
     { github: 'GitHub', gitlab: 'GitLab' }[
       (repoUrl || '').match(/(github|gitlab)/)?.[1] || 'nothing'


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->
暂无相关issue，[复现demo](https://github.com/avennn/dumi-demo)，操作步骤demo的README.md有描述

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->
问题：使用dumi开发文档系统时，因为组件有使用到[date-time-format-timezone](https://github.com/formatjs/date-time-format-timezone)，在组件文档路由切换过程中报错。

原因：date-time-format-timezone polyfill了Date对象的toLocaleDateString，最终使用Intl.DateTimeFormat来格式化时间。而默认主题的layout.tsx文件中，`const updatedTimeIns = new Date(meta.updatedTime)`在组件切换过程meta.updatedTime有可能为undefined，对应updatedTimeIns为Invalid Date对象，调用toLocaleDateString（实际Intl.DateTimeFormat）就会报错：
<img width="562" alt="image" src="https://user-images.githubusercontent.com/14135956/175571675-f387e4bf-c04e-4faf-bfb7-5dc226906144.png">

修复方式：
当meta.updatedTime为undefined时，生成的updatedTime为”Invalid Date Invalid Date"，展示在页面上没有意义
所以，只有当meta.updatedTime有值时才执行原来的格式化的逻辑。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix invalid date error when switch between component routes |
| 🇨🇳 Chinese | 修复切换组件路由时invalid date的错误 |
