### PR TITLE
fix: modify the codesandbox default template and import react

### DIFF
--- a/packages/preset-dumi/src/theme/hooks/useCodeSandbox.ts
+++ b/packages/preset-dumi/src/theme/hooks/useCodeSandbox.ts
@@ -51,20 +51,6 @@ root.render(<App />);`;
   }
 };
 
-/**
- * 如果是 react 17 以上可以不用写import React from 'react';
- * 但是我们用的模板还有问题，所以这里加一下，以后一定修
- * @param content
- * @returns
- */
-const injectReact = (content: string) => {
-  if (content.includes("import React from 'react';")) {
-    return content;
-  }
-  return `import React from 'react';
-${content}`;
-};
-
 function getTextContent(raw: string) {
   const elm = document.createElement('span');
 
@@ -108,7 +94,8 @@ function getCSBData(opts: IPreviewerComponentProps) {
   files['sandbox.config.json'] = {
     content: JSON.stringify(
       {
-        template: isTSX ? 'create-react-app-typescript' : 'create-react-app',
+        // 79e fix: codesandbox template create-react-app
+        template: 'create-react-app',
       },
       null,
       2,
@@ -121,7 +108,7 @@ function getCSBData(opts: IPreviewerComponentProps) {
     content: JSON.stringify(
       {
         name: opts.title,
-        description: getTextContent(opts.description) || 'An auto-generated demo by dumi',
+        description: getTextContent(opts.description ||  'An auto-generated demo by dumi'),
         main: entryFileName,
         dependencies: deps,
         // add TypeScript dependency if required, must in devDeps to avoid csb compile error
@@ -152,7 +139,7 @@ function getCSBData(opts: IPreviewerComponentProps) {
   Object.entries(opts.sources).forEach(([filename, { tsx, jsx, content }]) => {
     // handle primary content
     files[filename === '_' ? appFileName : filename] = {
-      content: injectReact(tsx || jsx || content),
+      content: tsx || jsx || content,
       isBinary: false,
     };
   });


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
暂无相关issue，操作步骤。

1. 版本小于 1.1.47 
2. 引入代码块 如果为 .tsx 文件 codesandbox 会识别为 Angular 并且无法加载 .less 样式（看图1图2）
3. injectReact 方法会给传入文件无论是tsx 还是jsx 还是 less，css都会加上 import React from 'react'; （看图3图4）

<img width="731" alt="image" src="https://user-images.githubusercontent.com/71202421/184090518-077c7b58-6932-4f9a-8579-1b17bd234ddf.png">

<img width="918" alt="image" src="https://user-images.githubusercontent.com/71202421/184090646-f5be1d98-4c32-4e5f-843f-1713572ddcec.png">

<img width="1202" alt="image" src="https://user-images.githubusercontent.com/71202421/184090790-94eb0e19-3495-4ec7-ae6e-d7640d74d297.png">

<img width="619" alt="image" src="https://user-images.githubusercontent.com/71202421/184091090-06444a75-2e5d-4fa9-ba5d-26964c66176a.png">

### 💡 需求背景和解决方案 / Background or solution
解决方案：
1. 取消自动导入react包，我认为这是多此一举的操作，用户应该保证它的代码别人复制是可以直接使用。
3. 将 codesandbox 模版设置为 create-react-app
