### PR TITLE
fix: codesandbox import React matching for double quotation marks

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -7,12 +7,12 @@ export default {
   navs: {
     'en-US': [
       null,
-      { title: 'GitHub', path: 'https://github.com/umijs/dumi' },
+      { title: 'GitHub', path: 'https://github.com/umijs/dumi/tree/1.x' },
       { title: 'Changelog', path: 'https://github.com/umijs/dumi/releases' },
     ],
     'zh-CN': [
       null,
-      { title: 'GitHub', path: 'https://github.com/umijs/dumi' },
+      { title: 'GitHub', path: 'https://github.com/umijs/dumi/tree/1.x' },
       { title: '更新日志', path: 'https://github.com/umijs/dumi/releases' },
     ],
   },

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -215,6 +215,9 @@ export default {
 
 Configure the document directory for dumi sniffing. Dumi will try to recursively find markdown files in the configured directory. The default values are the `docs` directory and the `src` directory (common projects). If the environment is the lerna project, the `src` directory will change It is the `packages/pkg/src` directory, and usually does not need to be configured, unless the automatic sniffing appears 『injuryed』.
 
+note:
+  - The default `src` and `docs` directories automatically exclude the `node_modules` and `fixtures` directories.
+
 #### resolve.excludes
 
 - Type：`Array<String>`

--- a/docs/config/index.zh-CN.md
+++ b/docs/config/index.zh-CN.md
@@ -216,6 +216,9 @@ export default {
 
 配置 dumi 嗅探的文档目录，dumi 会尝试在配置的目录中递归寻找 markdown 文件，默认值为 `docs` 目录、`src` 目录（普通项目），如果环境为 lerna 项目，则 `src` 目录变为 `packages/pkg/src` 目录，通常不需要配置，除非自动嗅探出现了『误伤』。
 
+注意：
+  - 默认的 `src` 和 `docs` 目录会自动排除 `node_modules` 和 `fixtures` 目录。
+
 #### resolve.excludes
 
 - 类型：`Array<String>`

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -261,4 +261,4 @@ Like other built-in components, the `API` component also supports override throu
 
 You only need to create a `.dumi/theme/builtins/API.tsx` (local theme) or create a theme package containing `API.tsx`, combining with the `useApiData` hook exposed by `dumi/theme`, you can control the rendering of the API table yourself.
 
-Please refer to the [API component implementation](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/builtins/API.tsx) of the dumi default theme.
+Please refer to the [API component implementation](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/builtins/API.tsx) of the dumi default theme.

--- a/docs/guide/advanced.zh-CN.md
+++ b/docs/guide/advanced.zh-CN.md
@@ -62,6 +62,8 @@ toc: menu
 
 使用方式很简单：在已有 Umi 项目中安装 `@umijs/preset-dumi` 到 `devDependencies` 中，再根据需要配置 `resolve.includes` 即可（比如约定 `src/components` 目录下为业务组件库和组件库对应的文档）。
 
+> dumi 1.x 暂不支持与 Umi 4 项目集成，请耐心等待 [dumi 2.0](https://github.com/umijs/dumi/issues/1151) 发布
+
 ## UI 资产数据化
 
 如何理解资产？从开发者视角狭义的理解，只要是生产出来可以帮助下游提效的实体，都可以称之为资产，比如组件、文档、组件 API、组件 demo 等等。

--- a/docs/guide/advanced.zh-CN.md
+++ b/docs/guide/advanced.zh-CN.md
@@ -235,5 +235,5 @@ dumi 背后的类型解析工具是 `react-docgen-typescript`，更多类型和�
 
 ### 自定义 API 表格渲染
 
-和其他内置组件一样，`API` 组件也支持通过 theme API 进行复写，只需要创建 `.dumi/theme/builtins/API.tsx`（本地主题）或者创建一个包含 `API.tsx` 的主题包，结合 `dumi/theme` 暴露的 `useApiData` hook，即可自行控制 API 表格的渲染，可参考 dumi 默认主题的 [API 组件实现](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/builtins/API.tsx)。
+和其他内置组件一样，`API` 组件也支持通过 theme API 进行复写，只需要创建 `.dumi/theme/builtins/API.tsx`（本地主题）或者创建一个包含 `API.tsx` 的主题包，结合 `dumi/theme` 暴露的 `useApiData` hook，即可自行控制 API 表格的渲染，可参考 dumi 默认主题的 [API 组件实现](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/builtins/API.tsx)。
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -197,7 +197,7 @@ jobs:
 
 ## During the development, how to configure the styles in the md file in load-on-demand?
 
-Dumi will alias pkgName/es, pkgName/lib, [for details, see](https://github.com/umijs/dumi/blob/master/packages/preset-dumi/src/plugins/features/symlink.ts#L62)
+Dumi will alias pkgName/es, pkgName/lib, [for details, see](https://github.com/umijs/dumi/blob/1.x/packages/preset-dumi/src/plugins/features/symlink.ts#L62)
 
 Configure `extraBabelPlugins` (Attention, it is a configuration of `.umirc.ts`, not `.fatherrc.ts`), add [`babel-plugin-import`](https://github.com/ant-design/babel-plugin-import), and configure reasonably according to the directory structure.
 

--- a/docs/guide/faq.zh-CN.md
+++ b/docs/guide/faq.zh-CN.md
@@ -197,7 +197,7 @@ jobs:
 
 ## 开发阶段，如何配置 md 文件中的样式按需引入？
 
-dumi 会对 pkgName/es、pkgName/lib 做 alias，[详情见](https://github.com/umijs/dumi/blob/master/packages/preset-dumi/src/plugins/features/symlink.ts#L62)
+dumi 会对 pkgName/es、pkgName/lib 做 alias，[详情见](https://github.com/umijs/dumi/blob/1.x/packages/preset-dumi/src/plugins/features/symlink.ts#L62)
 
 配置 `extraBabelPlugins` (注意是 `.umirc.ts` 的配置项，不是 `.fatherrc.ts`)，加入 [`babel-plugin-import`](https://github.com/ant-design/babel-plugin-import)，根据目录结构合理配置
 

--- a/docs/guide/index.zh-CN.md
+++ b/docs/guide/index.zh-CN.md
@@ -85,4 +85,4 @@ $ yarn start
 
 ### 构建及部署
 
-执行 `npm run docs:build` (组件开发脚手架) / `npm run build`（静态站点脚手架), 或 `npx dumi build` 即可对我们的文档站点做构建，构建产物默认会输出到 `dist` 目录下，我们可以将 `dist` 目录部署在 now.sh、GitHub Pages 等静态站点托管平台或者某台服务器上。
+执行 `npm run docs:build` (组件开发脚手架) / `npm run build`（静态站点脚手架), 或 `npx dumi build` 即可对我们的文档站点做构建，构建产物默认会输出到 `dist` 目录下，我们可以将 `dist` 目录部署在 Vercel、GitHub Pages 等静态站点托管平台或者某台服务器上。

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -258,7 +258,7 @@ export default (api) => {
       ) => {
         // implementation...
 
-        // output type refer: https://github.com/umijs/dumi/blob/master/packages/preset-dumi/src/transformer/remark/previewer/builtin.ts#L50
+        // output type refer: https://github.com/umijs/dumi/blob/1.x/packages/preset-dumi/src/transformer/remark/previewer/builtin.ts#L50
         return {
           // props for Previewer component
           previewerProps: {

--- a/docs/plugin/index.zh-CN.md
+++ b/docs/plugin/index.zh-CN.md
@@ -247,7 +247,7 @@ export default (api) => {
         opts,
       ) => {
         // 从其他技术栈工具中获取 demo 渲染需要的内容，例如 dev server 的产物地址等
-        // 出参类型参考：https://github.com/umijs/dumi/blob/master/packages/preset-dumi/src/transformer/remark/previewer/builtin.ts#L50
+        // 出参类型参考：https://github.com/umijs/dumi/blob/1.x/packages/preset-dumi/src/transformer/remark/previewer/builtin.ts#L50
         return {
           // 传递给主题预览组件 Previewer 的 props
           previewerProps: {

--- a/docs/theme/api.md
+++ b/docs/theme/api.md
@@ -11,7 +11,7 @@ In order to customize the theme, dumi provides a set of theme API, we can import
 
 You can get the configuration items of dumi, meta information of the current routing, international language options, etc.
 
-The detailed definition of context can be <a target="_blank" href="https://github.com/umijs/dumi/blob/master/packages/preset-dumi/src/theme/context.ts#L8">View source code</a>.
+The detailed definition of context can be <a target="_blank" href="https://github.com/umijs/dumi/blob/1.x/packages/preset-dumi/src/theme/context.ts#L8">View source code</a>.
 
 ## Link
 
@@ -76,7 +76,7 @@ export default props => {
 
 According to the configuration, automatically provide algolia's binding function or return the search results of the built-in search according to the keyword.
 
-For specific usage, please refer to the [SearchBar component](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/components/SearchBar.tsx#L9) of dumi built-in themes.
+For specific usage, please refer to the [SearchBar component](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/components/SearchBar.tsx#L9) of dumi built-in themes.
 
 ## useLocaleProps
 
@@ -87,7 +87,7 @@ For specific usage, please refer to the [SearchBar component](https://github.com
 
 Automatically filter and convert props according to locale to facilitate the realization of the internationalization of FrontMatter definitions. For example, `title.zh-CN` will be converted to `title` in Chinese language.
 
-For specific usage, please refer to the [Previewer component](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/builtins/Previewer.tsx#L72) of dumi built-in themes.
+For specific usage, please refer to the [Previewer component](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/builtins/Previewer.tsx#L72) of dumi built-in themes.
 
 ## useDemoUrl
 
@@ -101,7 +101,7 @@ Get the URL of the page that opened the demo separately. For example, `useDemoUr
 - **props:** `String`. The `identifier` parameter received by the subject `API` component, the unique identifier of the API
 - **return:** `Array`. Props property list
 
-To get the API metadata of the specified component, please refer to the [API component implementation](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/builtins/API.tsx) of the dumi default theme.
+To get the API metadata of the specified component, please refer to the [API component implementation](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/builtins/API.tsx) of the dumi default theme.
 
 ## useTSPlaygroundUrl
 

--- a/docs/theme/api.zh-CN.md
+++ b/docs/theme/api.zh-CN.md
@@ -9,7 +9,7 @@ toc: menu
 
 ## context
 
-可获取到 dumi 的配置项、当前路由的 meta 信息、国际化语言选择项等等，context 的详细定义可 <a target="_blank" href="https://github.com/umijs/dumi/blob/master/packages/preset-dumi/src/theme/context.ts#L8">查看源代码</a>
+可获取到 dumi 的配置项、当前路由的 meta 信息、国际化语言选择项等等，context 的详细定义可 <a target="_blank" href="https://github.com/umijs/dumi/blob/1.x/packages/preset-dumi/src/theme/context.ts#L8">查看源代码</a>
 
 ## Link
 
@@ -25,7 +25,7 @@ toc: menu
 
 ## useCodeSandbox
 
-- **参数：** 
+- **参数：**
   - opts：`Object`。主题 `Previewer` 组件接收到的 props
   - api：`String`。CodeSandbox创建 demo 时调用的API地址，默认值为`https://codesandbox.io/api/v1/sandboxes/define`
 - **返回：** `Function`。在 CodeSandbox.io 打开 demo 的执行函数
@@ -72,7 +72,7 @@ export default props => {
   - `Function`。如果用户开启 algolia，则返回 algolia 的绑定函数，将输入框的 CSS 选择器传入即可，后续筛选、呈现工作全部交给 algolia
   - `Array`。如果用户未开启 algolia，则返回基于关键字的内置搜索结果，目前只能搜索标题
 
-根据配置自动提供 algolia 的绑定函数或者根据关键字返回内置搜索的检索结果，具体用法可参考 dumi 内置主题的 [SearchBar 组件](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/components/SearchBar.tsx#L9)。
+根据配置自动提供 algolia 的绑定函数或者根据关键字返回内置搜索的检索结果，具体用法可参考 dumi 内置主题的 [SearchBar 组件](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/components/SearchBar.tsx#L9)。
 
 ## useLocaleProps
 
@@ -81,7 +81,7 @@ export default props => {
   - props：`Object`。需要过滤、转换的 props
 - **返回：** `Object`。过滤、转换之后的 props
 
-根据 locale 自动过滤、转换 props，便于实现国际化 FrontMatter 的定义，比如 `title.zh-CN` 在中文语言下会被转换为 `title`，具体示例可参考 dumi 内置主题的 [Previewer 组件](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/builtins/Previewer.tsx#L72)。
+根据 locale 自动过滤、转换 props，便于实现国际化 FrontMatter 的定义，比如 `title.zh-CN` 在中文语言下会被转换为 `title`，具体示例可参考 dumi 内置主题的 [Previewer 组件](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/builtins/Previewer.tsx#L72)。
 
 ## useDemoUrl
 
@@ -95,7 +95,7 @@ export default props => {
 - **参数：** `String`。主题 `API` 组件接收到的 `identifier` 参数，API 的唯一标识符
 - **返回：** `Array`。Props 属性列表
 
-获取指定组件的 API 元数据，可参考 dumi 默认主题的 [API 组件实现](https://github.com/umijs/dumi/blob/master/packages/theme-default/src/builtins/API.tsx)。
+获取指定组件的 API 元数据，可参考 dumi 默认主题的 [API 组件实现](https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/builtins/API.tsx)。
 
 ## useTSPlaygroundUrl
 

--- a/docs/theme/index.md
+++ b/docs/theme/index.md
@@ -9,13 +9,13 @@ nav:
 
 ## `dumi-theme-default`
 
-- **Code address:** [dumi/packages/theme-default](https://github.com/umijs/dumi/tree/master/packages/theme-default)
+- **Code address:** [dumi/packages/theme-default](https://github.com/umijs/dumi/tree/1.x/packages/theme-default)
 - **Experience address:** [dumi official website](https://d.umijs.org)
 - **Theme introduction:** Built-in themes of dumi
 
 ## `dumi-theme-mobile`
 
-- **Code address:** [dumi/packages/theme-mobile](https://github.com/umijs/dumi/tree/master/packages/theme-mobile)
+- **Code address:** [dumi/packages/theme-mobile](https://github.com/umijs/dumi/tree/1.x/packages/theme-mobile)
 - **Experience address:** (Missing)
 - **Theme introduction:** The mobile terminal research and development theme based on the dumi default theme extension It will have the following characteristics:
   1. Sticky mobile phone simulation container + iframe preview demo
@@ -46,7 +46,7 @@ export default {
         { maxWidth: 375, mode: 'vw', options: [100, 750] },
         { minWidth: 376, maxWidth: 750, mode: 'vw', options: [100, 1500] },
       ],
-      // More rule: https://github.com/umijs/dumi/blob/master/packages/theme-mobile/src/typings/config.d.ts#L7
+      // More rule: https://github.com/umijs/dumi/blob/1.x/packages/theme-mobile/src/typings/config.d.ts#L7
     }
   }
 }
@@ -67,4 +67,4 @@ Markdown content
 
 If you have created a good dumi theme and want to share it with everyone.
 
-Please send your theme information through Pull Request [to this document](https://github.com/umijs/dumi/edit/master/docs/theme/index.md).
+Please send your theme information through Pull Request [to this document](https://github.com/umijs/dumi/edit/1.x/docs/theme/index.md).

--- a/docs/theme/index.zh-CN.md
+++ b/docs/theme/index.zh-CN.md
@@ -9,13 +9,13 @@ nav:
 
 ## `dumi-theme-default`
 
-- **仓库地址：** [dumi/packages/theme-default](https://github.com/umijs/dumi/tree/master/packages/theme-default)
+- **仓库地址：** [dumi/packages/theme-default](https://github.com/umijs/dumi/tree/1.x/packages/theme-default)
 - **体验地址：** [dumi 官网](https://d.umijs.org)
 - **主题简介：** dumi 的内置主题
 
 ## `dumi-theme-mobile`
 
-- **仓库地址：** [dumi/packages/theme-mobile](https://github.com/umijs/dumi/tree/master/packages/theme-mobile)
+- **仓库地址：** [dumi/packages/theme-mobile](https://github.com/umijs/dumi/tree/1.x/packages/theme-mobile)
 - **体验地址：**（缺失）
 - **主题简介：** 基于 dumi 默认主题扩展的移动端研发主题，特性如下：
   1. sticky 手机模拟容器 + iframe 预览 demo
@@ -44,7 +44,7 @@ export default {
         { maxWidth: 375, mode: 'vw', options: [100, 750] },
         { minWidth: 376, maxWidth: 750, mode: 'vw', options: [100, 1500] },
       ],
-      // 更多 rule 配置访问 https://github.com/umijs/dumi/blob/master/packages/theme-mobile/src/typings/config.d.ts#L7
+      // 更多 rule 配置访问 https://github.com/umijs/dumi/blob/1.x/packages/theme-mobile/src/typings/config.d.ts#L7
     }
   }
 }
@@ -69,4 +69,4 @@ Markdown 正文
 
 ## 虚位以待
 
-如果你创建了不错的 dumi 主题、想分享给大家使用，请将你的主题信息通过 Pull Request [更新到此文档](https://github.com/umijs/dumi/edit/master/docs/theme/index.zh-CN.md)。
+如果你创建了不错的 dumi 主题、想分享给大家使用，请将你的主题信息通过 Pull Request [更新到此文档](https://github.com/umijs/dumi/edit/1.x/docs/theme/index.zh-CN.md)。

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/umijs/dumi.git"
+    "url": "git+https://github.com/umijs/dumi.git",
+    "branch": "1.x"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",

--- a/packages/assets-types/package.json
+++ b/packages/assets-types/package.json
@@ -8,11 +8,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/umijs/dumi",
-    "directory": "dumi"
+    "url": "https://github.com/umijs/dumi",
+    "branch": "1.x",
+    "directory": "packages/assets-types"
   },
-  "homepage": "http://github.com/umijs/dumi",
-  "bugs": "http://github.com/umijs/dumi/issues",
+  "homepage": "https://github.com/umijs/dumi/tree/1.x/packages/assets-types#readme",
+  "bugs": "https://github.com/umijs/dumi/issues",
   "authors": [
     "PeachScript <scdzwyxst@gmail.com> (https://github.com/PeachScript)"
   ],

--- a/packages/create-dumi-app/package.json
+++ b/packages/create-dumi-app/package.json
@@ -11,7 +11,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/dumi"
+    "url": "https://github.com/umijs/dumi",
+    "branch": "1.x",
+    "directory": "packages/create-dumi-app"
   },
   "keywords": [
     "dumi",
@@ -21,8 +23,8 @@
     "Peach <scdzwyxst@gmail.com> (https://github.com/PeachScript)"
   ],
   "license": "MIT",
-  "bugs": "http://github.com/umijs/dumi/issues",
-  "homepage": "https://github.com/umijs/dumi/tree/master/packages/create-dumi-app#readme",
+  "bugs": "https://github.com/umijs/dumi/issues",
+  "homepage": "https://github.com/umijs/dumi/tree/1.x/packages/create-dumi-app#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/create-dumi-lib/package.json
+++ b/packages/create-dumi-lib/package.json
@@ -11,7 +11,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/dumi"
+    "url": "https://github.com/umijs/dumi",
+    "branch": "1.x",
+    "directory": "packages/create-dumi-lib"
   },
   "keywords": [
     "dumi",
@@ -22,8 +24,8 @@
     "Peach <scdzwyxst@gmail.com> (https://github.com/PeachScript)"
   ],
   "license": "MIT",
-  "bugs": "http://github.com/umijs/dumi/issues",
-  "homepage": "https://github.com/umijs/dumi/tree/master/packages/create-dumi-lib#readme",
+  "bugs": "https://github.com/umijs/dumi/issues",
+  "homepage": "https://github.com/umijs/dumi/tree/1.x/packages/create-dumi-lib#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/dumi/package.json
+++ b/packages/dumi/package.json
@@ -14,11 +14,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/umijs/dumi",
-    "directory": "dumi"
+    "url": "https://github.com/umijs/dumi",
+    "branch": "1.x",
+    "directory": "packages/dumi"
   },
-  "homepage": "http://github.com/umijs/dumi",
-  "bugs": "http://github.com/umijs/dumi/issues",
+  "homepage": "https://github.com/umijs/dumi/tree/1.x/packages/dumi#readme",
+  "bugs": "https://github.com/umijs/dumi/issues",
   "authors": [
     "ycjcl868 <chaolinjin@gmail.com> (https://github.com/ycjcl868)",
     "PeachScript <scdzwyxst@gmail.com> (https://github.com/PeachScript)"

--- a/packages/preset-dumi/package.json
+++ b/packages/preset-dumi/package.json
@@ -8,11 +8,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/umijs/dumi",
-    "directory": "preset-dumi"
+    "url": "https://github.com/umijs/dumi",
+    "branch": "1.x",
+    "directory": "packages/preset-dumi"
   },
-  "homepage": "http://github.com/umijs/dumi",
-  "bugs": "http://github.com/umijs/dumi/issues",
+  "homepage": "https://github.com/umijs/dumi/tree/1.x/packages/preset-dumi#readme",
+  "bugs": "https://github.com/umijs/dumi/issues",
   "authors": [
     "ycjcl868 <chaolinjin@gmail.com> (https://github.com/ycjcl868)",
     "PeachScript <scdzwyxst@gmail.com> (https://github.com/PeachScript)"

--- a/packages/preset-dumi/src/plugins/features/theme.ts
+++ b/packages/preset-dumi/src/plugins/features/theme.ts
@@ -8,7 +8,7 @@ import { setOptions } from '../../context';
 // initialize data-prefers-color attr for HTML tag
 const COLOR_HEAD_SCP = `
 (function () {
-  var cache = localStorage.getItem('dumi:prefers-color');
+  var cache = navigator.cookieEnabled && typeof window.localStorage !== 'undefined' ? localStorage.getItem('dumi:prefers-color') : 'auto';
   var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   var enums = ['light', 'dark', 'auto'];
 

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -11,11 +11,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/umijs/dumi",
-    "directory": "dumi-theme-default"
+    "url": "https://github.com/umijs/dumi",
+    "branch": "1.x",
+    "directory": "packages/theme-default"
   },
-  "homepage": "http://github.com/umijs/dumi",
-  "bugs": "http://github.com/umijs/dumi/issues",
+  "homepage": "https://github.com/umijs/dumi/tree/1.x/packages/theme-default#readme",
+  "bugs": "https://github.com/umijs/dumi/issues",
   "authors": [],
   "dependencies": {
     "lodash.throttle": "^4.1.1",

--- a/packages/theme-mobile/package.json
+++ b/packages/theme-mobile/package.json
@@ -11,7 +11,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/dumi"
+    "url": "https://github.com/umijs/dumi",
+    "branch": "1.x",
+    "directory": "packages/theme-mobile"
   },
   "keywords": [
     "dumi",
@@ -22,8 +24,8 @@
     "xiaohuoni <448627663@qq.com> (https://github.com/xiaohuoni)"
   ],
   "license": "MIT",
-  "bugs": "http://github.com/umijs/dumi/issues",
-  "homepage": "https://github.com/umijs/dumi/tree/master/packages/theme-mobile#readme",
+  "bugs": "https://github.com/umijs/dumi/issues",
+  "homepage": "https://github.com/umijs/dumi/tree/1.x/packages/theme-mobile#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -41,7 +41,7 @@ const FILE_LIST = [
       // replace same page url
       { type: 'replace', value: [/https:\/\/umijs\.org\/zh-CN\/config/g, ''] },
       // replace @primary-color to @c-primary (dumi theme variables)
-      { type: 'replace', value: ["'@primary-color': '#1DA57A',", "// 修改 dumi 默认主题的主色，更多变量详见：https://github.com/umijs/dumi/blob/master/packages/theme-default/src/style/variables.less\n    '@c-primary': '#1DA57A',"] },
+      { type: 'replace', value: ["'@primary-color': '#1DA57A',", "// 修改 dumi 默认主题的主色，更多变量详见：https://github.com/umijs/dumi/blob/1.x/packages/theme-default/src/style/variables.less\n    '@c-primary': '#1DA57A',"] },
     ],
   },
 ];


### PR DESCRIPTION
codesandbox 自动引入React 判断时 只判断了的单引号的形式
导致打开 codeSandbox报错