### PR TITLE
fix: sanbox template import react is only acting on the double quotat…

### DIFF
--- a/packages/preset-dumi/src/theme/hooks/useCodeSandbox.ts
+++ b/packages/preset-dumi/src/theme/hooks/useCodeSandbox.ts
@@ -58,9 +58,12 @@ root.render(<App />);`;
  * @returns
  */
 const injectReact = (content: string) => {
-  if (content.includes("import React from 'react';")) {
+  const reg1 = /import React, \{.*\} from ['"]react['"];/i;
+  const reg2 = /import \{.*\}, React from ['"]react['"];/i;
+  if (content.includes("import React from 'react'") || content.includes(`import React from "react"`) || reg1.test(content) || reg2.test(content)) {
     return content;
   }
+
   return `import React from 'react';
 ${content}`;
 };


### PR DESCRIPTION
只能识别单引号的react引入。导致打开sandbox多引用了一次React
<img width="1085" alt="截屏2022-09-26 20 11 02" src="https://user-images.githubusercontent.com/63464198/192272934-5a5b1bd3-96e7-46cd-9292-2a8074c91b65.png">
<img width="922" alt="截屏2022-09-26 20 11 37" src="https://user-images.githubusercontent.com/63464198/192273050-12297caa-fc4e-46b5-80f7-3a1d32283167.png">
