### PR TITLE
fix(theme-mobile): layouts demo 组件在支持 touch 事件的浏览器中不再触发 TouchEmulator

### DIFF
--- a/packages/theme-mobile/src/layouts/demo.tsx
+++ b/packages/theme-mobile/src/layouts/demo.tsx
@@ -19,6 +19,8 @@ const HD_MODES = {
   vh,
 };
 
+const isSupportTouch = 'ontouchstart' in window;
+
 const MobileDemoLayout: React.FC<IRouteComponentProps> = ({ children }) => {
   const { config } = useContext(context);
   const target = useRef<HTMLDivElement>(null);
@@ -28,7 +30,7 @@ const MobileDemoLayout: React.FC<IRouteComponentProps> = ({ children }) => {
 
   useEffect(() => {
     // Simulate the touch event of mobile terminal
-    if (target.current) {
+    if (target.current && !isSupportTouch) {
       // fix https://github.com/umijs/dumi/issues/996
       TouchEmulator(document);
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
背景：在移动端会触发两次 touch 事件
解决方法：layouts demo 组件在支持 touch 事件的浏览器中不再触发 TouchEmulator
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
