### PR TITLE
fix: fix the prevIndexRef.current param the TypeError for undefined

### DIFF
--- a/src/client/theme-default/slots/Toc/index.tsx
+++ b/src/client/theme-default/slots/Toc/index.tsx
@@ -45,8 +45,8 @@ const Toc: FC = () => {
                 const link = `#${encodeURIComponent(item.id)}`;
                 const activeIndex =
                   currentElementIndexInViewport > -1
-                    ? currentElementIndexInViewport
-                    : prevIndexRef.current;
+                    ? prevIndexRef.current
+                    : currentElementIndexInViewport;
 
                 return (
                   <li key={item.id} data-depth={item.depth}>


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

修复`prevIndexRef.current`参数写反问题./ Fix the `prevIndexRef.current` param of writing backward problem.
- [ ] bug 修复 / Fix bug

### 🔗 相关 Issue / Related Issue

调试时，出现报错
```
Uncaught TypeError: Cannot read properties of undefined (reading 'current') 
```

### 💡 需求背景和解决方案 / Background or solution

修改参数的位置

### 📝 更新日志 / Changelog



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
