### PR TITLE
feat: localize page routes from .dumi/pages

### DIFF
--- a/src/features/routes.ts
+++ b/src/features/routes.ts
@@ -26,7 +26,7 @@ function localizeUmiRoute(route: IRoute, locales: IApi['config']['locales']) {
       // avoid locale id conflict with folder/file name
       path.parse(route.file).name.endsWith(`.${locale.id}`),
   );
-
+  
   if (locale) {
     // strip single `/` locale base or move `/` to the end of locale base for join
     const base =
@@ -145,6 +145,8 @@ export default (api: IApi) => {
       );
       // flat route
       flatRoute(route);
+      // localize route
+      localizeUmiRoute(route, api.config.locales);
       routes[route.id] = route;
     });
 

--- a/src/features/routes.ts
+++ b/src/features/routes.ts
@@ -26,7 +26,6 @@ function localizeUmiRoute(route: IRoute, locales: IApi['config']['locales']) {
       // avoid locale id conflict with folder/file name
       path.parse(route.file).name.endsWith(`.${locale.id}`),
   );
-  
   if (locale) {
     // strip single `/` locale base or move `/` to the end of locale base for join
     const base =


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
通过umi约定式路由生成的嵌套层级routes
在用户本地编写国际化路由Page时与编写Markdown国际化文件体验不一致
理想写法：✅
![image](https://user-images.githubusercontent.com/94534613/201290170-68f2ef2c-aedb-4056-a6a8-25b3878372cf.png)
实际写法：❌
![image](https://user-images.githubusercontent.com/94534613/201290411-959aa367-602f-46e0-ad2f-c39843de7d17.png)

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      localize page routes from .dumi/pages     |
| 🇨🇳 Chinese |     本地生成的UmiPage路由通过文件名语言后缀生成国际化路由      |
