### PR TITLE
fix: writeTmpFile content can't be empty

### DIFF
--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -150,7 +150,7 @@ export default (api: IApi) => {
     // write shadow theme files to tmp dir
     themeMapKeys.forEach((key) => {
       Object.values(originalThemeData[key] || {}).forEach((item) => {
-        let contents = [];
+        let contents = ['//EMPTY'];
         // parse exports for theme module
         const [, exports] = parseModuleSync({
           path: item.source,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
当content为空时
![image](https://user-images.githubusercontent.com/94534613/201469048-530bf905-8d49-44e2-ac35-fbb223ea1398.png)

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     writeTmpFile content can't be empty      |
| 🇨🇳 Chinese |      写入临时文件的时候content不能为空     |
