### PR TITLE
fix: monorepo下路由id生成规则不唯一

### DIFF
--- a/src/features/routes.ts
+++ b/src/features/routes.ts
@@ -209,7 +209,7 @@ export default (api: IApi) => {
           // like umi standard route
           // ref: https://github.com/umijs/umi/blob/cabb186057d801494340f533195b6b330e5ef4e0/packages/core/src/route/routesConvention.ts#L88
           .replace(/\./g, '/');
-        const routeId = createRouteId(file);
+        const routeId = createRouteId(winPath(path.join(plural(type), file)));
 
         routes[routeId] = {
           id: routeId,

--- a/src/features/routes.ts
+++ b/src/features/routes.ts
@@ -204,12 +204,13 @@ export default (api: IApi) => {
       );
 
       atomFiles.forEach((file) => {
-        const routePath = winPath(path.join(plural(type), file))
+        const routeFile = winPath(path.join(plural(type), file));
+        const routePath = routeFile
           .replace(/(\/index|\/README)?\.md$/, '')
           // like umi standard route
           // ref: https://github.com/umijs/umi/blob/cabb186057d801494340f533195b6b330e5ef4e0/packages/core/src/route/routesConvention.ts#L88
           .replace(/\./g, '/');
-        const routeId = createRouteId(winPath(path.join(plural(type), file)));
+        const routeId = createRouteId(routeFile);
 
         routes[routeId] = {
           id: routeId,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

1.路由id生成规则感觉有点问题，在Monorepo使用下，如果我每个包下面都有一个index.md，就只会出现一个。
![201286086-e4b57574-12b1-468b-94e7-55ad73c67895](https://user-images.githubusercontent.com/18420689/201612819-f55ea5a2-f6ad-4d93-abc4-56f1356fb83d.jpeg)
2.ID加上包type
<img width="916" alt="201286687-f278bd2c-bfd2-43f2-a0c4-25b46ba1a910" src="https://user-images.githubusercontent.com/18420689/201612966-96fad133-2a3b-42f4-8bc6-05ab6283dba0.png">

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
