### PR TITLE
feat(theme): feat default theme toc module support

### DIFF
--- a/src/client/theme-default/layouts/DemoTabs/index.less
+++ b/src/client/theme-default/layouts/DemoTabs/index.less
@@ -1,0 +1,51 @@
+@import (reference) '../../styles/variables.less';
+
+.@{prefix}-doc-tabs {
+  position: fixed;
+  top: 114px;
+  max-height: calc(90vh - 144px);
+  list-style: none;
+  z-index: 10;
+  right: 0;
+  width: 136px;
+  margin: 0;
+  padding: 0 24px 0 0;
+  background-color: transparent;
+  box-sizing: content-box;
+  overflow: auto;
+
+  li {
+    position: relative;
+    margin: 0;
+    padding: 4px 0 4px 6px;
+    text-indent: 12px;
+    font-size: 13px;
+    line-height: 1.40625;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    a {
+      color: #454d64;
+      text-decoration: none;
+      cursor: pointer;
+
+      &:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        display: inline-block;
+        width: 2px;
+        background: #ebedf1;
+      }
+    }
+    .active {
+      color: #4569d4;
+
+      &:before {
+        background: #4569d4;
+      }
+    }
+  }
+}

--- a/src/client/theme-default/layouts/DemoTabs/index.tsx
+++ b/src/client/theme-default/layouts/DemoTabs/index.tsx
@@ -1,0 +1,97 @@
+import React, { useState, useEffect } from 'react';
+import { useRouteMeta } from 'dumi';
+import './index.less';
+
+export default function DemoTabs() {
+  const [activedId, setActivedId] = useState('');
+
+  const { toc } = useRouteMeta();
+
+  const onSyncAffix = () => {
+    const { scrollY } = window;
+    const apiDoms = Array.from(document.querySelectorAll('h2[id]')).map(({ id }) => id);
+
+    for (let i = 0; i < apiDoms.length; i++) {
+      const current = document.getElementById(apiDoms[i]);
+      // 元素在当前页面的位置，负数则表示已经滚过
+      if (current) {
+        const currentInNowPageY = current?.offsetTop - scrollY;
+        if (currentInNowPageY >= 0) {
+          setActivedId(apiDoms[i]);
+          return;
+        }
+      }
+    }
+  };
+
+  const isInViewport = (dom) => {
+    // 兼容写法
+    let viewPortHeight = window.innerHeight || document.documentElement.clientHeight;
+    let viewPortWidth = window.innerWidth || document.documentElement.clientWidth;
+    let { top, left, bottom, right } = dom.getBoundingClientRect();
+
+    // 返回元素是否在视口内、元素距离视窗顶部距离
+    return {
+      res: top >= 0 && left >= 0 && bottom <= viewPortHeight && right <= viewPortWidth,
+      top,
+    };
+  };
+
+  const scrollToId = (id: string) => {
+    const clickNode = document.getElementById(id);
+
+    if (clickNode) {
+      const scrollTop = clickNode.offsetTop;
+      const htmlNode = document.documentElement;
+      let beforeTop;
+
+      function scroll() {
+        const nowTop = window.scrollY;
+        const { res, top } = isInViewport(clickNode);
+        // 元素出现在视口内，并且顶部距离符合条件
+        if (res && top > 0 && top < 80) {
+          return;
+        }
+        if (scrollTop > nowTop) {
+          htmlNode.scrollTop += 80;
+        } else {
+          htmlNode.scrollTop -= 80;
+        }
+        // 保存上一次状态，防止滚动到底部时，scrollTop不变，重复执行scroll
+        beforeTop = htmlNode.scrollTop;
+        if (nowTop === beforeTop) return;
+        window.requestAnimationFrame(scroll);
+      }
+      window.requestAnimationFrame(scroll);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', onSyncAffix);
+    window.addEventListener('resize', onSyncAffix);
+    onSyncAffix();
+
+    return () => {
+      window.removeEventListener('scroll', onSyncAffix);
+      window.removeEventListener('resize', onSyncAffix);
+    };
+  });
+
+  return (
+    <ul className="dumi-default-doc-tabs">
+      {toc.slice(1).map(({ id }) => {
+        return (
+          <li key={id}>
+            <a
+              className={id === activedId ? 'active' : ''}
+              onClick={() => scrollToId(id)}
+              aria-current="page"
+            >
+              <span>{id}</span>
+            </a>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [x] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 💡 需求背景和解决方案 / Background or solution

从dumi1.x 迁移到 dumi2.x，原来markdown右上角的toc不支持了，个人觉得这个还是蛮通用的，所以加在了默认主题里。

![image](https://user-images.githubusercontent.com/78004597/202912877-dbb5eb33-ce1b-4005-8023-4e12740777fe.png)


