### PR TITLE
fix: hidden below text baseline

### DIFF
--- a/src/client/theme-default/slots/Sidebar/index.less
+++ b/src/client/theme-default/slots/Sidebar/index.less
@@ -50,10 +50,11 @@
 
     > dd {
       margin: 0;
-      padding: 10px 0;
+      padding: 8px 0 10px;
 
       > a {
         display: block;
+        height: 18px;
         color: @c-text-secondary;
         font-size: 16px;
         text-decoration: none;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [x] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
Sidebar标题文字基线一下部分被隐藏
before:
![image](https://user-images.githubusercontent.com/38075730/203932596-39e652c0-fced-4530-9e81-340af932911e.png)


### 💡 需求背景和解决方案 / Background or solution

为<a>设置高度，同时减少padding-top，力求修改后与原样差异最小，不知道有无更好的解决办法
after:
![image](https://user-images.githubusercontent.com/38075730/203933366-0278c81a-0157-4aa9-a860-86c36601b285.png)

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: hidden below text baseline |
| 🇨🇳 Chinese | 修复文学基线以下部分被隐藏 |
