### PR TITLE
fix: non-mobile projects do not expand source code display by default

### DIFF
--- a/src/client/theme-default/slots/PreviewerActions/index.tsx
+++ b/src/client/theme-default/slots/PreviewerActions/index.tsx
@@ -46,7 +46,7 @@ const PreviewerActions: FC<IPreviewerActionsProps> = (props) => {
     ([, { type }]) => type === 'FILE',
   );
   const [activeKey, setActiveKey] = useState(0);
-  const [showCode, setShowCode] = useState(!props?.forceShowCode);
+  const [showCode, setShowCode] = useState(props?.forceShowCode);
   const isSingleFile = files.length === 1;
   const lang = (files[activeKey][0].match(/\.([^.]+)$/)?.[1] || 'text') as any;
 
@@ -103,7 +103,7 @@ const PreviewerActions: FC<IPreviewerActionsProps> = (props) => {
           </a>
         )}
         <PreviewerActionsExtra {...props} />
-        {props?.forceShowCode && (
+        {!props?.forceShowCode && (
           <button
             className="dumi-default-previewer-action-btn"
             type="button"

--- a/suites/theme-mobile/src/builtins/Previewer/index.tsx
+++ b/suites/theme-mobile/src/builtins/Previewer/index.tsx
@@ -30,7 +30,7 @@ const MobilePreviewer: FC<IPreviewerProps> = (props) => {
       demoUrl={demoUrl}
       iframe={mobile ? false : props?.iframe}
       className={mobile ? 'dumi-mobile-previewer' : undefined}
-      forceShowCode={!mobile}
+      forceShowCode={mobile}
       style={{
         '--device-width': themeConfig.deviceWidth
           ? `${themeConfig.deviceWidth}px`


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?
非 mobile 项目默认不展开源代码显示
- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
