### PR TITLE
fix: don't make svg a target for mouse events

### DIFF
--- a/src/client/theme-default/builtins/SourceCode/index.less
+++ b/src/client/theme-default/builtins/SourceCode/index.less
@@ -39,6 +39,7 @@
       width: 16px;
       fill: darken(@c-border, 20%);
       transition: fill 0.2s;
+      pointer-events: none;
     }
 
     &:hover > svg {

--- a/src/client/theme-default/slots/PreviewerActions/index.less
+++ b/src/client/theme-default/slots/PreviewerActions/index.less
@@ -28,6 +28,7 @@
       width: 16px;
       fill: darken(@c-border, 20%);
       transition: fill 0.2s;
+      pointer-events: none;
     }
 
     &:hover > svg {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [x] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
Previewer 的 actions 部分和复制代码的按钮，不让其内部的SVG成为鼠标事件的目标。
场景：存在通过监听这些按钮的触发，进行埋点上报的情况
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
