### PR TITLE
fix: mfsu support pass true to use default mfsu config

### DIFF
--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -151,6 +151,9 @@ export default (api: IApi) => {
   });
 
   api.modifyConfig((memo) => {
+    if (api.userConfig.mfsu === true) {
+      memo.mfsu = {};
+    }
     if (api.userConfig.alias?.['@']) {
       // respect user @ alias
       // because dumi force to use .dumi as absSrcPath for move all conventional

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,10 @@ let unistUtilVisit: typeof import('unist-util-visit');
 
 export * from 'umi';
 export { unistUtilVisit };
-export const defineConfig = (config: IDumiUserConfig) => config;
+export const defineConfig = (config: IDumiUserConfig) => {
+  // delete the mfsu prop from config to use default mfsu config when pass ture
+  if (config.mfsu === true) {
+    delete config.mfsu;
+  }
+  return config;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,4 @@ let unistUtilVisit: typeof import('unist-util-visit');
 
 export * from 'umi';
 export { unistUtilVisit };
-export const defineConfig = (config: IDumiUserConfig) => {
-  // delete the mfsu prop from config to use default mfsu config when pass ture
-  if (config.mfsu === true) {
-    delete config.mfsu;
-  }
-  return config;
-};
+export const defineConfig = (config: IDumiUserConfig) => config;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [X] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<img width="1594" alt="image" src="https://user-images.githubusercontent.com/10286961/212851917-244d68dc-d734-4e2d-9fe6-bacb78e1c145.png">

解决当`mfsu`传入`true`时，`dumi`报错无法正常工作的问题

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | mfsu support pass true to use default mfsu config |
| 🇨🇳 Chinese |  mfsu 支持传入 true 以使用默认 mfsu 配置  |
