### PR TITLE
fix: codesanbox react not found

### DIFF
--- a/src/client/theme-api/openCodeSandbox.ts
+++ b/src/client/theme-api/openCodeSandbox.ts
@@ -42,7 +42,7 @@ function getCSBData(opts: IPreviewerProps) {
   files['sandbox.config.json'] = {
     content: JSON.stringify(
       {
-        template: isTSX ? 'create-react-app-typescript' : 'create-react-app',
+        template: 'create-react-app',
       },
       null,
       2,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

### 💡 需求背景和解决方案 / Background or solution

如果 `tsx` 组件示例没引入 react，codesandbox 预览不会自动导入 react，而 `jsx` 组件示例会导入。原因是 codesandbox 的 [`create-react-app-typescript`](https://github.com/wmonk/create-react-app-typescript) 模板很久就已经不维护了。

而 `create-react-app` 模板已经支持 `tsx` 了，所以可以直接用 `create-react-app` 了。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix codesandbox can't auto import react |
| 🇨🇳 Chinese | 修复 codesandbox 预览不能自动导入 react 的问题 |
