### PR TITLE
fix: disable preview globally

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -15,6 +15,9 @@ export default defineConfig({
 <br />
 Powered by self`,
     prefersColor: { default: 'auto' },
+    preview: {
+      disabledActions: ['CSB', 'STACKBLITZ', 'STACKBLITZ', 'EXTERNAL'],
+    },
   },
   ...(process.env.NODE_ENV === 'development' ? {} : { ssr: {} }),
   sitemap: { hostname: 'https://d.umijs.org' },

--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -15,9 +15,6 @@ export default defineConfig({
 <br />
 Powered by self`,
     prefersColor: { default: 'auto' },
-    preview: {
-      disabledActions: ['CSB', 'STACKBLITZ', 'STACKBLITZ', 'EXTERNAL'],
-    },
   },
   ...(process.env.NODE_ENV === 'development' ? {} : { ssr: {} }),
   sitemap: { hostname: 'https://d.umijs.org' },

--- a/src/client/theme-api/types.ts
+++ b/src/client/theme-api/types.ts
@@ -170,7 +170,12 @@ export interface IThemeConfig {
     default: 'light' | 'dark' | 'auto';
     switch: boolean;
   };
+  preview?: IPreviewConfig;
   [key: string]: any;
+}
+
+export interface IPreviewConfig {
+  disabledActions?: ('CSB' | 'CODEPEN' | 'STACKBLITZ' | 'EXTERNAL')[];
 }
 
 export type IRoutesById = Record<

--- a/src/client/theme-default/slots/PreviewerActions/index.tsx
+++ b/src/client/theme-default/slots/PreviewerActions/index.tsx
@@ -1,10 +1,12 @@
 import { ReactComponent as IconCodeSandbox } from '@ant-design/icons-svg/inline-svg/outlined/code-sandbox.svg';
 // import { ReactComponent as IconCodePen } from '@ant-design/icons-svg/inline-svg/outlined/codepen.svg';
+import { type IPreviewConfig } from '@/client/theme-api/types';
 import { ReactComponent as IconStackBlitz } from '@ant-design/icons-svg/inline-svg/outlined/thunderbolt.svg';
 import {
   openCodeSandbox,
   openStackBlitz,
   useIntl,
+  useSiteData,
   type IPreviewerProps,
 } from 'dumi';
 import SourceCode from 'dumi/theme/builtins/SourceCode';
@@ -17,7 +19,7 @@ export interface IPreviewerActionsProps extends IPreviewerProps {
   /**
    * disabled actions
    */
-  disabledActions?: ('CSB' | 'CODEPEN' | 'STACKBLITZ' | 'EXTERNAL')[];
+  disabledActions?: IPreviewConfig['disabledActions'];
   forceShowCode?: boolean;
 }
 
@@ -52,10 +54,14 @@ const PreviewerActions: FC<IPreviewerActionsProps> = (props) => {
   const isSingleFile = files.length === 1;
   const lang = (files[activeKey][0].match(/\.([^.]+)$/)?.[1] || 'text') as any;
 
+  const { themeConfig } = useSiteData();
+  const disabledActions =
+    props.disabledActions || themeConfig.preview?.disabledActions || [];
+
   return (
     <>
       <div className="dumi-default-previewer-actions">
-        {!props.disabledActions?.includes('CSB') && (
+        {!disabledActions.includes('CSB') && (
           <button
             className="dumi-default-previewer-action-btn"
             type="button"
@@ -67,7 +73,7 @@ const PreviewerActions: FC<IPreviewerActionsProps> = (props) => {
             <IconCodeSandbox />
           </button>
         )}
-        {/* {!props.disabledActions?.includes('CODEPEN') && (
+        {/* {!disabledActions.includes('CODEPEN') && (
           <button
             className="dumi-default-previewer-action-btn"
             type="button"
@@ -78,7 +84,7 @@ const PreviewerActions: FC<IPreviewerActionsProps> = (props) => {
             <IconCodePen />
           </button>
         )} */}
-        {!props.disabledActions?.includes('STACKBLITZ') && (
+        {!disabledActions.includes('STACKBLITZ') && (
           <button
             className="dumi-default-previewer-action-btn"
             type="button"
@@ -91,7 +97,7 @@ const PreviewerActions: FC<IPreviewerActionsProps> = (props) => {
           </button>
         )}
 
-        {!props.disabledActions?.includes('EXTERNAL') && (
+        {!disabledActions.includes('EXTERNAL') && (
           <a
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

我的组件库的 stackblitz 演示全挂掉了（不是 dumi 的原因），所以想全局禁用 stackblitz 的演示

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support ban preview action globally |
| 🇨🇳 Chinese | 支持全局禁用 preview action |
