### PR TITLE
fix: cmd & plugin hook bugs caused by parser worker thread

### DIFF
--- a/src/assetParsers/atom.ts
+++ b/src/assetParsers/atom.ts
@@ -179,7 +179,7 @@ class AtomAssetsParser {
     this.cbs.splice(this.cbs.indexOf(cb), 1);
   }
 
-  destroy() {
+  destroyWorker() {
     // wait for current parse finished
     if (this.parseDeferrer) {
       this.parseDeferrer.finally(() => this.parser.$$destroyWorker());

--- a/src/assetParsers/atom.ts
+++ b/src/assetParsers/atom.ts
@@ -180,8 +180,12 @@ class AtomAssetsParser {
   }
 
   destroy() {
-    this.resolver?.$$destroyWorker();
-    this.parser.$$destroyWorker();
+    // wait for current parse finished
+    if (this.parseDeferrer) {
+      this.parseDeferrer.finally(() => this.parser.$$destroyWorker());
+    } else {
+      this.parser.$$destroyWorker();
+    }
   }
 }
 

--- a/src/assetParsers/atom.ts
+++ b/src/assetParsers/atom.ts
@@ -12,7 +12,7 @@ class AtomAssetsParser {
   private resolveDir: string;
   private unresolvedFiles: string[] = [];
   private parser: SchemaParser;
-  private resolver: SchemaResolver | undefined;
+  private isParsing = false;
   private parseDeferrer:
     | Promise<{
         components: Record<string, AtomComponentAsset>;
@@ -50,9 +50,13 @@ class AtomAssetsParser {
   }
 
   async parse() {
-    // to avoid parse multiple times
+    // use cache first, and only one parse task can be running at the same time
     // FIXME: result may outdated
-    if (!this.parseDeferrer) {
+    if (
+      !this.parseDeferrer ||
+      (this.unresolvedFiles.length && !this.isParsing)
+    ) {
+      this.isParsing = true;
       this.parseDeferrer = (async () => {
         // patch unresolved files, and this method also will init parser before the first time
         await this.parser.patch(this.unresolvedFiles.splice(0));
@@ -61,7 +65,6 @@ class AtomAssetsParser {
         const resolver = new SchemaResolver(await this.parser.parse(), {
           mode: 'worker',
         });
-        this.resolver = resolver;
 
         // parse atoms from resolver
         const result: Awaited<NonNullable<AtomAssetsParser['parseDeferrer']>> =
@@ -126,15 +129,12 @@ class AtomAssetsParser {
           };
         }
 
+        // reset status after parse finished
+        resolver.$$destroyWorker();
+        this.isParsing = false;
+
         return result;
       })();
-
-      // reset deferred after parse finished
-      this.parseDeferrer.finally(() => {
-        this.resolver?.$$destroyWorker();
-        this.resolver = undefined;
-        this.parseDeferrer = undefined;
-      });
     }
 
     return this.parseDeferrer;

--- a/src/features/parser.ts
+++ b/src/features/parser.ts
@@ -41,10 +41,14 @@ export default (api: IApi) => {
   });
 
   // share parser with other plugins via service
-  api.onStart(async () => {
+  // why use `onCheckPkgJSON` instead of `onStart`?
+  // because `onStart` will be called before any commands
+  // and `onCheckPkgJson` only be called in dev and build
+  api.onCheckPkgJSON(async () => {
     const {
       default: AtomAssetsParser,
     }: typeof import('@/assetParsers/atom') = require('@/assetParsers/atom');
+
     api.service.atomParser = new AtomAssetsParser({
       entryFile: api.config.resolve.entryFile!,
       resolveDir: api.cwd,

--- a/src/features/parser.ts
+++ b/src/features/parser.ts
@@ -67,10 +67,17 @@ export default (api: IApi) => {
     if (api.env === 'production') {
       // sync parse in production
       writeAtomsMetaFile(await api.service.atomParser.parse());
-      api.service.atomParser.destroy();
     } else if (prevData) {
       // also write prev data when re-generate files in development
       writeAtomsMetaFile(prevData);
     }
+  });
+
+  // destroy parser worker after build complete
+  api.onBuildComplete({
+    stage: Infinity,
+    fn() {
+      api.service.atomParser.destroyWorker();
+    },
   });
 };


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复 api parser 挪到子线程执行以后的两个问题：

1. 非 `dev/build` 命令执行时挂起的问题，因为在不需要的情况下创建了 parser，导致子线程一直挂起、命令不会终止
2. `assets.json` 生成失败，因为 parser 的子线程被过早销毁，导致后续命令执行中断

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix command & plugin hook bugs that casued by api parser worker thread  |
| 🇨🇳 Chinese | 修复 API 解析器子线程引发的命令执行 bug 和插件 hook 执行 bug |
