### PR TITLE
feat: nav 配置支持追加模式配置导航

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /examples/*/.dumi/tmp
 /examples/*/.dumi/tmp-production
 /docs/.upstream
+.idea

--- a/docs/theme/default.md
+++ b/docs/theme/default.md
@@ -32,7 +32,8 @@ dumi 内置了一套完善的默认主题，默认主题的呈现效果与 dumi 
 
 ### nav
 
-- 类型：`{ title: '导航标题', link: '导航路由' }[] | Record<string, { title: '导航标题', link: '导航路由' }[]>`
+- `Navs`类型：`{ title: '导航标题', link: '导航路由' }[] | Record<string, { title: '导航标题', link: '导航路由' }[]>`
+- 类型：`Navs | {mode: "override" | "append" | "prepend", value: Navs}`
 - 默认值：`约定式导航`
 
 配置导航栏上的导航项，不配置时默认为约定式导航。约定式导航生成规则可参考 [约定式路由](/guide/conventional-routing)。
@@ -47,6 +48,16 @@ dumi 内置了一套完善的默认主题，默认主题的呈现效果与 dumi 
     'zh-CN': [{ title: '博客', link: '/blog' }],
     'en-US': [{ title: 'Blog', link: '/en/blog' }],
   },
+
+  // 支持通过 nav 将路由追加到约定路由前面或后面
+  nav: {
+    // mode可选值有：override、append、prepend
+    // - override: 直接覆盖约定导航，与 nav: [{ title: 'Blog', link: '/blog' }] 配置相同
+    // - append: 将 value 中的导航追加到约定路由后面
+    // - prepend: 将 value 中的导航添加到约定路由前面
+    mode: "append",
+    value: [{ title: 'Blog', link: '/blog' }]
+  }
 }
 ```
 

--- a/src/client/theme-api/types.ts
+++ b/src/client/theme-api/types.ts
@@ -168,14 +168,13 @@ export type SocialTypes =
   | 'yuque'
   | 'linkedin';
 
-export type IUserNavItem = Pick<INavItem, 'title' | 'link'>;
 export type INavItems = (INavItem & { children?: INavItem[] })[];
-export type INavs = INavItems | Record<string, INavItems>;
+export type INav = INavItems | Record<string, INavItems>;
+type IUserNavItem = Pick<INavItem, 'title' | 'link'>;
 export type IUserNavMode = 'override' | 'append' | 'prepend';
-type IUserNavItems = (IUserNavItem & { children?: IUserNavItem[] })[];
-type IUserNavValue = IUserNavItems | Record<string, IUserNavItems>;
-
-export type NavsWithMode<T extends INavs | IUserNavValue> = {
+export type IUserNavItems = (IUserNavItem & { children?: IUserNavItem[] })[];
+export type IUserNavValue = IUserNavItems | Record<string, IUserNavItems>;
+export type NavWithMode<T extends IUserNavValue> = {
   /**
    * 扩展导航的模式
    * @description
@@ -190,7 +189,7 @@ export type NavsWithMode<T extends INavs | IUserNavValue> = {
 export interface IThemeConfig {
   name?: string;
   logo?: string | false;
-  nav?: IUserNavValue | NavsWithMode<IUserNavValue>;
+  nav?: IUserNavValue | NavWithMode<IUserNavValue>;
   sidebar?: Record<string, ISidebarGroup[]>;
   footer?: string | false;
   prefersColor: {

--- a/src/client/theme-api/types.ts
+++ b/src/client/theme-api/types.ts
@@ -167,12 +167,29 @@ export type SocialTypes =
   | 'zhihu'
   | 'yuque'
   | 'linkedin';
+
+export type IUserNavItem = Omit<INavItem, 'order'>;
+export type UserNavItems = (IUserNavItem & { children?: IUserNavItem[] })[];
+export type UserNavs = IUserNavItem | Record<string, IUserNavItem>;
+export type NavItems = (INavItem & { children?: INavItem[] })[];
+export type Navs = NavItems | Record<string, NavItems>;
+
+export type NavsWithMode<T> = {
+  /**
+   * 扩展导航的模式
+   * @description
+   * - 'override': 用 value 中配置的导航直接覆盖约定路由的导航
+   * - 'append': 将 value 中配置的导航追加到约定路由导航后面
+   * - 'prepend': 将 value 中配置的导航添加到约定路由导航前面
+   */
+  mode: 'override' | 'append' | 'prepend';
+  value: T;
+};
+
 export interface IThemeConfig {
   name?: string;
   logo?: string | false;
-  nav?:
-    | (INavItem & { children?: INavItem[] })[]
-    | Record<string, (INavItem & { children?: INavItem[] })[]>;
+  nav?: UserNavs | NavsWithMode<UserNavs>;
   sidebar?: Record<string, ISidebarGroup[]>;
   footer?: string | false;
   prefersColor: {

--- a/src/client/theme-api/types.ts
+++ b/src/client/theme-api/types.ts
@@ -168,13 +168,13 @@ export type SocialTypes =
   | 'yuque'
   | 'linkedin';
 
-export type IUserNavItem = Omit<INavItem, 'order'>;
-export type UserNavItems = (IUserNavItem & { children?: IUserNavItem[] })[];
-export type UserNavs = IUserNavItem | Record<string, IUserNavItem>;
-export type NavItems = (INavItem & { children?: INavItem[] })[];
-export type Navs = NavItems | Record<string, NavItems>;
+export type IUserNavItem = Pick<INavItem, 'title' | 'link'>;
+export type INavItems = (INavItem & { children?: INavItem[] })[];
+export type INavs = INavItems | Record<string, INavItems>;
+type IUserNavItems = (IUserNavItem & { children?: IUserNavItem[] })[];
+type IUserNavs = IUserNavItems | Record<string, IUserNavItems>;
 
-export type NavsWithMode<T> = {
+export type NavsWithMode<T extends INavs | IUserNavs> = {
   /**
    * 扩展导航的模式
    * @description
@@ -189,7 +189,7 @@ export type NavsWithMode<T> = {
 export interface IThemeConfig {
   name?: string;
   logo?: string | false;
-  nav?: UserNavs | NavsWithMode<UserNavs>;
+  nav?: IUserNavs | NavsWithMode<IUserNavs>;
   sidebar?: Record<string, ISidebarGroup[]>;
   footer?: string | false;
   prefersColor: {

--- a/src/client/theme-api/types.ts
+++ b/src/client/theme-api/types.ts
@@ -171,10 +171,11 @@ export type SocialTypes =
 export type IUserNavItem = Pick<INavItem, 'title' | 'link'>;
 export type INavItems = (INavItem & { children?: INavItem[] })[];
 export type INavs = INavItems | Record<string, INavItems>;
+export type IUserNavMode = 'override' | 'append' | 'prepend';
 type IUserNavItems = (IUserNavItem & { children?: IUserNavItem[] })[];
-type IUserNavs = IUserNavItems | Record<string, IUserNavItems>;
+type IUserNavValue = IUserNavItems | Record<string, IUserNavItems>;
 
-export type NavsWithMode<T extends INavs | IUserNavs> = {
+export type NavsWithMode<T extends INavs | IUserNavValue> = {
   /**
    * 扩展导航的模式
    * @description
@@ -182,14 +183,14 @@ export type NavsWithMode<T extends INavs | IUserNavs> = {
    * - 'append': 将 value 中配置的导航追加到约定路由导航后面
    * - 'prepend': 将 value 中配置的导航添加到约定路由导航前面
    */
-  mode: 'override' | 'append' | 'prepend';
+  mode: IUserNavMode;
   value: T;
 };
 
 export interface IThemeConfig {
   name?: string;
   logo?: string | false;
-  nav?: IUserNavs | NavsWithMode<IUserNavs>;
+  nav?: IUserNavValue | NavsWithMode<IUserNavValue>;
   sidebar?: Record<string, ISidebarGroup[]>;
   footer?: string | false;
   prefersColor: {

--- a/src/client/theme-api/useNavData.ts
+++ b/src/client/theme-api/useNavData.ts
@@ -32,11 +32,6 @@ export const useNavData = () => {
         nav = themeConfig.nav as Navs;
       }
       customNav = resolveNav(nav, locale);
-      if (customNav.find((item) => item.order !== undefined)) {
-        console.warn(
-          `order is no longer support now, you can adjust the order of nav to achieve the same effect`,
-        );
-      }
       if (mode === 'override') return customNav;
     }
 

--- a/src/client/theme-api/useNavData.ts
+++ b/src/client/theme-api/useNavData.ts
@@ -65,12 +65,8 @@ export const useNavData = () => {
           : data),
       ].sort(sidebarDataComparer);
     if (mode === 'prepend')
-      return customNav
-        .sort(sidebarDataComparer)
-        .concat(data.sort(sidebarDataComparer));
-    return data
-      .sort(sidebarDataComparer)
-      .concat(customNav.sort(sidebarDataComparer));
+      return customNav.concat(data.sort(sidebarDataComparer));
+    return data.sort(sidebarDataComparer).concat(customNav);
   });
 
   return nav;

--- a/src/client/theme-api/useNavData.ts
+++ b/src/client/theme-api/useNavData.ts
@@ -1,6 +1,6 @@
 import { useFullSidebarData, useLocale, useSiteData } from 'dumi';
 import { useState } from 'react';
-import type { INav, IThemeConfig, IUserNavItems, NavWithMode } from './types';
+import type { IThemeConfig, IUserNavItems, IUserNavMode } from './types';
 import {
   getLocaleNav,
   pickRouteSortMeta,
@@ -22,20 +22,19 @@ export const useNavData = () => {
   const [nav] = useState<INavData>(() => {
     // use user config first
     let userNavValue: IUserNavItems = [];
-    let mode: NavWithMode<INav>['mode'] | undefined;
+    let mode: IUserNavMode | undefined;
     if (themeConfig.nav) {
-      let value;
       // 形如：{mode: "append", value: []}
       if (
         'mode' in themeConfig.nav &&
         typeof themeConfig.nav.mode === 'string'
       ) {
         mode = themeConfig.nav.mode;
-        value = themeConfig.nav.value;
+        const value = themeConfig.nav.value;
         userNavValue = getLocaleNav(value, locale);
       } else if (!('mode' in themeConfig.nav)) {
         // 形如：[] 或 {"zh-CN": []}
-        value = themeConfig.nav;
+        const value = themeConfig.nav;
         userNavValue = getLocaleNav(value, locale);
       }
       if (!mode || mode === 'override') return userNavValue;

--- a/src/client/theme-api/useNavData.ts
+++ b/src/client/theme-api/useNavData.ts
@@ -30,12 +30,10 @@ export const useNavData = () => {
         typeof themeConfig.nav.mode === 'string'
       ) {
         mode = themeConfig.nav.mode;
-        const value = themeConfig.nav.value;
-        userNavValue = getLocaleNav(value, locale);
+        userNavValue = getLocaleNav(themeConfig.nav.value, locale);
       } else if (!('mode' in themeConfig.nav)) {
         // 形如：[] 或 {"zh-CN": []}
-        const value = themeConfig.nav;
-        userNavValue = getLocaleNav(value, locale);
+        userNavValue = getLocaleNav(themeConfig.nav, locale);
       }
       if (!mode || mode === 'override') return userNavValue;
     }

--- a/src/client/theme-api/useNavData.ts
+++ b/src/client/theme-api/useNavData.ts
@@ -1,6 +1,6 @@
 import { useFullSidebarData, useLocale, useSiteData } from 'dumi';
 import { useState } from 'react';
-import type { INavItems, INavs, NavsWithMode } from './types';
+import type { INav, IThemeConfig, IUserNavItems, NavWithMode } from './types';
 import {
   getLocaleNav,
   pickRouteSortMeta,
@@ -8,7 +8,7 @@ import {
   useRouteDataComparer,
 } from './utils';
 
-type INavData = Extract<NonNullable<INavs | NavsWithMode<INavs>>, Array<any>>;
+type INavData = Extract<NonNullable<IThemeConfig['nav']>, Array<any>>;
 
 /**
  * hook for get nav data
@@ -21,13 +21,23 @@ export const useNavData = () => {
   const sidebarDataComparer = useRouteDataComparer<INavData[0]>();
   const [nav] = useState<INavData>(() => {
     // use user config first
-    let userNavValue: INavItems = [];
-    let mode: NavsWithMode<INavs>['mode'] | undefined;
+    let userNavValue: IUserNavItems = [];
+    let mode: NavWithMode<INav>['mode'] | undefined;
     if (themeConfig.nav) {
-      mode = (themeConfig.nav as NavsWithMode<INavs>).mode;
-      const value =
-        'mode' in themeConfig.nav ? themeConfig.nav.value : themeConfig.nav;
-      userNavValue = getLocaleNav(value as INavs, locale);
+      let value;
+      // 形如：{mode: "append", value: []}
+      if (
+        'mode' in themeConfig.nav &&
+        typeof themeConfig.nav.mode === 'string'
+      ) {
+        mode = themeConfig.nav.mode;
+        value = themeConfig.nav.value;
+        userNavValue = getLocaleNav(value, locale);
+      } else if (!('mode' in themeConfig.nav)) {
+        // 形如：[] 或 {"zh-CN": []}
+        value = themeConfig.nav;
+        userNavValue = getLocaleNav(value, locale);
+      }
       if (!mode || mode === 'override') return userNavValue;
     }
 

--- a/src/client/theme-api/utils.ts
+++ b/src/client/theme-api/utils.ts
@@ -2,10 +2,11 @@ import { useAppData, useIntl, useSiteData } from 'dumi';
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import type {
   ILocale,
+  INav,
   INavItem,
-  INavs,
   IRouteMeta,
   IRoutesById,
+  IUserNavValue,
 } from './types';
 import { useLocale } from './useLocale';
 
@@ -128,6 +129,6 @@ export const pickRouteSortMeta = (
   return original;
 };
 
-export function getLocaleNav(nav: INavs, locale: ILocale) {
+export function getLocaleNav(nav: IUserNavValue | INav, locale: ILocale) {
   return Array.isArray(nav) ? nav : nav[locale.id];
 }

--- a/src/client/theme-api/utils.ts
+++ b/src/client/theme-api/utils.ts
@@ -1,6 +1,12 @@
 import { useAppData, useIntl, useSiteData } from 'dumi';
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
-import type { ILocale, INavItem, IRouteMeta, IRoutesById, Navs } from './types';
+import type {
+  ILocale,
+  INavItem,
+  INavs,
+  IRouteMeta,
+  IRoutesById,
+} from './types';
 import { useLocale } from './useLocale';
 
 export const useLocaleDocRoutes = () => {
@@ -122,6 +128,6 @@ export const pickRouteSortMeta = (
   return original;
 };
 
-export function resolveNav(nav: Navs, locale: ILocale) {
+export function getLocaleNav(nav: INavs, locale: ILocale) {
   return Array.isArray(nav) ? nav : nav[locale.id];
 }

--- a/src/client/theme-api/utils.ts
+++ b/src/client/theme-api/utils.ts
@@ -1,6 +1,6 @@
 import { useAppData, useIntl, useSiteData } from 'dumi';
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
-import type { INavItem, IRouteMeta, IRoutesById } from './types';
+import type { ILocale, INavItem, IRouteMeta, IRoutesById, Navs } from './types';
 import { useLocale } from './useLocale';
 
 export const useLocaleDocRoutes = () => {
@@ -121,3 +121,7 @@ export const pickRouteSortMeta = (
 
   return original;
 };
+
+export function resolveNav(nav: Navs, locale: ILocale) {
+  return Array.isArray(nav) ? nav : nav[locale.id];
+}

--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -87,7 +87,7 @@ export default (api: IApi) => {
       }
       if (hasOrder) {
         logger.warn(
-          `order is deprecated in themeConfig.navs, you can order them directly in config`,
+          `\`order\` is deprecated in \`themeConfig.nav\`, you can order them directly in config`,
         );
       }
     }

--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -68,7 +68,7 @@ export default (api: IApi) => {
 
     const { themeConfig } = api.config;
     if (themeConfig?.nav) {
-      const hasOrder = !!JSON.stringify(themeConfig.nav).includes('order');
+      const hasOrder = !!JSON.stringify(themeConfig.nav).includes('"order":');
       if (hasOrder) {
         logger.warn(
           `\`order\` is deprecated in \`themeConfig.nav\`, you can order them directly in config`,

--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -1,4 +1,3 @@
-import { NavItems, Navs, NavsWithMode } from '@/client/theme-api/types';
 import { CLIENT_DEPS, LOCAL_PAGES_DIR, USELESS_TMP_FILES } from '@/constants';
 import type { IApi } from '@/types';
 import assert from 'assert';
@@ -67,24 +66,9 @@ export default (api: IApi) => {
       );
     }
 
-    const { themeConfig } = api.userConfig;
+    const { themeConfig } = api.config;
     if (themeConfig?.nav) {
-      const mode = (themeConfig.nav as NavsWithMode<Navs>).mode;
-      let nav: Navs;
-      if (mode) {
-        nav = (themeConfig.nav as NavsWithMode<Navs>).value;
-      } else {
-        nav = themeConfig.nav as Navs;
-      }
-      let hasOrder = false;
-      if (Array.isArray(nav)) {
-        hasOrder = !!nav.find((item) => item.order !== undefined);
-      } else {
-        hasOrder = Object.keys(nav).some((key: string) => {
-          const item = (nav as Record<string, NavItems>)[key];
-          return !!item.find((item2) => item2.order !== undefined);
-        });
-      }
+      const hasOrder = !!JSON.stringify(themeConfig.nav).includes('order');
       if (hasOrder) {
         logger.warn(
           `\`order\` is deprecated in \`themeConfig.nav\`, you can order them directly in config`,

--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -1,3 +1,4 @@
+import { NavItems, Navs, NavsWithMode } from '@/client/theme-api/types';
 import { CLIENT_DEPS, LOCAL_PAGES_DIR, USELESS_TMP_FILES } from '@/constants';
 import type { IApi } from '@/types';
 import assert from 'assert';
@@ -64,6 +65,31 @@ export default (api: IApi) => {
       logger.warn(
         'Hash history is temporarily incompatible, it is recommended to use browser history for now.',
       );
+    }
+
+    const { themeConfig } = api.userConfig;
+    if (themeConfig?.nav) {
+      const mode = (themeConfig.nav as NavsWithMode<Navs>).mode;
+      let nav: Navs;
+      if (mode) {
+        nav = (themeConfig.nav as NavsWithMode<Navs>).value;
+      } else {
+        nav = themeConfig.nav as Navs;
+      }
+      let hasOrder = false;
+      if (Array.isArray(nav)) {
+        hasOrder = !!nav.find((item) => item.order !== undefined);
+      } else {
+        hasOrder = Object.keys(nav).some((key: string) => {
+          const item = (nav as Record<string, NavItems>)[key];
+          return !!item.find((item2) => item2.order !== undefined);
+        });
+      }
+      if (hasOrder) {
+        logger.warn(
+          `order is deprecated in themeConfig.navs, you can order them directly in config`,
+        );
+      }
     }
 
     // check tsconfig.json


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [X] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

`themeConfig.nav`支持通过配置模式控制自定义导航的追加模式

![image](https://user-images.githubusercontent.com/10286961/216518817-a0941b74-60e7-4854-9ff8-2005d6f61e30.png)


<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `themeConfig.nav`support  append mode to change default nav |
| 🇨🇳 Chinese | `themeConfig.nav`支持通过配置模式控制自定义导航的追加模式 |
