### PR TITLE
fix: lang switch lost in root route of non-default locales

### DIFF
--- a/src/client/theme-default/slots/LangSwitch/index.tsx
+++ b/src/client/theme-default/slots/LangSwitch/index.tsx
@@ -23,7 +23,8 @@ function getTargetLocalePath({
 }) {
   const clearPath =
     'base' in current
-      ? pathname.replace(current.base.replace(/\/$/, ''), '')
+      ? // handle '/en-US/a' => '/a' or '/en-US' => '' => '/'
+        pathname.replace(current.base.replace(/\/$/, ''), '') || '/'
       : pathname.replace(new RegExp(`${current.suffix}$`), '');
 
   return 'base' in target


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复非默认语言根路由的语言切换按钮丢失的问题，比如当存在中英文两种语言的时候，`/en-US/components` 是有切换按钮的，但 `/en-US` 的切换按钮丢失了，原因是计算目标切换路由 `/` 的时候返回了空串，所以对空串做了特判

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix lang switch lost in root route of non-default locales |
| 🇨🇳 Chinese | 修复非默认语言根路由的语言切换按钮丢失的问题 |
