### PR TITLE
fix: wrong sidebar config for 1-level routes of non-default locales

### DIFF
--- a/src/client/theme-api/useSidebarData.ts
+++ b/src/client/theme-api/useSidebarData.ts
@@ -182,7 +182,9 @@ export const useSidebarData = () => {
   // /en-US/a/b => /en-US/a
   // /en-US/a/b/ => /en-US/a (also strip trailing /)
   const parentPath = clearPath
-    ? pathname.replace(/(\/[^/]+)(\/[^/]+\/?)$/, '$1')
+    ? pathname.replace(clearPath, (s) =>
+        s.replace(/([^/]+)(\/[^/]+\/?)$/, '$1'),
+      )
     : pathname;
 
   return parentPath ? sidebar[parentPath] : [];


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复配置式侧边栏在非默认语言的一级路由下不生效的问题，比如 `/en-US/components` 下配置式侧边栏不生效，原因是计算 `/en-US/components` 父级路由的逻辑有问题，将其计算为 `/en-US` 导致获取到错误的侧边栏数据

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix wrong sidebar config for 1-level routes of non-default locales |
| 🇨🇳 Chinese | 修复配置式侧边栏在非默认语言的一级路由下不生效的问题 |
