### PR TITLE
fix: conventional sidebar missing index route for non-default locales

### DIFF
--- a/src/client/theme-api/useSidebarData.ts
+++ b/src/client/theme-api/useSidebarData.ts
@@ -44,7 +44,9 @@ export const useFullSidebarData = () => {
         // en-US/a => /en-US/a
         // a/b => /a
         // en-US/a/b => /en-US/a
-        const parentPath = `/${route.path!.replace(/\/[^/]+$/, '')}`;
+        const parentPath = `/${route.path!.replace(clearPath, (s) =>
+          s.replace(/\/[^/]+$/, ''),
+        )}`;
         const { title, order } = pickRouteSortMeta(
           { order: 0 },
           'group',


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1459

### 💡 需求背景和解决方案 / Background or solution

与 #1459 关联的修复，在约定式侧边栏数据生成的过程中，错误地将 `/en-US/a` 归属到 `/en-US` 的侧边栏数据中，但国际化前缀路由不应该参与匹配，导致在访问 `/en-US/a` 路由时，对应的侧边栏数据中缺少自己。

解决方案，在生成父级路由时不处理国际化前缀部分，确保 `/en-US/a` 归属于 `/en-US/a` 下。

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix conventional sidebar missing index route for non-default locales |
| 🇨🇳 Chinese | 修复非默认语言的约定式侧边栏缺少索引路由的问题 |
