### PR TITLE
refactor: improve prompt when use API without apiParser enabled

### DIFF
--- a/src/client/theme-default/builtins/API/index.tsx
+++ b/src/client/theme-default/builtins/API/index.tsx
@@ -48,7 +48,9 @@ const API: FC<{ id?: string }> = (props) => {
               <td colSpan={4}>
                 {intl.formatMessage(
                   {
-                    id: `api.component.${components ? 'not.found' : 'loading'}`,
+                    id: `api.component.${
+                      components ? 'not.found' : 'unavailable'
+                    }`,
                   },
                   { id },
                 )}

--- a/src/client/theme-default/locales/en-US.json
+++ b/src/client/theme-default/locales/en-US.json
@@ -24,6 +24,7 @@
   "api.component.type": "Type",
   "api.component.default": "Default",
   "api.component.required": "(required)",
+  "api.component.unavailable": "apiParser must be enabled to use auto-generated API",
   "api.component.loading": "Properties definition is resolving, wait a moment...",
   "api.component.not.found": "Properties definition not found for {id} component",
   "content.tabs.default": "Doc",

--- a/src/client/theme-default/locales/zh-CN.json
+++ b/src/client/theme-default/locales/zh-CN.json
@@ -24,6 +24,7 @@
   "api.component.type": "类型",
   "api.component.default": "默认值",
   "api.component.required": "(必选)",
+  "api.component.unavailable": "必须启用 apiParser 才能使用自动 API 特性",
   "api.component.loading": "属性定义正在解析中，稍等片刻...",
   "api.component.not.found": "未找到 {id} 组件的属性定义",
   "content.tabs.default": "文档",

--- a/src/features/parser.ts
+++ b/src/features/parser.ts
@@ -84,4 +84,19 @@ export default (api: IApi) => {
       api.service.atomParser.destroyWorker();
     },
   });
+
+  // update unavailable locale text for API component
+  api.modifyTheme((memo) => {
+    const parserOffKey = 'api.component.unavailable';
+    const parserOnKey = 'api.component.loading';
+
+    // use loading key as normal unavailable key when apiParser enabled
+    Object.keys(memo.locales).forEach((locale) => {
+      if (memo.locales[locale][parserOnKey]) {
+        memo.locales[locale][parserOffKey] = memo.locales[locale][parserOnKey];
+      }
+    });
+
+    return memo;
+  });
 };


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

优化在未开启 `apiParser` 时使用 API 组件的提示，告诉用户需要先启用配置项；目前提示在解析中，会让用户产生误解。

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve prompt when use API without apiParser enabled |
| 🇨🇳 Chinese | 优化在未开启 `apiParser` 时使用 API 组件的提示 |
