### PR TITLE
feat: custom tech-stack supports modify demo sources data

### DIFF
--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -93,6 +93,9 @@ export const texts = {{{texts}}};
 
           // use raw-loader to load all source files
           Object.keys(this.sources).forEach((file: string) => {
+            // handle un-existed source file, e.g. custom tech-stack return custom dependencies
+            if (!asset.dependencies[file]) return;
+
             // to avoid modify original asset object
             asset = lodash.cloneDeep(asset);
             asset.dependencies[

--- a/src/loaders/markdown/transformer/rehypeDemo.ts
+++ b/src/loaders/markdown/transformer/rehypeDemo.ts
@@ -351,7 +351,9 @@ export default function rehypeDemo(
                     asset: techStack.generateMetadata
                       ? await techStack.generateMetadata(asset, techStackOpts)
                       : asset,
-                    sources,
+                    sources: techStack.generateSources
+                      ? await techStack.generateSources(sources, techStackOpts)
+                      : sources,
                   };
                 },
               ),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type AtomAssetsParser from '@/assetParsers/atom';
+import type { IParsedBlockAsset } from '@/assetParsers/block';
 import type { IDumiDemoProps } from '@/client/theme-api/DumiDemo';
 import type { ILocalesConfig, IThemeConfig } from '@/client/theme-api/types';
 import type { IContentTab } from '@/features/tabs';
@@ -102,6 +103,13 @@ export abstract class IDumiTechStack {
   ):
     | Promise<IDumiDemoProps['previewerProps']>
     | IDumiDemoProps['previewerProps'];
+  /**
+   * generator for return file path of demo sources
+   */
+  abstract generateSources?(
+    sources: IParsedBlockAsset['sources'],
+    opts: Parameters<NonNullable<IDumiTechStack['generateMetadata']>>[1],
+  ): Promise<IParsedBlockAsset['sources']> | IParsedBlockAsset['sources'];
 }
 
 export type IApi = IUmiApi & {


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

背景：
1. demo sources 数据用于将 demo 元数据中源代码的字符串替换为 raw-loader，实现文件复用（比如两个 demo 同时依赖了某一个 util），减小产物尺寸
2. 默认 demo sources 由内置的区块 parser 生成
3. 自定义技术栈目前能修改 demo 元数据中的源代码，但却无法控制 demo sources，这样一旦两者数据对不齐，在 raw-loader 替换的时候就会报错

解法：
1. 自定义技术栈支持修改 demo 引入的源文件列表，这样两份数据都能修改，可以自行保证一致性
2. raw-loader 替换的逻辑考虑异常链路，避免报错

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Custom tech-stack supports modify demo sources data |
| 🇨🇳 Chinese | 自定义技术栈支持修改 demo 源文件数据 |
