### PR TITLE
feat: render detailed types in API component

### DIFF
--- a/examples/normal/src/Foo/index.tsx
+++ b/examples/normal/src/Foo/index.tsx
@@ -1,14 +1,28 @@
 import React, { type FC } from 'react';
 
+interface A {
+  a: string;
+}
+
 const Foo: FC<{
   /**
    * @description 标题
+   * @default "标题"
    */
-  title: string;
+  title?: string;
   /**
    * @description 顺序
    */
   order?: number;
+  a: A[];
+  b: { c?: string };
+  c: '1' | '2' | '3';
+  d: 1 | 2 | 3;
+  e: A | 1;
+  f: { g?: string }[];
+  onClick: (e?: MouseEvent) => void;
+  children: React.ReactNode;
+  onConfirm: (output: { children: any[] }) => void;
 }> = (props) => {
   return <>{props.title}</>;
 };

--- a/src/client/theme-default/builtins/API/index.tsx
+++ b/src/client/theme-default/builtins/API/index.tsx
@@ -55,7 +55,7 @@ const HANDLERS = {
       );
     });
 
-    return props.length ? `{ ${props.join(', ')} }` : '{}';
+    return props.length ? `{ ${props.join('; ')} }` : '{}';
   },
   array(prop: Extract<PropertySchema, { type: 'array' }>) {
     if (prop.items) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1395 

### 💡 需求背景和解决方案 / Background or solution

自动 API 组件支持渲染更详细的类型，而不只是简单的 `object`、`function`，效果：
![图片](https://user-images.githubusercontent.com/5035925/219581180-a2836aa4-df0f-4a70-811c-ad6c3ba6cdae.png)

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | API component supports render detailed types |
| 🇨🇳 Chinese | 自动 API 组件支持渲染更详细的类型 |
