### PR TITLE
fix: ambiguous relative link problem in md

### DIFF
--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -42,7 +42,7 @@ export default (api: IApi) => {
       resolve: api.config.resolve,
       extraRemarkPlugins: api.config.extraRemarkPlugins,
       extraRehypePlugins: api.config.extraRehypePlugins,
-      routers: api.appData.routes,
+      routes: api.appData.routes,
     };
 
     memo.module

--- a/src/features/tabs.ts
+++ b/src/features/tabs.ts
@@ -21,6 +21,10 @@ export function getTabKeyFromFile(file: string) {
   return file.match(/\$tab-([^.]+)/)![1];
 }
 
+export function getHostForTabRouteFile(file: string) {
+  return file.replace(/\$tab-[^.]+\./, '');
+}
+
 /**
  * plugin for add conventional tab and plugin tab into page content
  */

--- a/src/loaders/markdown/transformer/index.ts
+++ b/src/loaders/markdown/transformer/index.ts
@@ -61,7 +61,7 @@ export interface IMdTransformerOptions {
   resolve: IDumiConfig['resolve'];
   extraRemarkPlugins?: IDumiConfig['extraRemarkPlugins'];
   extraRehypePlugins?: IDumiConfig['extraRehypePlugins'];
-  routers: Record<string, IRoute>;
+  routes: Record<string, IRoute>;
 }
 
 export interface IMdTransformerResult {
@@ -147,7 +147,7 @@ export default async (raw: string, opts: IMdTransformerOptions) => {
     .use(rehypeSlug)
     .use(rehypeLink, {
       fileAbsPath: opts.fileAbsPath,
-      routers: opts.routers,
+      routes: opts.routes,
     })
     .use(rehypeAutolinkHeadings)
     .use(rehypeIsolation)

--- a/src/loaders/markdown/transformer/rehypeLink.ts
+++ b/src/loaders/markdown/transformer/rehypeLink.ts
@@ -1,6 +1,7 @@
+import { getHostForTabRouteFile } from '@/features/tabs';
 import type { Root } from 'hast';
 import path from 'path';
-import { lodash, winPath } from 'umi/plugin-utils';
+import { lodash, logger, winPath } from 'umi/plugin-utils';
 import type { Transformer } from 'unified';
 import url from 'url';
 import type { IMdTransformerOptions } from '.';
@@ -13,10 +14,7 @@ let SKIP: typeof import('unist-util-visit').SKIP;
   ({ visit, SKIP } = await import('unist-util-visit'));
 })();
 
-type IRehypeLinkOptions = Pick<
-  IMdTransformerOptions,
-  'fileAbsPath' | 'routers'
->;
+type IRehypeLinkOptions = Pick<IMdTransformerOptions, 'fileAbsPath' | 'routes'>;
 
 export default function rehypeLink(
   opts: IRehypeLinkOptions,
@@ -26,22 +24,55 @@ export default function rehypeLink(
       if (node.tagName === 'a' && typeof node.properties?.href === 'string') {
         const href = node.properties.href;
         const parsedUrl = url.parse(href);
+        const hostAbsPath = getHostForTabRouteFile(opts.fileAbsPath);
 
         // handle internal link
         if (parsedUrl.hostname) return SKIP;
 
-        // handle markdown link
         if (/\.md$/i.test(parsedUrl.pathname!)) {
-          const { routers } = opts;
+          // handle markdown link
+          const { routes } = opts;
           const absPath = winPath(
-            path.resolve(opts.fileAbsPath, '..', parsedUrl.pathname!),
+            path.resolve(hostAbsPath, '..', parsedUrl.pathname!),
           );
 
-          Object.keys(routers).forEach((key) => {
-            if (routers[key].file === absPath) {
-              parsedUrl.pathname = routers[key].absPath;
+          Object.keys(routes).forEach((key) => {
+            if (routes[key].file === absPath) {
+              parsedUrl.pathname = routes[key].absPath;
             }
           });
+        } else if (
+          /^\.?\.\//.test(parsedUrl.pathname!) ||
+          /^(\w+:)?\/\//.test(parsedUrl.pathname!)
+        ) {
+          // handle relative link
+          // transform relative link to absolute link
+          // because react-router@6 and HTML href are different in processing relative link
+          // e.g. in /a page, <Link to="./b">b</Link> will be resolved to /a/b in react-router@6
+          //      but will be resolved to /b in <a href="./b">b</a>
+          const routes = Object.values(opts.routes);
+          const basePath = routes.find(
+            (route) => route.file === hostAbsPath,
+          )!.absPath;
+          const htmlTargetPath = url.resolve(basePath, parsedUrl.pathname!);
+          const rr6TargetPath = winPath(
+            path.resolve(basePath, parsedUrl.pathname!),
+          );
+
+          // use html way first
+          parsedUrl.pathname = htmlTargetPath;
+
+          // warn if user already use react-router@6 way
+          if (
+            routes.every((route) => route.absPath !== htmlTargetPath) &&
+            routes.some((route) => route.absPath === rr6TargetPath)
+          ) {
+            parsedUrl.pathname = rr6TargetPath;
+            logger.warn(
+              `Detected ambiguous link \`${href}\` in \`${opts.fileAbsPath}\`, please use \`./xxx.md\` file path instead of normal relative path, dumi will deprecate this behavior in the future.
+        See more: https://github.com/umijs/dumi/pull/1491`,
+            );
+          }
         }
 
         parent!.children.splice(i!, 1, {


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

目前 Markdown 中的相对路径链接存在歧义，原因在于 react-router-dom@6 中 `Link` 的行为与 HTML 的 `a` 标签行为[不一致](https://reactrouter.com/en/main/upgrading/v5#note-on-link-to-values)，例如当前页面路径为 `/a`，目标路径为 `./b` 时：

- 在 react-router@6 下最终路径为 `/a/b`，行为类似 `path.resolve(from, to)`
- 在 HTML 规范下最终路径为 `/b`，等同于 `url.resolve(from, to)`

dumi 此前直接将相对路径交给 `Link` 组件跳转，所以都是 react-router@6 的解析逻辑，但 GitHub 预览页显然又是 HTML 的解析逻辑，这使得**同一份 Markdown 的同一个链接在文档站点和 GitHub 预览页之间存在歧义**，肯定是有问题的。

所以这个 PR 做了 3 件事：

1. dumi 是基于 Markdown 生成内容而不是 react-router，所以后续对相对路径的解析会统一使用 HTML 的规范，处理成绝对路径再交给 `Link`
2. 同时对 react-router 的用法做兼容，避免已经在使用 react-router 行为的项目出现问题
3. 最后对 react-router 的用法做警告，建议开发者使用 Markdown 文件的引用方式，因为该方式更简单（特别是像 Ant Design 这类后缀式多语言的站点，还需要考虑 `./xxx-cn` 的情况），不需要考虑 HTML 规范与 react-router@6 行为间的区别，且在 GitHub 预览页也能工作

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix ambiguous relative link problem in markdown |
| 🇨🇳 Chinese | 修复 Markdown 内有歧义的相对路径链接问题 |
