### PR TITLE
fix: built-in dark theme var lost if set modifyVars option

### DIFF
--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -163,9 +163,30 @@ export default (api: IApi) => {
       path.resolve(__dirname, '../../client/theme-api'),
     );
 
-    // set dark mode selector as less variable
-    memo.theme ??= {};
-    memo.theme['dark-selector'] = `~'[${PREFERS_COLOR_ATTR}="dark"]'`;
+    return memo;
+  });
+
+  // set dark mode selector as less variable
+  // why not use `theme` or `modifyVars`?
+  // because `theme` will be override by `modifyVars` in umi
+  // and `modifyVar` will override `theme` from user
+  api.chainWebpack((memo) => {
+    const lessRule = memo.module.rule('less');
+
+    ['css', 'css-modules'].forEach((rule) => {
+      Object.values(lessRule.oneOf(rule).uses.entries()).forEach((loader) => {
+        if (loader.get('loader').includes('less-loader')) {
+          loader.tap((opts) => {
+            opts.lessOptions.modifyVars ??= {};
+            opts.lessOptions.modifyVars[
+              'dark-selector'
+            ] = `~'[${PREFERS_COLOR_ATTR}="dark"]'`;
+
+            return opts;
+          });
+        }
+      });
+    });
 
     return memo;
   });


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1490 

### 💡 需求背景和解决方案 / Background or solution

Umi 层的逻辑是 `lessLoader.modifyVars` 会覆盖 `theme`，之前 dumi 暗黑模式的选择器变量是通过 `theme` 传入的，这意味着会被用户配置的 `modifyVars` 覆盖，所以改用 chainWebpack 直接改最终的 loader 配置，避免被覆盖

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix built-in dark theme var lost bug if set modifyVars option |
| 🇨🇳 Chinese | 修复配置 modifyVars 时内置暗黑模式选择器变量丢失的 bug |
