### PR TITLE
feat: hero title follow primary color in default theme

### DIFF
--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -140,7 +140,7 @@ const FILE_LIST = [
       // replace plugin api link
       {
         type: 'replace',
-        value: [/\/api\/plugin-api/g, '/plugin/api'],
+        value: [/\/api\/plugin-api/g, '/plugin/api.md'],
       },
     ],
   },

--- a/src/client/theme-default/slots/HeroTitle/index.less
+++ b/src/client/theme-default/slots/HeroTitle/index.less
@@ -10,14 +10,18 @@
   display: inline-block;
   font-family: Alibaba-PuHuiTi, 'Gill Sans', 'Gill Sans MT', Calibri,
     'Trebuchet MS', sans-serif;
-  color: #82cdf8;
+  color: lighten(desaturate(spin(@c-primary, -13), 10.5), 20);
   font-size: 180px;
   line-height: 1;
 
   > span {
+    // generated via: https://nicothin.pro/lessColourFunctionCalculator/
+    @from: lighten(spin(@c-primary, -12.5), 24);
+    @to: lighten(@c-primary, 15.5);
+
     color: transparent;
-    text-shadow: 0 10px 20px rgba(22, 119, 255, 15%);
-    background: linear-gradient(30deg, #91d6ff 30%, #66a6ff);
+    text-shadow: 0 10px 20px fadeout(@c-primary, 85%);
+    background: linear-gradient(30deg, @from 30%, @to);
     background-clip: text;
   }
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

默认主题的 Hero 标题支持跟随 `@c-primary` 主色改色，效果如下：

![preview](https://user-images.githubusercontent.com/5035925/220658045-5f18cc58-4049-44ba-98a8-5ca498a3da1d.png)

Less 转换函数借助该项目生成：https://github.com/nicothin/lessColourFunctionCalculator

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hero title follow primary color in default theme |
| 🇨🇳 Chinese | 默认主题的 Hero 标题支持跟随主色变量 |
