### PR TITLE
chore(theme): improve the operability of website theme switching

### DIFF
--- a/src/client/theme-api/usePrefersColor.ts
+++ b/src/client/theme-api/usePrefersColor.ts
@@ -108,7 +108,7 @@ class ColorChanger {
     this.prefersColor = color;
     this.color =
       color === 'auto' ? (this.isColorMode('dark') ? 'dark' : 'light') : color;
-    document.documentElement.setAttribute(PREFERS_COLOR_ATTR, color);
+    document.documentElement.setAttribute(PREFERS_COLOR_ATTR, this.color);
     this.applyCallbacks();
 
     return color;

--- a/src/client/theme-default/slots/ColorSwitch/index.less
+++ b/src/client/theme-default/slots/ColorSwitch/index.less
@@ -54,5 +54,9 @@
     max-width: 100%;
     max-height: 16px;
     cursor: pointer;
+
+    @media @mobile {
+      display: none;
+    }
   }
 }

--- a/src/client/theme-default/slots/ColorSwitch/index.tsx
+++ b/src/client/theme-default/slots/ColorSwitch/index.tsx
@@ -2,19 +2,19 @@ import { useIntl, usePrefersColor, useSiteData } from 'dumi';
 import React, { type FC } from 'react';
 import './index.less';
 
-const IconDark = () => (
+const IconDark = (
   <svg viewBox="0 0 16 16">
     <path d="M8.218 1.455c3.527.109 6.327 3.018 6.327 6.545 0 3.6-2.945 6.545-6.545 6.545a6.562 6.562 0 0 1-6.036-4h.218c3.6 0 6.545-2.945 6.545-6.545 0-.91-.182-1.745-.509-2.545m0-1.455c-.473 0-.909.218-1.2.618-.29.4-.327.946-.145 1.382.254.655.4 1.31.4 2 0 2.8-2.291 5.09-5.091 5.09h-.218c-.473 0-.91.22-1.2.62-.291.4-.328.945-.146 1.38C1.891 14.074 4.764 16 8 16c4.4 0 8-3.6 8-8a7.972 7.972 0 0 0-7.745-8h-.037Z" />
   </svg>
 );
 
-const IconLight = () => (
+const IconLight = (
   <svg viewBox="0 0 16 16">
     <path d="M8 13a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM8 3a1 1 0 0 1-1-1V1a1 1 0 1 1 2 0v1a1 1 0 0 1-1 1Zm7 4a1 1 0 1 1 0 2h-1a1 1 0 1 1 0-2h1ZM3 8a1 1 0 0 1-1 1H1a1 1 0 1 1 0-2h1a1 1 0 0 1 1 1Zm9.95 3.536.707.707a1 1 0 0 1-1.414 1.414l-.707-.707a1 1 0 0 1 1.414-1.414Zm-9.9-7.072-.707-.707a1 1 0 0 1 1.414-1.414l.707.707A1 1 0 0 1 3.05 4.464Zm9.9 0a1 1 0 0 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 1.414l-.707.707Zm-9.9 7.072a1 1 0 0 1 1.414 1.414l-.707.707a1 1 0 0 1-1.414-1.414l.707-.707ZM8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Zm0 6.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Z" />
   </svg>
 );
 
-const IconAuto = () => (
+const IconAuto = (
   <svg viewBox="0 0 16 16">
     <path d="M14.595 8a6.595 6.595 0 1 1-13.19 0 6.595 6.595 0 0 1 13.19 0ZM8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm0 2.014v11.972A5.986 5.986 0 0 0 8 2.014Z" />
   </svg>
@@ -24,7 +24,11 @@ const ICON_MAPPING = {
   light: IconLight,
   dark: IconDark,
   auto: IconAuto,
-};
+} as const;
+
+const prefersOptions = Object.keys(ICON_MAPPING) as Array<
+  keyof typeof ICON_MAPPING
+>;
 
 const ColorSwitch: FC = () => {
   const {
@@ -34,7 +38,24 @@ const ColorSwitch: FC = () => {
   } = useSiteData();
   const intl = useIntl();
   const [, prefersColor = defaultColor, setPrefersColor] = usePrefersColor();
-  const Icon = ICON_MAPPING[prefersColor];
+
+  const iconNode = React.useMemo(
+    () =>
+      React.createElement(
+        'div',
+        {
+          // 不需要判断是否为移动的，因为 PC 端被 select 遮挡了。点击直接被 select 捕获了
+          // 此外就是移动端(移动端默认隐藏了 select); 点击仅做 dark 和 light 之间的切换
+          onClick(event) {
+            event.stopPropagation();
+            const nextColor = prefersColor === 'dark' ? 'light' : 'dark';
+            setPrefersColor(nextColor);
+          },
+        },
+        ICON_MAPPING[prefersColor],
+      ),
+    [prefersColor],
+  );
 
   return (
     <span
@@ -44,12 +65,12 @@ const ColorSwitch: FC = () => {
       })}
       data-dumi-tooltip-bottom
     >
-      {Icon && <Icon />}
+      {iconNode}
       <select
         onChange={(ev) => setPrefersColor(ev.target.value as any)}
         value={prefersColor}
       >
-        {['light', 'dark', 'auto'].map((c) => (
+        {prefersOptions.map((c) => (
           <option value={c} key={c}>
             {intl.formatMessage({ id: `header.color.mode.${c}` })}
           </option>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [x] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [x] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

存在的问题：

1. 移动端下切换主题功能无效，难以操作
2. 跟随主题功能不能及时生效。（假设系统便好设置是 dark，网站是 light 模式，这个时候选择跟随主题，页面还是 light 模式。期望是立即为 dark 模式。）

问题 1 复现视频：

https://user-images.githubusercontent.com/32004925/222501699-d11e38b4-3c7a-48e4-becb-abeef4cbb9be.mp4


修复后视频演示


https://user-images.githubusercontent.com/32004925/222502344-851d8a3e-5f6b-4aa2-8e56-73db6cf4f927.mp4


<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    improve the operability of website theme switching       |
| 🇨🇳 Chinese |     提高网站主题切换的可操作性      |
