### PR TITLE
fix: special links not working bug in markdown

### DIFF
--- a/src/loaders/markdown/transformer/rehypeLink.ts
+++ b/src/loaders/markdown/transformer/rehypeLink.ts
@@ -23,12 +23,11 @@ export default function rehypeLink(
       if (
         node.tagName === 'a' &&
         typeof node.properties?.href === 'string' &&
-        // skip:
-        //   - schema:// (full) or // (protocol-relative)
-        //   - mailto: or tel: (protocol)
-        //   - data:image (data)
-        //   - / (absolute)
-        !/^((\w+:)?\/\/|(mailto|tel):|\w+:\w+|\/)/.test(node.properties.href)
+        // match:
+        //   - ./xx or ../xx or ./xx.md
+        //   - xx or xx.md
+        //   - xx/yy
+        /^[^/:]+(\/[^/:]|(\.\w+)?$)/.test(node.properties.href)
       ) {
         const href = node.properties.href;
         const parsedUrl = url.parse(href);

--- a/src/loaders/markdown/transformer/rehypeLink.ts
+++ b/src/loaders/markdown/transformer/rehypeLink.ts
@@ -26,8 +26,9 @@ export default function rehypeLink(
         // skip:
         //   - schema:// (full) or // (protocol-relative)
         //   - mailto: or tel: (protocol)
+        //   - data:image (data)
         //   - / (absolute)
-        !/^(\w+:)?\/\/|^(mailto|tel):|^\//.test(node.properties.href)
+        !/^((\w+:)?\/\/|(mailto|tel):|\w+:\w+|\/)/.test(node.properties.href)
       ) {
         const href = node.properties.href;
         const parsedUrl = url.parse(href);

--- a/src/loaders/markdown/transformer/rehypeLink.ts
+++ b/src/loaders/markdown/transformer/rehypeLink.ts
@@ -27,7 +27,7 @@ export default function rehypeLink(
         //   - ./xx or ../xx or ./xx.md
         //   - xx or xx.md
         //   - xx/yy
-        /^[^/:]+(\/[^/:]|(\.\w+)?$)/.test(node.properties.href)
+        /^[^/:#]+(\/[^/]|(\.\w+)?$)/.test(node.properties.href)
       ) {
         const href = node.properties.href;
         const parsedUrl = url.parse(href);

--- a/src/loaders/markdown/transformer/rehypeLink.ts
+++ b/src/loaders/markdown/transformer/rehypeLink.ts
@@ -23,7 +23,11 @@ export default function rehypeLink(
       if (
         node.tagName === 'a' &&
         typeof node.properties?.href === 'string' &&
-        /^\.?\.\//.test(node.properties.href)
+        // skip:
+        //   - schema:// (full) or // (protocol-relative)
+        //   - mailto: or tel: (protocol)
+        //   - / (absolute)
+        !/^(\w+:)?\/\/|^(mailto|tel):|^\//.test(node.properties.href)
       ) {
         const href = node.properties.href;
         const parsedUrl = url.parse(href);


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1258 

### 💡 需求背景和解决方案 / Background or solution

修复 Markdown 中的特殊链接无法工作的问题，比如 `mailto:abc@example.com`、`<a href="xxx" download>xxx</a>`

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix absolute links and schema links lost bug in markdown |
| 🇨🇳 Chinese | 修复 Markdown 中的绝对路径链接及特殊协议链接丢失的问题 |
