### PR TITLE
fix: react types is missing in react template

### DIFF
--- a/suites/boilerplate/templates/react/package.json.tpl
+++ b/suites/boilerplate/templates/react/package.json.tpl
@@ -56,6 +56,8 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "@umijs/lint": "^4.0.0",
     "dumi": "{{{ version }}}",
     "eslint": "^8.23.0",


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复 React 模板缺少 `@types/{react,react-dom}` 导致编辑器类型提示丢失的问题

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix react types is missing in react template |
| 🇨🇳 Chinese | 修复 React 模板缺少类型包的问题 |
