### PR TITLE
refactor: allow custom father config for auto alias

### DIFF
--- a/examples/normal/.fatherrc.ts
+++ b/examples/normal/.fatherrc.ts
@@ -1,0 +1,3 @@
+export default {
+  esm: {},
+};

--- a/src/features/autoAlias.ts
+++ b/src/features/autoAlias.ts
@@ -12,6 +12,13 @@ export default (api: IApi) => {
     enableBy: ({ userConfig }) => userConfig.autoAlias !== false,
   });
 
+  api.modifyAppData(async (memo) => {
+    // save father configs to appData, allow other plugins to modify
+    memo.fatherConfigs = await tryFatherBuildConfigs(api.cwd);
+
+    return memo;
+  });
+
   api.modifyConfig(async (memo) => {
     let entryDir = '';
 
@@ -22,7 +29,7 @@ export default (api: IApi) => {
     }
 
     if (entryDir && api.pkg.name) {
-      const fatherConfigs = await tryFatherBuildConfigs(api.cwd);
+      const fatherConfigs = api.appData.fatherConfigs as any[];
 
       // sort by output level, make sure the deepest output has the highest priority
       fatherConfigs.sort((a, b) => {

--- a/src/features/autoAlias.ts
+++ b/src/features/autoAlias.ts
@@ -4,49 +4,55 @@ import fs from 'fs';
 import path from 'path';
 
 export default (api: IApi) => {
+  let entryDir: string;
+
   api.describe({
     key: 'autoAlias',
     config: {
       schema: (Joi) => Joi.bool(),
     },
-    enableBy: ({ userConfig }) => userConfig.autoAlias !== false,
+    enableBy: () => !!api.pkg.name,
   });
 
   api.modifyAppData(async (memo) => {
+    if (api.config.resolve?.entryFile) {
+      entryDir = path.resolve(api.cwd, api.config.resolve.entryFile);
+    } else if (fs.existsSync(path.join(api.cwd, 'src'))) {
+      entryDir = path.join(api.cwd, 'src');
+    }
+
     // save father configs to appData, allow other plugins to modify
     memo.fatherConfigs = await tryFatherBuildConfigs(api.cwd);
 
     return memo;
   });
 
-  api.modifyConfig(async (memo) => {
-    let entryDir = '';
+  api.chainWebpack((memo) => {
+    const fatherConfigs = api.appData.fatherConfigs as any[];
 
-    if (memo.resolve?.entryFile) {
-      entryDir = path.resolve(api.cwd, memo.resolve.entryFile);
-    } else if (fs.existsSync(path.join(api.cwd, 'src'))) {
-      entryDir = path.join(api.cwd, 'src');
-    }
+    // sort by output level, make sure the deepest output has the highest priority
+    fatherConfigs.sort((a, b) => {
+      const aLevel = (a.output?.path || a.output).split('/').length;
+      const bLevel = (b.output?.path || b.output).split('/').length;
 
-    if (entryDir && api.pkg.name) {
-      const fatherConfigs = api.appData.fatherConfigs as any[];
+      return bLevel - aLevel;
+    });
 
-      // sort by output level, make sure the deepest output has the highest priority
-      fatherConfigs.sort((a, b) => {
-        const aLevel = (a.output?.path || a.output).split('/').length;
-        const bLevel = (b.output?.path || b.output).split('/').length;
+    // create subpaths alias for each input/entry
+    fatherConfigs.forEach((item) => {
+      const key = `${api.pkg.name}/${item.output?.path || item.output}`;
 
-        return bLevel - aLevel;
-      });
+      if (!memo.resolve.alias.has(key)) {
+        memo.resolve.alias.set(
+          key,
+          path.join(api.cwd, item.entry || item.input),
+        );
+      }
+    });
 
-      // create subpaths alias for each input/entry
-      fatherConfigs.forEach((item) => {
-        memo.alias[`${api.pkg.name}/${item.output?.path || item.output}`] ??=
-          path.join(api.cwd, item.entry || item.input);
-      });
-
-      // create pkg alias to entry dir
-      memo.alias[api.pkg.name] ??= entryDir;
+    // create pkg alias to entry dir
+    if (entryDir && !memo.resolve.alias.has(api.pkg.name!)) {
+      memo.resolve.alias.set(api.pkg.name!, entryDir);
     }
 
     return memo;


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

允许修改 autoAlias 特性消费的 father 序列化配置值，用于同时 dumi 和 father 集成封装的场景

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow custom father config for auto alias |
| 🇨🇳 Chinese | 允许修改 autoAlias 特性消费的 father 序列化配置值 |
