### PR TITLE
fix: demo url incompatible with hash router

### DIFF
--- a/src/client/theme-api/DumiDemo.tsx
+++ b/src/client/theme-api/DumiDemo.tsx
@@ -51,20 +51,16 @@ export const DumiDemo: FC<IDumiDemoProps> = (props) => {
 
   const isHashRoute = historyType === 'hash';
 
-  const {
-    location: { href, origin },
-  } = window;
-  const [base] = href.split(/#\//);
-
   return (
     <Previewer
       asset={asset}
       demoUrl={
         // allow user override demoUrl by frontmatter
         props.previewerProps.demoUrl ||
-        `${
-          isHashRoute ? `${base}#` : origin
-        }${basename}${SP_ROUTE_PREFIX}demos/${props.demo.id}`
+        // when use hash route, browser can automatically handle relative paths starting with #
+        `${isHashRoute ? `#` : ''}${basename}${SP_ROUTE_PREFIX}demos/${
+          props.demo.id
+        }`
       }
       {...props.previewerProps}
     >

--- a/src/client/theme-api/DumiDemo.tsx
+++ b/src/client/theme-api/DumiDemo.tsx
@@ -37,7 +37,7 @@ const DemoErrorBoundary: FC<{ children: ReactNode }> = (props) => (
 );
 
 export const DumiDemo: FC<IDumiDemoProps> = (props) => {
-  const { demos } = useSiteData();
+  const { demos, historyType } = useSiteData();
   const { basename } = useAppData();
   const { component, asset } = demos[props.demo.id];
 
@@ -49,11 +49,12 @@ export const DumiDemo: FC<IDumiDemoProps> = (props) => {
     return <DemoErrorBoundary>{createElement(component)}</DemoErrorBoundary>;
   }
 
+  const isHashRoute = historyType === 'hash';
+
   const {
-    location: { href },
+    location: { href, origin },
   } = window;
-  const [, hashRoute] = href.split(/#\//);
-  const isHashRoute = typeof hashRoute === 'string';
+  const [base] = href.split(/#\//);
 
   return (
     <Previewer
@@ -61,9 +62,9 @@ export const DumiDemo: FC<IDumiDemoProps> = (props) => {
       demoUrl={
         // allow user override demoUrl by frontmatter
         props.previewerProps.demoUrl ||
-        `${isHashRoute ? `/#${basename}` : basename}${SP_ROUTE_PREFIX}demos/${
-          props.demo.id
-        }`
+        `${
+          isHashRoute ? `${base}#` : origin
+        }${basename}${SP_ROUTE_PREFIX}demos/${props.demo.id}`
       }
       {...props.previewerProps}
     >

--- a/src/client/theme-api/DumiDemo.tsx
+++ b/src/client/theme-api/DumiDemo.tsx
@@ -49,13 +49,21 @@ export const DumiDemo: FC<IDumiDemoProps> = (props) => {
     return <DemoErrorBoundary>{createElement(component)}</DemoErrorBoundary>;
   }
 
+  const {
+    location: { href },
+  } = window;
+  const [, hashRoute] = href.split(/#\//);
+  const isHashRoute = typeof hashRoute === 'string';
+
   return (
     <Previewer
       asset={asset}
       demoUrl={
         // allow user override demoUrl by frontmatter
         props.previewerProps.demoUrl ||
-        `${basename}${SP_ROUTE_PREFIX}demos/${props.demo.id}`
+        `${isHashRoute ? `/#${basename}` : basename}${SP_ROUTE_PREFIX}demos/${
+          props.demo.id
+        }`
       }
       {...props.previewerProps}
     >

--- a/src/client/theme-api/context.ts
+++ b/src/client/theme-api/context.ts
@@ -5,6 +5,7 @@ import type { ILocalesConfig, IPreviewerProps, IThemeConfig } from './types';
 
 interface ISiteContext {
   pkg: Partial<Record<keyof typeof PICKED_PKG_FIELDS, any>>;
+  historyType: 'browser' | 'hash' | 'memory';
   entryExports: Record<string, any>;
   demos: Record<
     string,
@@ -23,6 +24,7 @@ interface ISiteContext {
 
 export const SiteContext = createContext<ISiteContext>({
   pkg: {},
+  historyType: 'browser',
   entryExports: {},
   demos: {},
   components: {},

--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -282,6 +282,7 @@ export default function DumiContextWrapper() {
       pkg: ${JSON.stringify(
         lodash.pick(api.pkg, ...Object.keys(PICKED_PKG_FIELDS)),
       )},
+      historyType: "${api.config.history?.type || 'browser'}",
       entryExports,
       demos,
       components,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

配置路由 history 类型为 hash 且用 iframe 形式渲染 demo 时，默认的 demoUrl 没有带上 #，导致渲染结果不正确。

解决方案：参考了1.x的写法，判断是hash路由时给 demoUrl 添加 # 

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: demo url incompatible with hash router  |
| 🇨🇳 Chinese | 修复demoUrl在hash路由下不正确问题 |
