### PR TITLE
fix: socialIcons slot cannot override bug

### DIFF
--- a/src/client/theme-default/slots/Header/index.tsx
+++ b/src/client/theme-default/slots/Header/index.tsx
@@ -9,8 +9,8 @@ import Logo from 'dumi/theme/slots/Logo';
 import Navbar from 'dumi/theme/slots/Navbar';
 import RtlSwitch from 'dumi/theme/slots/RtlSwitch';
 import SearchBar from 'dumi/theme/slots/SearchBar';
+import SocialIcon from 'dumi/theme/slots/SocialIcon';
 import React, { useMemo, useState, type FC } from 'react';
-import SocialIcon from '../SocialIcon';
 import './index.less';
 
 const Header: FC = () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->
无

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->
默认主题中引用 `SocialIcon` 组件使用相对路径的方式引入，导致定制主题是如果单独定制 `SocialIcon` 时会出现组件引用错误的情况。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | To avoid resolving errors in a custom theme, modify the import path of `SocialIcon` in `Header`. |
| 🇨🇳 Chinese | 修改 `SocialIcon` 在 `Header` 中的引用路径，避免自定义主题的情况下解析错误。 |
