### PR TITLE
fix: crash when function type has `oneOf` definition in signature

### DIFF
--- a/src/client/theme-default/builtins/API/index.tsx
+++ b/src/client/theme-default/builtins/API/index.tsx
@@ -72,9 +72,13 @@ const HANDLERS = {
   },
   // FIXME: extract real type
   function({ signature }: any) {
-    return `${signature.isAsync ? 'async ' : ''}(${signature.arguments
-      .map((arg: any) => `${arg.key}: ${this.toString(arg)}`)
-      .join(', ')}) => ${this.toString(signature.returnType)}`;
+    const signatures = 'oneOf' in signature ? signature.oneOf : [signature];
+
+    return signatures
+      .map(signature => `${signature.isAsync ? 'async ' : ''}(${signature.arguments
+           .map((arg: any) => `${arg.key}: ${this.toString(arg)}`)
+           .join(', ')}) => ${this.toString(signature.returnType)}`)
+      .join(' | ');
   },
   // FIXME: extract real type
   dom(prop: any) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

暂无

### 💡 需求背景和解决方案 / Background or solution

```ts
interface Foo {
  bar(): Date; // cause crash!!!
}
```

如上写法，如果 interface 有个字段的定义为 lib 的 `Date` 类型，则会导致解析出来的 `signature` 里面是个 `oneOf` 的 Key （例如下图的 `Date.toString`），而不是正常的 `arguments` 之类的，从而导致渲染 function 类型字符串的时候页面挂了：

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/3380894/228756778-c3d74728-20a9-4ff1-b4e6-aff6727833bb.png">

目前只发现 `Date` 会有这个问题，也没办法手动复现，看了下 `lib.es5.d.ts` 的 `Date` 的定义也没啥问题。不了解为什么会解析 function 的 signature 为啥会有个 `oneOf`，先从渲染方面修复。

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix <API> crashed in some type definition |
| 🇨🇳 Chinese | 修复某些类型会导致 <API> crash 的问题 |
