### PR TITLE
fix: search keyword may mismatch in different pages

### DIFF
--- a/src/client/theme-api/useNavData.ts
+++ b/src/client/theme-api/useNavData.ts
@@ -1,14 +1,12 @@
 import { useFullSidebarData, useLocale, useSiteData } from 'dumi';
 import { useState } from 'react';
-import type { IThemeConfig, IUserNavItems, IUserNavMode } from './types';
+import type { INavItems, IUserNavItems, IUserNavMode } from './types';
 import {
   getLocaleNav,
   pickRouteSortMeta,
   useLocaleDocRoutes,
   useRouteDataComparer,
 } from './utils';
-
-type INavData = Extract<NonNullable<IThemeConfig['nav']>, Array<any>>;
 
 /**
  * hook for get nav data
@@ -18,8 +16,8 @@ export const useNavData = () => {
   const routes = useLocaleDocRoutes();
   const { themeConfig } = useSiteData();
   const sidebar = useFullSidebarData();
-  const sidebarDataComparer = useRouteDataComparer<INavData[0]>();
-  const [nav] = useState<INavData>(() => {
+  const sidebarDataComparer = useRouteDataComparer<INavItems[0]>();
+  const [nav] = useState<INavItems>(() => {
     // use user config first
     let userNavValue: IUserNavItems = [];
     let mode: IUserNavMode | undefined;
@@ -39,7 +37,7 @@ export const useNavData = () => {
     }
 
     // fallback to generate nav data from sidebar data
-    const data = Object.entries(sidebar).map<INavData[0]>(([link, groups]) => {
+    const data = Object.entries(sidebar).map<INavItems[0]>(([link, groups]) => {
       const meta = Object.values(routes).reduce<{
         title?: string;
         order?: number;

--- a/src/client/theme-api/useSiteSearch/searchWorker.ts
+++ b/src/client/theme-api/useSiteSearch/searchWorker.ts
@@ -241,7 +241,7 @@ function generateSearchResult(metadata: ISearchMetadata, keywordsStr: string) {
   const keywords = keywordsStr.split(' ');
   const matchReg = new RegExp(
     keywordsStr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(' ', '|'),
-    'gi',
+    'i',
   );
   const resultMapping: Record<string, ISearchNavResult> = {};
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1557 

### 💡 需求背景和解决方案 / Background or solution

修复由于正则表达式错误引起的相同关键字在不同页面中可能部分匹配丢失的问题

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Same search keyword may mismatch in different pages |
| 🇨🇳 Chinese | 相同关键字在不同页面中可能部分匹配丢失 |
