### PR TITLE
fix: default theme lost bug if major version mixed in monorepo

### DIFF
--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -5,13 +5,14 @@ import {
   THEME_PREFIX,
 } from '@/constants';
 import type { IApi } from '@/types';
-import { getClientDistFile } from '@/utils';
 import { parseModuleSync } from '@umijs/bundler-utils';
 import fs from 'fs';
 import path from 'path';
 import { deepmerge, lodash, resolve, winPath } from 'umi/plugin-utils';
 import { safeExcludeInMFSU } from '../derivative';
 import loadTheme, { IThemeLoadResult } from './loader';
+
+const DEFAULT_THEME_PATH = path.join(__dirname, '../../../theme-default');
 
 /**
  * get pkg theme name
@@ -57,10 +58,6 @@ function getModuleExports(modulePath: string) {
 }
 
 export default (api: IApi) => {
-  const DEFAULT_THEME_PATH = path.join(
-    getClientDistFile('theme-default/locales/zh-CN.json', api.cwd),
-    '../..',
-  );
   // load default theme
   const defaultThemeData = loadTheme(DEFAULT_THEME_PATH);
   // try to load theme package

--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -58,8 +58,8 @@ function getModuleExports(modulePath: string) {
 
 export default (api: IApi) => {
   const DEFAULT_THEME_PATH = path.join(
-    getClientDistFile('package.json', api.cwd),
-    '../theme-default',
+    getClientDistFile('theme-default/locales/zh-CN.json', api.cwd),
+    '../..',
   );
   // load default theme
   const defaultThemeData = loadTheme(DEFAULT_THEME_PATH);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import Cache from 'file-system-cache';
 import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
-import { lodash, logger, resolve, winPath } from 'umi/plugin-utils';
+import { lodash, logger, winPath } from 'umi/plugin-utils';
 
 /**
  * get route path from file-system path
@@ -157,26 +157,4 @@ export function getProjectRoot(cwd: string) {
   }
 
   return winPath(cwd);
-}
-
-/**
- * get dumi client dist file and preserve symlink(pnpm, tnpm & etc.) to make chunk name clean
- */
-export function getClientDistFile(file: string, cwd: string) {
-  let clientFile: string;
-
-  try {
-    // why use `resolve`?
-    // because `require.resolve` will use the final path of symlink file
-    // and in tnpm or pnpm project, the long realpath make chunk name unexpected
-    clientFile = resolve.sync(`dumi/${file}`, {
-      basedir: cwd,
-      preserveSymlinks: true,
-    });
-  } catch {
-    // fallback to use `require.resolve`, for dumi self docs & examples
-    clientFile = require.resolve(`../${file}`);
-  }
-
-  return winPath(clientFile);
 }


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1513 

### 💡 需求背景和解决方案 / Background or solution

修复在 monorepo 中同时使用多个不同主版本的 dumi 时，默认主题可能丢失的 bug。

原因：Umi 的路由组件基于文件路径转换成 ChunkName，dumi 2 为了让 ChunkName 保持干净，在 #1513 里用不解析软连接的形式确保绝对路径层级最少（例如 `node_modules/dumi/dist/client/pages/404` 而不是 `node_modules/.pnpm/dumi@2.1.19_xxxx/node_modules/dumi/dist/client/pages/404`），算是一种绕过的方式；但当 monorepo 下存在多个 dumi 主版本、提取到顶层的版本有可能是 dumi 1 时，就会导致默认主题解析失败（因为 dumi 1 产物里不存在 `theme-default` 文件夹），进而导致产物出问题

解法：因为 Umi [不会对 `@/` 开头的路由组件做转换](https://github.com/umijs/umi/blob/30a11c60b1be9066ea0162fe279aaf62b70b0b14/packages/preset-umi/src/features/tmpFiles/routes.ts#L229)，所以改用类似 `@/dumi__pages` 的 alias 指向真正的 `dumi/dist/client/pages`，路由表里直接使用 `@/dumi__pages/404` 以保持路由组件的路径层级足够简洁，进而确保 ChunkName 也是简洁的

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix default theme lost bug if major version mixed in monorepo |
| 🇨🇳 Chinese | 修复在 monorepo 中使用不同主版本的 dumi 时默认主题丢失的 bug |
