### PR TITLE
fix: auto-alias pkg missing bug in demo deps meta

### DIFF
--- a/src/features/autoAlias.ts
+++ b/src/features/autoAlias.ts
@@ -4,8 +4,6 @@ import fs from 'fs';
 import path from 'path';
 
 export default (api: IApi) => {
-  let entryDir: string;
-
   api.describe({
     key: 'autoAlias',
     config: {
@@ -14,21 +12,12 @@ export default (api: IApi) => {
     enableBy: () => !!api.pkg.name,
   });
 
-  api.modifyAppData(async (memo) => {
-    if (api.config.resolve?.entryFile) {
-      entryDir = path.resolve(api.cwd, api.config.resolve.entryFile);
-    } else if (fs.existsSync(path.join(api.cwd, 'src'))) {
-      entryDir = path.join(api.cwd, 'src');
-    }
-
-    // save father configs to appData, allow other plugins to modify
-    memo.fatherConfigs = await tryFatherBuildConfigs(api.cwd);
-
-    return memo;
-  });
-
-  api.chainWebpack((memo) => {
-    const fatherConfigs = api.appData.fatherConfigs as any[];
+  api.modifyConfig(async (memo) => {
+    const fatherConfigs: any[] = await api.applyPlugins({
+      key: 'dumi.modifyFatherConfigs',
+      type: api.ApplyPluginsType.modify,
+      initialValue: await tryFatherBuildConfigs(api.cwd),
+    });
 
     // sort by output level, make sure the deepest output has the highest priority
     fatherConfigs.sort((a, b) => {
@@ -40,19 +29,21 @@ export default (api: IApi) => {
 
     // create subpaths alias for each input/entry
     fatherConfigs.forEach((item) => {
-      const key = `${api.pkg.name}/${item.output?.path || item.output}`;
-
-      if (!memo.resolve.alias.has(key)) {
-        memo.resolve.alias.set(
-          key,
-          path.join(api.cwd, item.entry || item.input),
-        );
-      }
+      memo.alias[`${api.pkg.name}/${item.output?.path || item.output}`] ??=
+        path.join(api.cwd, item.entry || item.input);
     });
 
-    // create pkg alias to entry dir
-    if (entryDir && !memo.resolve.alias.has(api.pkg.name!)) {
-      memo.resolve.alias.set(api.pkg.name!, entryDir);
+    let entryDir = '';
+
+    if (memo.resolve?.entryFile) {
+      entryDir = path.resolve(api.cwd, memo.resolve.entryFile);
+    } else if (fs.existsSync(path.join(api.cwd, 'src'))) {
+      entryDir = path.join(api.cwd, 'src');
+    }
+
+    // create pkg alias to entry dir, must behind subpaths alias from father configs
+    if (entryDir) {
+      memo.alias[api.pkg.name!] ??= entryDir;
     }
 
     return memo;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1531 

### 💡 需求背景和解决方案 / Background or solution

修复 demo 元数据的依赖描述中缺少 `autoAlias` 的 NPM 包（也就是组件库自己）的问题，会影响如下两个地方：
1. 在其他平台打开 demo 会缺少依赖
2. `assets.json` 的内容

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix auto-alias pkg missing bug in demo deps meta |
| 🇨🇳 Chinese | 修复 demo 元数据的依赖中缺少 `autoAlias` NPM 包的问题 |
