### PR TITLE
refactor: allow monorepoRedirect from umi

### DIFF
--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -28,6 +28,10 @@ const FILE_LIST = [
     localname: 'config.md',
     upstream: 'https://cdn.jsdelivr.net/gh/umijs/umi@4/docs/docs/api/config.md',
     actions: [
+      {
+        type: 'replace',
+        value: ["<Message fontsize='small'", '<Message emoji="💡"'],
+      },
       ...REPLACE_MESSAGE_MDX,
       // remove head content
       { type: 'slice', value: [2] },

--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -42,7 +42,6 @@ const FILE_LIST = [
         'jsMinifier \\(vite 构建\\)',
         'mdx',
         'mpa',
-        'monorepoRedirect',
         'phantomDependency',
         'reactRouter5Compat',
         'vite',

--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -17,7 +17,7 @@ const REPLACE_MESSAGE_MDX = [
   {
     type: 'replace',
     value: [
-      /<Message(?: type="[^"]+")? emoji="(💡|🚀)">([^]+?)<\/Message>/,
+      /<Message(?: type="[^"]+")? emoji="(?:💡|🚀)">([^]+?)<\/Message>/,
       ':::info$1:::',
     ],
   },

--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -54,7 +54,6 @@ export default (api: IApi) => {
       'icons',
       'mdx',
       'mpa',
-      'monorepoRedirect',
       'reactRouter5Compat',
       'verifyCommit',
     ].forEach((key) => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1570 

### 💡 需求背景和解决方案 / Background or solution

允许配置继承自 Umi 的 `monorepoRedirect` 配置项，经测试可以在 dumi 项目中使用

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow monorepoRedirect option from umi |
| 🇨🇳 Chinese | 允许配置继承自 Umi 的 monorepoRedirect 配置项 |
