### PR TITLE
fix: language selector is too close to other components

### DIFF
--- a/src/client/theme-default/slots/ColorSwitch/index.less
+++ b/src/client/theme-default/slots/ColorSwitch/index.less
@@ -12,13 +12,15 @@
       inset-inline-end: -15px;
       transform: none;
 
-      [class*='-switch'] + & {
+      [class*='-switch'] + &,
+      [class*='-select'] + & {
         inset-inline-end: 0;
       }
     }
   }
 
-  [class*='-switch'] + & {
+  [class*='-switch'] + &,
+  [class*='-select'] + & {
     margin-inline-start: 15px;
     margin-inline-end: -15px;
     padding-inline: 15px;

--- a/src/client/theme-default/slots/RtlSwitch/index.less
+++ b/src/client/theme-default/slots/RtlSwitch/index.less
@@ -7,7 +7,8 @@
   background-color: transparent;
   cursor: pointer;
 
-  [class*='-switch'] + & {
+  [class*='-switch'] + &,
+  [class*='-select'] + & {
     margin-inline-start: 15px;
     margin-inline-end: -15px;
     padding-inline: 15px;

--- a/src/client/theme-default/slots/SocialIcon/index.less
+++ b/src/client/theme-default/slots/SocialIcon/index.less
@@ -4,7 +4,8 @@
   font-size: 0;
   line-height: 0;
 
-  [class*='-switch'] + & {
+  [class*='-switch'] + &,
+  [class*='-select'] + & {
     margin-inline-start: 15px;
     margin-inline-end: -15px;
     padding-inline: 15px;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [x] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

![image](https://user-images.githubusercontent.com/14073775/232787586-b0d15216-1a37-4007-9e98-aa7e74dedb8d.png)


LangSelect在三个语言及以上时会使用`.dumi-default-lang-select`，而其他组件样式没有把它囊括在内，我本来想把`.dumi-default-lang-select`改成`.dumi-default-lang-multi-switch`但与语义上差太多，所以还是选择现在这个方法

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
