### PR TITLE
fix: atom parser uses wacher cwd to resolve full path

### DIFF
--- a/src/assetParsers/atom.ts
+++ b/src/assetParsers/atom.ts
@@ -178,7 +178,7 @@ class AtomAssetsParser {
             ['add', 'change'].includes(ev) &&
             /((?<!\.d)\.ts|\.(jsx?|tsx))$/.test(file)
           ) {
-            this.unresolvedFiles.push(path.join(this.resolveDir, file));
+            this.unresolvedFiles.push(path.join(this.watchArgs.options.cwd, file));
             lazyParse();
           }
         });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

https://github.com/umijs/dumi/pull/1611 中自定义 watch 参数后，`resolveDir` 仍然用的 `cwd`，可能造成拼接出来的文件路径不存在。

watcher 里的 file 路径相对于 `this.watchArgs.options.cwd`，改用 `this.watchArgs.options.cwd` 可以保证文件路径始终正确。

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  atom parser uses wacher cwd to resolve full path   |
| 🇨🇳 Chinese |  atom parser 使用 watcher 当前目录拼接文件路径         |
