### PR TITLE
fix: pnpm 8 install minimal version in create-dumi

### DIFF
--- a/suites/boilerplate/.fatherrc.ts
+++ b/suites/boilerplate/.fatherrc.ts
@@ -1,3 +1,9 @@
+import { version } from '../../package.json';
+
 export default {
   cjs: { output: 'dist' },
+  define: {
+    // replace process.env.DUMI_VERSION to current version
+    'process.env.DUMI_VERSION': JSON.stringify(`^${version}`),
+  },
 };

--- a/suites/boilerplate/src/index.ts
+++ b/suites/boilerplate/src/index.ts
@@ -131,7 +131,7 @@ export default async ({
     path: join(__dirname, `../templates/${type}`),
     target,
     data: {
-      version: '^2.0.2',
+      version: process.env.DUMI_VERSION,
       npmClient,
       registry,
     },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1620 

### 💡 需求背景和解决方案 / Background or solution

PNPM v8 默认安装依赖声明的最小版本号，如果 create-dumi 模板中的 dumi 版本太旧，如果安装最新的主题包（比如 mobile 或三方主题包）可能会工作异常，做了两个优化：

1. 如果用户安装的是 PNPM v8，则执行 `pnpm up -L` 而非 `pnpm i`
2. create-dumi 构建的时候每次取仓库里当前的 dumi 版本作为模板版本

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix pnpm 8 install minimal version in create-dumi |
| 🇨🇳 Chinese | 修复 create-dumi 使用 pnpm 8 时始终安装最小版本的问题 |
