### PR TITLE
fix: args type of chainWebpck in defineConfig

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import type AtomAssetsParser from '@/assetParsers/atom';
 import type { IParsedBlockAsset } from '@/assetParsers/block';
 import type { IDumiDemoProps } from '@/client/theme-api/DumiDemo';
@@ -16,14 +17,10 @@ type FunctionType = (...args: any[]) => any;
 type Subset<K> = {
   [attr in keyof K]?: K[attr] extends Array<any>
     ? K[attr]
+    : K[attr] extends Function | undefined
+    ? K[attr]
     : K[attr] extends object
     ? Subset<K[attr]>
-    : K[attr] extends FunctionType
-    ? K[attr]
-    : K[attr] extends FunctionType | null
-    ? K[attr] | null
-    : K[attr] extends FunctionType | null | undefined
-    ? K[attr] | null | undefined
     : K[attr] extends object | null
     ? Subset<K[attr]> | null
     : K[attr] extends object | null | undefined
@@ -61,9 +58,7 @@ interface IDumiExtendsConfig {
   /**
    * extra unified plugins
    */
-  // eslint-disable-next-line @typescript-eslint/ban-types
   extraRemarkPlugins?: (string | Function | [string | Function, object])[];
-  // eslint-disable-next-line @typescript-eslint/ban-types
   extraRehypePlugins?: (string | Function | [string | Function, object])[];
 }
 export type IDumiConfig = IUmiConfig & IDumiExtendsConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,17 +10,20 @@ import type { Element } from 'hast';
 import type { defineConfig as defineUmiConfig, IApi as IUmiApi } from 'umi';
 
 // ref: https://grrr.tech/posts/2021/typescript-partial/
+// 作用于函数类型的时候需要特殊处理一下
+type FunctionType = (...args: any[]) => any;
+
 type Subset<K> = {
   [attr in keyof K]?: K[attr] extends Array<any>
     ? K[attr]
-    : K[attr] extends Function
-    ? K[attr]
-    : K[attr] extends Function | null
-    ? K[attr] | null
-    : K[attr] extends Function | null | undefined
-    ? K[attr] | null | undefined
     : K[attr] extends object
     ? Subset<K[attr]>
+    : K[attr] extends FunctionType
+    ? K[attr]
+    : K[attr] extends FunctionType | null
+    ? K[attr] | null
+    : K[attr] extends FunctionType | null | undefined
+    ? K[attr] | null | undefined
     : K[attr] extends object | null
     ? Subset<K[attr]> | null
     : K[attr] extends object | null | undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,6 @@ import type { Element } from 'hast';
 import type { defineConfig as defineUmiConfig, IApi as IUmiApi } from 'umi';
 
 // ref: https://grrr.tech/posts/2021/typescript-partial/
-// 作用于函数类型的时候需要特殊处理一下
-type FunctionType = (...args: any[]) => any;
-
 type Subset<K> = {
   [attr in keyof K]?: K[attr] extends Array<any>
     ? K[attr]

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,12 @@ import type { defineConfig as defineUmiConfig, IApi as IUmiApi } from 'umi';
 type Subset<K> = {
   [attr in keyof K]?: K[attr] extends Array<any>
     ? K[attr]
+    : K[attr] extends Function
+    ? K[attr]
+    : K[attr] extends Function | null
+    ? K[attr] | null
+    : K[attr] extends Function | null | undefined
+    ? K[attr] | null | undefined
     : K[attr] extends object
     ? Subset<K[attr]>
     : K[attr] extends object | null


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?
- [x] 其他 / Other

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->
在defineConfig中使用chainWebpack配置的时候函数参数没有正确的类型推断



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix the type hinting of chainWebpack       |
| 🇨🇳 Chinese |    修复了配置文件对chainWebpack的类型提示       |
