### PR TITLE
fix: assets data may lost due to md loader cache

### DIFF
--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -148,6 +148,10 @@ export default function mdLoader(this: any, content: string) {
   const opts: IMdLoaderOptions = this.getOptions();
   const cb = this.async();
 
+  // disable cache for avoid onResolveDemos and onResolveAtomMeta not work
+  // and dumi already save cache by self, loader cache is unnecessary
+  this.cacheable(false);
+
   const cache = getCache('md-loader');
   // format: {path:mtime:loaderOpts}
   const baseCacheKey = [


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复资产元数据中的 demo 及原子资产 meta 在二次构建后可能部分丢失的问题，原因是 `md-loader` 结果被 webpack 缓存的情况下，与 assets.json 生成有关的钩子就不再执行，而 webpack 持久缓存是默认开启的，最终导致带缓存二次构建时部分元数据丢失。

解决方案：把 md-loader 标记为不可缓存，该行为不会影响性能，因为 dumi 已经对 Markdown 编译启用了自己的持久缓存，md-loader 重复执行也会复用上次编译好的结果。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix assets metadata may lost due to md loader cache |
| 🇨🇳 Chinese | 修复 loader 缓存导致部分资产元数据丢失的问题 |
