### PR TITLE
fix: hmr spent a long time due to disable loader cache

### DIFF
--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -148,10 +148,6 @@ export default function mdLoader(this: any, content: string) {
   const opts: IMdLoaderOptions = this.getOptions();
   const cb = this.async();
 
-  // disable cache for avoid onResolveDemos and onResolveAtomMeta not work
-  // and dumi already save cache by self, loader cache is unnecessary
-  this.cacheable(false);
-
   const cache = getCache('md-loader');
   // format: {path:mtime:loaderOpts}
   const baseCacheKey = [


### PR DESCRIPTION
This reverts commit 7b0a3fdde7615e493f3cce95234221398a351cb8.

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Since #1649 

### 💡 需求背景和解决方案 / Background or solution

禁用 loader 缓存后在 antd 项目中发现热更新耗时会非常长，固先 revert 之前的修复方案，后续再找其他办法解决

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix HMR spent a long time due to disable loader cache |
| 🇨🇳 Chinese | 修复 HMR 在禁用 loader 缓存后耗时过长的问题 |
