### PR TITLE
feat: .dumirc apiParser add propFilter skipPropsWithName config

### DIFF
--- a/examples/normal/.dumirc.ts
+++ b/examples/normal/.dumirc.ts
@@ -1,3 +1,8 @@
+const names = [
+  'skipProps1',
+  'skipProps2'
+];
+
 export default {
   locales: [
     { id: 'zh-CN', name: '中文' },
@@ -5,6 +10,10 @@ export default {
   ],
   themeConfig: { name: '示例' },
   mfsu: false,
-  apiParser: {},
+  apiParser: {
+    propFilter: {
+      skipPropsWithName: names
+    }
+  },
   resolve: { entryFile: './src/index.ts' },
 };

--- a/examples/normal/src/Foo/index.tsx
+++ b/examples/normal/src/Foo/index.tsx
@@ -4,6 +4,11 @@ interface A {
   a: string;
 }
 
+interface SkipProps {
+  skipProps1: string;
+  skipProps2: number;
+}
+
 const Foo: FC<{
   /**
    * @description 标题
@@ -24,7 +29,7 @@ const Foo: FC<{
   children: React.ReactNode;
   onConfirm: (output: { children: any[] }) => void;
   dom: HTMLElement;
-}> = (props) => {
+} & SkipProps> = (props) => {
   return <>{props.title}</>;
 };
 

--- a/src/features/parser.ts
+++ b/src/features/parser.ts
@@ -26,6 +26,7 @@ export default (api: IApi) => {
           unpkgHost: Joi.string().uri().optional(),
           resolveFilter: Joi.function().optional(),
           parseOptions: Joi.object().optional(),
+          propFilter: Joi.object().optional(),
         }),
     },
   });
@@ -56,6 +57,7 @@ export default (api: IApi) => {
       unpkgHost: api.config.apiParser!.unpkgHost,
       resolveFilter: api.config.apiParser!.resolveFilter,
       parseOptions: api.config.apiParser!.parseOptions,
+      propFilter: api.config.apiParser!.propFilter,
     });
   });
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature

### 🔗 相关 Issue / Related Issue

#1644 

### 💡 需求背景和解决方案 / Background or solution

实现 dumi v1 apiParser 中的 propFilter 内的 skipPropsWithName 配置。

对 `API` 生成的属性进行过滤

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Feature apiParser add propFilter skipPropsWithName config |
| 🇨🇳 Chinese |  按 dumi v1 apiParser 配置，新增 propFilter 的 skipPropsWithName属性，实现API自动生成属性过滤功能 |
