### PR TITLE
perf: avoid unnecessary re-rendering for demos

### DIFF
--- a/src/client/theme-api/DumiDemo.tsx
+++ b/src/client/theme-api/DumiDemo.tsx
@@ -36,37 +36,43 @@ const DemoErrorBoundary: FC<{ children: ReactNode }> = (props) => (
   </ErrorBoundary>
 );
 
-export const DumiDemo: FC<IDumiDemoProps> = (props) => {
-  const { demos, historyType } = useSiteData();
-  const { basename } = useAppData();
-  const { component, asset } = demos[props.demo.id];
+export const DumiDemo: FC<IDumiDemoProps> = React.memo(
+  (props) => {
+    const { demos, historyType } = useSiteData();
+    const { basename } = useAppData();
+    const { component, asset } = demos[props.demo.id];
 
-  // hide debug demo in production
-  if (process.env.NODE_ENV === 'production' && props.previewerProps.debug)
-    return null;
+    // hide debug demo in production
+    if (process.env.NODE_ENV === 'production' && props.previewerProps.debug)
+      return null;
 
-  if (props.demo.inline) {
-    return <DemoErrorBoundary>{createElement(component)}</DemoErrorBoundary>;
-  }
+    if (props.demo.inline) {
+      return <DemoErrorBoundary>{createElement(component)}</DemoErrorBoundary>;
+    }
 
-  const isHashRoute = historyType === 'hash';
+    const isHashRoute = historyType === 'hash';
 
-  return (
-    <Previewer
-      asset={asset}
-      demoUrl={
-        // allow user override demoUrl by frontmatter
-        props.previewerProps.demoUrl ||
-        // when use hash route, browser can automatically handle relative paths starting with #
-        `${isHashRoute ? `#` : ''}${basename}${SP_ROUTE_PREFIX}demos/${
-          props.demo.id
-        }`
-      }
-      {...props.previewerProps}
-    >
-      {props.previewerProps.iframe ? null : (
-        <DemoErrorBoundary>{createElement(component)}</DemoErrorBoundary>
-      )}
-    </Previewer>
-  );
-};
+    return (
+      <Previewer
+        asset={asset}
+        demoUrl={
+          // allow user override demoUrl by frontmatter
+          props.previewerProps.demoUrl ||
+          // when use hash route, browser can automatically handle relative paths starting with #
+          `${isHashRoute ? `#` : ''}${basename}${SP_ROUTE_PREFIX}demos/${
+            props.demo.id
+          }`
+        }
+        {...props.previewerProps}
+      >
+        {props.previewerProps.iframe ? null : (
+          <DemoErrorBoundary>{createElement(component)}</DemoErrorBoundary>
+        )}
+      </Previewer>
+    );
+  },
+  (prev, next) => {
+    // compare length for performance
+    return JSON.stringify(prev).length === JSON.stringify(next).length;
+  },
+);

--- a/src/loaders/markdown/transformer/rehypeDemo.ts
+++ b/src/loaders/markdown/transformer/rehypeDemo.ts
@@ -273,9 +273,9 @@ export default function rehypeDemo(
                 localId,
                 vFile.data.frontmatter!.atomId,
               );
-              component = `React.lazy(() => import( /* webpackChunkName: "${chunkName}" */ '${winPath(
+              component = `React.memo(React.lazy(() => import( /* webpackChunkName: "${chunkName}" */ '${winPath(
                 parseOpts.fileAbsPath,
-              )}?techStack=${techStack.name}'))`;
+              )}?techStack=${techStack.name}')))`;
               // use code value as title
               // TODO: force checking
               if (codeValue) codeNode.properties!.title = codeValue;

--- a/src/techStacks/react.ts
+++ b/src/techStacks/react.ts
@@ -36,9 +36,9 @@ export default class ReactTechStack implements IDumiTechStack {
         },
       });
 
-      return `React.lazy(async () => {
+      return `React.memo(React.lazy(async () => {
 ${code}
-})`;
+}))`;
     }
 
     return raw;


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [x] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Related: https://github.com/ant-design/ant-design/pull/42255

### 💡 需求背景和解决方案 / Background or solution

为 demo 包裹 `React.memo` 避免不必要的重新渲染，demo 没有 props 不需要响应父级的 re-render

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
