### PR TITLE
fix: search box may throw error in react 16

### DIFF
--- a/src/client/theme-default/slots/SearchBar/Input.tsx
+++ b/src/client/theme-default/slots/SearchBar/Input.tsx
@@ -36,9 +36,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       }}
       onChange={(ev) => {
         // wait for onCompositionEnd event be triggered
+        const value = ev.target.value;
         setTimeout(() => {
           if (!imeWaiting.current) {
-            props.onChange(ev.target.value);
+            props.onChange(value);
           }
         }, 1);
       }}


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

https://github.com/umijs/dumi/issues/1640 之前也有issue反馈类似问题

这个链接可以复现问题 [https://github.com/tgxpuisb/dumi-demo](https://github.com/tgxpuisb/dumi-demo)

### 💡 需求背景和解决方案 / Background or solution

Versions
- dumi: ^2.2.1
- node: >=14.18.1
- npm: 6.14.15
- OS: MacOS
- Browser: chrome 112.0.5615.138（正式版本） （64 位）
- react: 16.14.0
- react-dom: 16.14.0

在react16版本下，在搜索输入框中输入内容时报空指针错误。

<img width="1505" alt="image" src="https://github.com/umijs/dumi/assets/11400784/78f26a9c-7edf-4a6a-879b-3bbd9b6c0923">

查询原因与解决方案如下：

[https://github.com/tgxpuisb/dumi-demo/blob/master/README.md](https://github.com/tgxpuisb/dumi-demo/blob/master/README.md)

该问题在React高版本中没有复现，但考虑到React16版本还在大量使用中，还是期望能修复一下

### 📝 更新日志 / Changelog

不需要

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
