### PR TITLE
feat: support MDX remarkContainer-CodeGroup

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -92,9 +92,9 @@ dumi 内置了 Badge 组件，可以为 Markdown 内容（例如标题）添加�
 这是一条错误信息
 :::
 
-## CodeGroup
+## CodeGroup <Badge>2.2.2+</Badge>
 
-当你的代码需要根据不同环境来采用不同的方案的时候使用，例如：
+需要将多代码块合并成一个分组进行展示时，可以使用 CodeGroup 语法，例如：
 
 ````jsx
 /**
@@ -104,35 +104,75 @@ import SourceCode from 'dumi/theme/builtins/SourceCode';
 const content =
   ':::code-group \n\n' +
   '```bash npm\n' +
-  '$ npm install\n' +
+  '$ npm install -D dumi\n' +
   '```\n\n' +
   '```bash yarn\n' +
-  '$ yarn install\n' +
+  '$ yarn install -D dumi\n' +
   '```\n\n' +
   '```bash pnpm\n' +
-  '$ pnpm install\n' +
+  '$ pnpm install -D dumi\n' +
   '```\n\n' +
   ':::';
 export default () => <SourceCode lang="md">{content}</SourceCode>;
 ````
 
-##### 将会被渲染为：
+将会被渲染为：
 
 :::code-group
 
 ```bash npm
-$ npm install
+$ npm install -D dumi
 ```
 
 ```bash yarn
-$ yarn install
+$ yarn install -D dumi
 ```
 
 ```bash pnpm
-$ pnpm install
+$ pnpm install -D dumi
 ```
 
 :::
+
+或者直接使用内置 `<code-group>` 标签
+
+````jsx
+/**
+ * inline: true
+ */
+import SourceCode from 'dumi/theme/builtins/SourceCode';
+const content =
+  '<code-group>\n' +
+  '\n' +
+  '```js JavaScript\n' +
+  "const dumi = 'dumi';\n" +
+  '```\n\n' +
+  '```ts TypeScript\n' +
+  "const dumi: string = 'dumi';\n" +
+  '```\n\n' +
+  '```md MarkDown\n' +
+  'Welcome to Dumi! 😄\n' +
+  '```\n' +
+  '\n' +
+  '</code-group>\n';
+export default () => <SourceCode lang="md">{content}</SourceCode>;
+````
+
+<code-group>
+
+```js JavaScript
+const dumi = 'dumi';
+```
+
+```ts TypeScript
+const dumi: string = 'dumi';
+```
+
+```md MarkDown
+Welcome to Dumi! 😄
+```
+
+</code-group>
 
 ## Line Highlighting
 

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -92,6 +92,48 @@ dumi 内置了 Badge 组件，可以为 Markdown 内容（例如标题）添加�
 这是一条错误信息
 :::
 
+## CodeGroup
+
+当你的代码需要根据不同环境来采用不同的方案的时候使用，例如：
+
+````jsx
+/**
+ * inline: true
+ */
+import SourceCode from 'dumi/theme/builtins/SourceCode';
+const content =
+  ':::code-group \n\n' +
+  '```bash npm\n' +
+  '$ npm install\n' +
+  '```\n\n' +
+  '```bash yarn\n' +
+  '$ yarn install\n' +
+  '```\n\n' +
+  '```bash pnpm\n' +
+  '$ pnpm install\n' +
+  '```\n\n' +
+  ':::';
+export default () => <SourceCode lang="md">{content}</SourceCode>;
+````
+
+##### 将会被渲染为：
+
+:::code-group
+
+```bash npm
+$ npm install
+```
+
+```bash yarn
+$ yarn install
+```
+
+```bash pnpm
+$ pnpm install
+```
+
+:::
+
 ## Line Highlighting
 
 在代码块中，如果您想要突出显示特定的一行，可以使用行高亮功能。使用行高亮功能的语法如下：

--- a/src/client/theme-default/builtins/CodeGroup/index.less
+++ b/src/client/theme-default/builtins/CodeGroup/index.less
@@ -1,14 +1,37 @@
 @import (reference) '../../styles/variables.less';
 
-.@{prefix}-tabs {
+.dumi-default-tabs {
   padding: 0;
   background-color: @c-site-bg;
+  position: relative;
 
-  @{dark-selector} & {
+  &.@{dark-selector} {
     background-color: @c-site-bg-dark;
+  }
+
+  .tab {
+    display: inline-block;
+    height: 40px;
+    line-height: 40px;
+    margin-right: 20px;
+    cursor: pointer;
+  }
+
+  .active-tab {
+    color: #1677ff;
   }
 
   &-tabpane-hidden {
     display: none;
   }
+}
+
+.line {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 32px;
+  height: 2px;
+  background-color: #1677ff;
+  transition: left 0.4s ease;
 }

--- a/src/client/theme-default/builtins/CodeGroup/index.less
+++ b/src/client/theme-default/builtins/CodeGroup/index.less
@@ -1,0 +1,14 @@
+@import (reference) '../../styles/variables.less';
+
+.@{prefix}-tabs {
+  padding: 0;
+  background-color: @c-site-bg;
+
+  @{dark-selector} & {
+    background-color: @c-site-bg-dark;
+  }
+
+  &-tabpane-hidden {
+    display: none;
+  }
+}

--- a/src/client/theme-default/builtins/CodeGroup/index.tsx
+++ b/src/client/theme-default/builtins/CodeGroup/index.tsx
@@ -1,0 +1,43 @@
+import SourceCode from 'dumi/theme/builtins/SourceCode';
+import { Language } from 'prism-react-renderer';
+import Tabs from 'rc-tabs';
+import React from 'React';
+
+import './index.less';
+
+interface CodeGroupItem {
+  label: string;
+  key: string;
+  lang: Language;
+  codeValue: string;
+}
+
+interface CodeGroupProps {
+  items: CodeGroupItem[];
+  defaultActiveKey?: string;
+  prefixCls?: string;
+  className?: string;
+  moreIcon?: string;
+  onChange?: (activeKey: string) => void;
+}
+const CodeGroup: React.FC<CodeGroupProps> = ({
+  items,
+  defaultActiveKey = '1',
+  prefixCls = 'dumi-default-tabs',
+  ...restProps
+}) => {
+  return (
+    <Tabs
+      defaultActiveKey={defaultActiveKey}
+      prefixCls={prefixCls}
+      items={items.map(({ label, key, lang, codeValue }) => ({
+        label,
+        key,
+        children: <SourceCode lang={lang}>{codeValue}</SourceCode>,
+      }))}
+      {...restProps}
+    />
+  );
+};
+
+export default CodeGroup;

--- a/src/client/theme-default/builtins/CodeGroup/index.tsx
+++ b/src/client/theme-default/builtins/CodeGroup/index.tsx
@@ -1,7 +1,7 @@
 import SourceCode from 'dumi/theme/builtins/SourceCode';
 import { Language } from 'prism-react-renderer';
 import Tabs from 'rc-tabs';
-import React from 'React';
+import React from 'react';
 
 import './index.less';
 

--- a/src/client/theme-default/builtins/CodeGroup/index.tsx
+++ b/src/client/theme-default/builtins/CodeGroup/index.tsx
@@ -1,42 +1,41 @@
-import SourceCode from 'dumi/theme/builtins/SourceCode';
-import { Language } from 'prism-react-renderer';
-import Tabs from 'rc-tabs';
-import React from 'react';
-
+import React, { useEffect, useRef, useState } from 'react';
 import './index.less';
 
-interface CodeGroupItem {
+interface CodeGroupChildrenProps {
   label: string;
-  key: string;
-  lang: Language;
-  codeValue: string;
+  children: React.ReactNode;
 }
 
 interface CodeGroupProps {
-  items: CodeGroupItem[];
-  defaultActiveKey?: string;
-  prefixCls?: string;
-  className?: string;
-  moreIcon?: string;
-  onChange?: (activeKey: string) => void;
+  children: React.ReactElement<CodeGroupChildrenProps>[];
 }
-const CodeGroup: React.FC<CodeGroupProps> = ({
-  items,
-  defaultActiveKey = '1',
-  prefixCls = 'dumi-default-tabs',
-  ...restProps
-}) => {
+
+const CodeGroup: React.FC<CodeGroupProps> = ({ children }) => {
+  const [activeTab, setActiveTab] = useState(0);
+  const [linePosition, setLinePosition] = useState(0);
+
+  const lineRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setLinePosition(52 * activeTab);
+  }, [activeTab]);
+
   return (
-    <Tabs
-      defaultActiveKey={defaultActiveKey}
-      prefixCls={prefixCls}
-      items={items.map(({ label, key, lang, codeValue }) => ({
-        label,
-        key,
-        children: <SourceCode lang={lang}>{codeValue}</SourceCode>,
-      }))}
-      {...restProps}
-    />
+    <>
+      <div className="dumi-default-tabs" ref={lineRef}>
+        {children?.map((child, index) => (
+          <span
+            key={index}
+            className={index === activeTab ? 'active-tab tab' : 'tab'}
+            onClick={() => setActiveTab(index)}
+          >
+            {child.props.label}
+          </span>
+        ))}
+        <div className="line" style={{ left: linePosition }} />
+      </div>
+      <div className="tabs">{children?.[activeTab]}</div>
+    </>
   );
 };
 

--- a/src/client/theme-default/builtins/SourceCode/index.less
+++ b/src/client/theme-default/builtins/SourceCode/index.less
@@ -156,3 +156,11 @@
     }
   }
 }
+
+.@{prefix}-tabs {
+  padding: 0;
+
+  &-tabpane-hidden {
+    display: none;
+  }
+}

--- a/src/client/theme-default/builtins/SourceCode/index.less
+++ b/src/client/theme-default/builtins/SourceCode/index.less
@@ -156,11 +156,3 @@
     }
   }
 }
-
-.@{prefix}-tabs {
-  padding: 0;
-
-  &-tabpane-hidden {
-    display: none;
-  }
-}

--- a/src/loaders/markdown/transformer/rehypeEnhancedTag.ts
+++ b/src/loaders/markdown/transformer/rehypeEnhancedTag.ts
@@ -44,6 +44,34 @@ export default function rehypeEnhancedTag(): Transformer<Root> {
             },
           ],
         });
+      } else if (
+        node.tagName === 'code-group' &&
+        isElement(node.children?.[0]) &&
+        node.children[0].tagName === 'pre'
+      ) {
+        const items = node.children.map((codeTags, index) => {
+          //@ts-ignore
+          const codeTag = codeTags?.children?.[0];
+          return {
+            label: codeTag.data?.meta,
+            key: index,
+            lang: codeTag.properties.className[0].split('-')[1],
+            codeValue: codeTag.children[0].value,
+          };
+        });
+
+        parent!.children.splice(i!, 1, {
+          type: 'element',
+          tagName: 'CodeGroup',
+          JSXAttributes: [
+            {
+              type: 'JSXAttribute',
+              name: 'items',
+              value: JSON.stringify(items),
+            },
+          ],
+          children: [],
+        });
       } else if (node.tagName === 'table') {
         // use enhanced Table component
         node.tagName = 'Table';

--- a/src/loaders/markdown/transformer/rehypeEnhancedTag.ts
+++ b/src/loaders/markdown/transformer/rehypeEnhancedTag.ts
@@ -24,7 +24,6 @@ export default function rehypeEnhancedTag(): Transformer<Root> {
         const lang = className.join('').match(/language-(\w+)(?:$| )/)?.[1];
         const highlightLines = node.children[0].data
           ?.highlightLines as number[];
-
         parent!.children.splice(i!, 1, {
           type: 'element',
           tagName: 'SourceCode',
@@ -35,6 +34,11 @@ export default function rehypeEnhancedTag(): Transformer<Root> {
               type: 'JSXAttribute',
               name: 'highlightLines',
               value: JSON.stringify(highlightLines),
+            },
+            {
+              type: 'JSXAttribute',
+              name: 'label',
+              value: JSON.stringify(node.children[0].data?.meta),
             },
           ],
           children: [

--- a/src/loaders/markdown/transformer/remarkContainer.ts
+++ b/src/loaders/markdown/transformer/remarkContainer.ts
@@ -36,27 +36,20 @@ export default function remarkContainer(this: any): Transformer<Root> {
       ) {
         switch (node.name) {
           case 'code-group': {
-            //@ts-ignore
-            const items = node.children.map(({ meta, lang, value }, index) => ({
-              label: meta,
-              key: index,
-              lang,
-              codeValue: value,
-            }));
             // replace directive node with container node
-            parent!.children.splice(i!, 1, {
-              type: 'code',
-              lang: 'jsx',
-              value: `
-                /**\n
-                 * inline: true\n
-                 */\n
-                import CodeGroup from 'dumi/theme/builtins/CodeGroup';\n       
-                export default () => <CodeGroup items={${JSON.stringify(
-                  items,
-                )}}></CodeGroup>`,
-              position: node.position,
-            });
+            parent!.children.splice(
+              i!,
+              1,
+              {
+                type: 'html',
+                value: `<CodeGroup>`,
+                position: node.position,
+              },
+              ...(node.children || []).concat({
+                type: 'html',
+                value: '</CodeGroup>',
+              }),
+            );
             break;
           }
           default: {

--- a/src/loaders/markdown/transformer/remarkContainer.ts
+++ b/src/loaders/markdown/transformer/remarkContainer.ts
@@ -36,6 +36,13 @@ export default function remarkContainer(this: any): Transformer<Root> {
       ) {
         switch (node.name) {
           case 'code-group': {
+            //@ts-ignore
+            const items = node.children.map(({ meta, lang, value }, index) => ({
+              label: meta,
+              key: index,
+              lang,
+              codeValue: value,
+            }));
             // replace directive node with container node
             parent!.children.splice(i!, 1, {
               type: 'code',
@@ -44,20 +51,10 @@ export default function remarkContainer(this: any): Transformer<Root> {
                 /**\n
                  * inline: true\n
                  */\n
-                import Tabs from 'rc-tabs';\n
-                import SourceCode from 'dumi/theme/builtins/SourceCode';\n       
-                const nodeChildren = ${JSON.stringify(node.children)}         
-                export default () => (
-                  <Tabs
-                    prefixCls="dumi-default-tabs"
-                    defaultActiveKey="1"
-                    items={nodeChildren.map((item,index) => ({
-                      label:item.meta,
-                      key:index,
-                      children: <SourceCode lang={item.lang} >{item.value}</SourceCode>
-                    }))}
-                  />
-                );`,
+                import CodeGroup from 'dumi/theme/builtins/CodeGroup';\n       
+                export default () => <CodeGroup items={${JSON.stringify(
+                  items,
+                )}}></CodeGroup>`,
               position: node.position,
             });
             break;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #352 

### 💡 需求背景和解决方案 / Background or solution
使用 md 增强语法 快速编写展示不同环境语法的 code-group
![20230612235101_rec_](https://github.com/umijs/dumi/assets/94534613/3e867f24-8fbe-446d-96fa-bbeb2cb8f142)

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    feat: support MDX remarkContainer-CodeGroup       |
| 🇨🇳 Chinese |      支持在 MD 中快速编写不同环境的 CodeGroup     |
