### PR TITLE
chore: remove useless plugin opts in md transformer

### DIFF
--- a/src/loaders/markdown/transformer/index.ts
+++ b/src/loaders/markdown/transformer/index.ts
@@ -152,9 +152,7 @@ export default async (raw: string, opts: IMdTransformerOptions) => {
     .use(rehypeRaw, {
       fileAbsPath: opts.fileAbsPath,
     })
-    .use(rehypeHighlightLine, {
-      resolve: opts.resolve,
-    })
+    .use(rehypeHighlightLine)
     .use(rehypeRemoveComments, { removeConditional: true })
     .use(rehypeStrip)
     .use(rehypeImg)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
![6f1d659d39095a5a02b9aaaea30070e8](https://github.com/umijs/dumi/assets/94534613/d18e3cd3-8fed-4fb2-8899-cce649b783b1)

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix: useless arg lead to ts type error       |
| 🇨🇳 Chinese |     修复 unified 插件传参与定义不一致导致的ts error      |
