### PR TITLE
feat: Support toggle for type attribute of docDirs

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -26,7 +26,7 @@ export default defineConfig({
 
 #### docDirs
 
-- 类型：`string[]`
+- 类型：`(string | { type?: string; dir: string; pluralType? boolean })[]`
 - 默认值：`['docs']`
 
 配置 Markdown 文档的解析目录，路径下的 Markdown 文档会根据目录结构解析为路由。

--- a/src/features/routes.ts
+++ b/src/features/routes.ts
@@ -215,7 +215,7 @@ export default (api: IApi) => {
     });
 
     // generate normal docs routes
-    docDirs.map(normalizeDocDir).forEach(({ type, dir }) => {
+    docDirs.map(normalizeDocDir).forEach(({ type, dir, pluralType }) => {
       const base = path.join(api.cwd, dir);
       const dirRoutes: Record<string, IRoute> = getConventionRoutes({
         base,
@@ -228,9 +228,7 @@ export default (api: IApi) => {
 
         // also allow prefix type for doc routes
         if (type) {
-          const pluralType = plural(type);
-
-          route.path = `${pluralType}/${route.path}`.replace(/\/+$/, '/');
+          route.path = `${pluralType ? plural(type): type}/${route.path}`.replace(/\/+$/, '/');
           route.absPath = `/${route.path}`;
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ type IUmiConfig = Omit<
 
 interface IDumiExtendsConfig {
   resolve: {
-    docDirs: (string | { type?: string; dir: string })[];
+    docDirs: (string | { type?: string; dir: string; pluralType?: boolean })[];
     atomDirs: { type: string; subType?: string; dir: string }[];
     codeBlockMode: 'active' | 'passive';
     entryFile?: string;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

#1736 

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

在某些时候我可能不需要`docDirs.type`被复数化，并且官方文档中没有相关消息告知，一度认为自己的配置出了问题。所以在不破坏原有的代码逻辑下，新增了一个`pluralType`属性标识`type`是否允许被复数化。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Support toggle for type attribute of docDirs |
| 🇨🇳 Chinese | 为docDirs的type属性支持开关 |
