### PR TITLE
fix: schema definition for subType of atomDirs config

### DIFF
--- a/src/client/typings.d.ts
+++ b/src/client/typings.d.ts
@@ -1,8 +1,3 @@
-declare module '*.less' {
-  const classes: CSSModuleClasses;
-  export default classes;
-}
-
 declare module '*.svg' {
   import * as React from 'react';
   export const ReactComponent: React.FunctionComponent<

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -31,7 +31,13 @@ export function getSchemas(): Record<string, (Joi: JoiRoot) => any> {
           )
           .optional(),
         atomDirs: Joi.array()
-          .items(Joi.object({ type: Joi.string(), dir: Joi.string() }))
+          .items(
+            Joi.object({
+              type: Joi.string(),
+              subType: Joi.string().optional(),
+              dir: Joi.string(),
+            }),
+          )
           .optional(),
         codeBlockMode: Joi.string().valid('active', 'passive').optional(),
         entryFile: Joi.string().optional(),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1740 

### 💡 需求背景和解决方案 / Background or solution

修复配置 `resolve.atomDirs.[n].subType` 时 schema 校验不通过的问题

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix schema definition for subType of atomDirs config |
| 🇨🇳 Chinese | 修复 atomDirs 配置项中 subType 的 schema 定义 |
