### PR TITLE
fix: same anchor jump incorrectly when set base

### DIFF
--- a/src/client/theme-default/slots/Toc/index.tsx
+++ b/src/client/theme-default/slots/Toc/index.tsx
@@ -69,7 +69,7 @@ const Toc: FC = () => {
                       to={link}
                       onClickCapture={() => {
                         if (decodeURIComponent(hash).slice(1) === item.id) {
-                          history.replace(search);
+                          history.replace(`${pathname}${search}`);
                         }
                       }}
                       title={item.title}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1771 

### 💡 需求背景和解决方案 / Background or solution

修复非根目录部署时点击相同锚点会错误跳转到首页的问题

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix same anchor jump incorrectly when set base |
| 🇨🇳 Chinese | 修复非根目录部署时点击相同锚点会跳转错误的问题 |
