### PR TITLE
fix: nprogress always pending in custom react pages

### DIFF
--- a/src/client/theme-api/DumiPage.tsx
+++ b/src/client/theme-api/DumiPage.tsx
@@ -1,7 +1,6 @@
-import { useRouteMeta, useSiteData } from 'dumi';
+import { useRouteMeta } from 'dumi';
 import ContentTabs from 'dumi/theme/slots/ContentTabs';
-import nprogress from 'nprogress';
-import React, { useEffect, useState, type FC, type ReactNode } from 'react';
+import React, { useState, type FC, type ReactNode } from 'react';
 import { useTabQueryState } from './useTabMeta';
 
 export const DumiPage: FC<{ children: ReactNode }> = (props) => {
@@ -10,13 +9,6 @@ export const DumiPage: FC<{ children: ReactNode }> = (props) => {
   const [tab, setTab] = useState<NonNullable<typeof tabs>[0] | undefined>(() =>
     tabs?.find(({ key }) => key === tabKey),
   );
-  const { setLoading } = useSiteData();
-
-  // update loading status when page loaded
-  useEffect(() => {
-    setLoading(false);
-    nprogress.done();
-  }, []);
 
   return (
     <>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1750 

### 💡 需求背景和解决方案 / Background or solution

修复启用 nprogress 时，打开自定义 React 页面进度条不会完成的 bug，原因是之前仅对 Markdown 异步路由的加载状态做了捕获

新的解决方案是借助 Suspense 的 fallback 组件（也就是 Umi 的 loading 组件）来设置加载状态，dumi 总是会内置一个空白 loading 来处理加载逻辑，如果用户有配置 loading 时，dumi 的内置 loading 则会包在用户的外面，不影响原有功能

这个方案相比原方案的好处是：
1. 不局限于 Markdown 路由，而是针对所有异步路由生效（修复原始 issue）
2. fallback 组件 mount 时开始加载，unmount 时完成加载，时机上比监听 history 更简洁
3. 再次访问已经完成异步加载的页面时不会再展示 loading

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix nprogress always pending in custom react pages |
| 🇨🇳 Chinese | 修复自定义 React 页面中的 nprogress 始终处于加载态的问题 |
