### PR TITLE
refactor: improve min-height and no-sidebar mode for content

### DIFF
--- a/.dumi/theme/slots/HeaderExtra/index.less
+++ b/.dumi/theme/slots/HeaderExtra/index.less
@@ -1,0 +1,16 @@
+@import (reference) '../../../../theme-default/styles/variables.less';
+
+.@{prefix}-lang-select.dumi-version-select {
+  border-inline-start: 1px solid @c-border;
+  margin-inline-start: 15px;
+  padding-inline-start: 5px;
+
+  @{dark-selector} & {
+    border-inline-start-color: @c-border-dark;
+  }
+
+  > select {
+    padding-top: 1px;
+    padding-bottom: 1px;
+  }
+}

--- a/.dumi/theme/slots/HeaderExtra/index.tsx
+++ b/.dumi/theme/slots/HeaderExtra/index.tsx
@@ -1,18 +1,11 @@
 import { ReactComponent as IconDown } from '@ant-design/icons-svg/inline-svg/outlined/down.svg';
 import React, { type FC } from 'react';
+import './index.less';
 
 const HeaderExtra: FC = () => {
   return (
-    <div
-      className="dumi-default-lang-select"
-      style={{
-        borderInlineStart: '1px solid #d0d5d8',
-        marginInlineStart: 15,
-        paddingInlineStart: 5,
-      }}
-    >
+    <div className="dumi-default-lang-select dumi-version-select">
       <select
-        style={{ paddingTop: 1, paddingBottom: 1 }}
         value={process.env.DUMI_VERSION}
         onChange={(e) => {
           if (e.target.value !== process.env.DUMI_VERSION) {

--- a/src/client/theme-default/layouts/DocLayout/index.tsx
+++ b/src/client/theme-default/layouts/DocLayout/index.tsx
@@ -92,7 +92,7 @@ const DocLayout: FC = () => {
       <main>
         {showSidebar && <Sidebar />}
         <Content>
-          {outlet}
+          <article>{outlet}</article>
           <Footer />
         </Content>
         {fm.toc === 'content' && (

--- a/src/client/theme-default/slots/Content/index.less
+++ b/src/client/theme-default/slots/Content/index.less
@@ -142,7 +142,9 @@
 }
 
 .@{prefix}-content {
+  display: flex;
   flex: 1;
+  flex-direction: column;
   min-width: 0;
   max-width: 100%;
   box-sizing: border-box;
@@ -175,12 +177,16 @@
     }
   }
 
+  article {
+    flex: 1;
+  }
+
   .@{prefix}-header + main > &,
   .@{prefix}-doc-layout-mobile-bar + main > & {
     min-height: calc(100vh - @s-header-height);
 
     @media @mobile {
-      min-height: calc(100vh - @s-header-height-m);
+      min-height: calc(100vh - @s-header-height-m - 40px);
     }
   }
 

--- a/src/client/theme-default/slots/Content/index.less
+++ b/src/client/theme-default/slots/Content/index.less
@@ -139,6 +139,15 @@
       visibility: hidden;
     }
   }
+
+  // horizontal line
+  hr {
+    background-color: @c-border-light;
+
+    @{dark-selector} & {
+      background-color: @c-border-less-dark;
+    }
+  }
 }
 
 .@{prefix}-content {

--- a/src/client/theme-default/slots/Content/index.tsx
+++ b/src/client/theme-default/slots/Content/index.tsx
@@ -1,4 +1,4 @@
-import { useSidebarData, useSiteData } from 'dumi';
+import { useRouteMeta, useSidebarData, useSiteData } from 'dumi';
 import React, { type FC, type ReactNode } from 'react';
 import './heti.scss';
 import './index.less';
@@ -6,11 +6,12 @@ import './index.less';
 const Content: FC<{ children: ReactNode }> = (props) => {
   const sidebar = useSidebarData();
   const { themeConfig } = useSiteData();
+  const { frontmatter } = useRouteMeta();
 
   return (
     <div
       className="dumi-default-content"
-      data-no-sidebar={!sidebar || undefined}
+      data-no-sidebar={!sidebar || frontmatter.sidebar === false || undefined}
       data-no-footer={themeConfig.footer === false || undefined}
     >
       {props.children}

--- a/src/client/theme-default/slots/RtlSwitch/index.less
+++ b/src/client/theme-default/slots/RtlSwitch/index.less
@@ -2,6 +2,7 @@
 
 .@{prefix}-rtl-switch {
   height: 16px;
+  padding: 0;
   appearance: none;
   border: 0;
   background-color: transparent;

--- a/src/client/theme-default/slots/RtlSwitch/index.less
+++ b/src/client/theme-default/slots/RtlSwitch/index.less
@@ -13,6 +13,10 @@
     margin-inline-end: -15px;
     padding-inline: 15px;
     border-inline-start: 1px solid @c-border-light;
+
+    @{dark-selector} & {
+      border-inline-start-color: @c-border-less-dark;
+    }
   }
 
   > svg {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1789 

### 💡 需求背景和解决方案 / Background or solution

包含和 Content 有关的几处样式改进：
1. 页面内容区域增加 min-height，避免在内容过少时 Footer 部分往上顶
2. 通过 FrontMatter 手动禁用 sidebar 时不再展示 Content 容器，和首页的状态一致
3. 优化 `hr` 在暗色模式下的样式

另外顺便修改了 RTL 开关在暗色模式下的边框颜色

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve min-height and no-sidebar mode for content area |
| 🇨🇳 Chinese | 改进内容区域的 min-height 及关闭 sidebar 情况下的样式 |
