### PR TITLE
fix: code block demos conflict in different locale

### DIFF
--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -43,6 +43,7 @@ export default (api: IApi) => {
       extraRemarkPlugins: api.config.extraRemarkPlugins,
       extraRehypePlugins: api.config.extraRehypePlugins,
       routes: api.appData.routes,
+      locales: api.config.locales,
       pkg: api.pkg,
     };
 

--- a/src/loaders/markdown/transformer/index.test.ts
+++ b/src/loaders/markdown/transformer/index.test.ts
@@ -29,7 +29,15 @@ for (let casePath of cases) {
       techStacks: [new FakeTechStack()],
       cwd: path.dirname(fileAbsPath),
       fileAbsPath: fileAbsPath,
-      resolve: { codeBlockMode: 'active', atomDirs: [], docDirs: [] },
+      resolve: {
+        codeBlockMode: 'active',
+        atomDirs: [],
+        docDirs: [],
+        forceKebabCaseRouting: true,
+      },
+      locales: [],
+      routes: {},
+      pkg: {},
       alias: {
         '@': __dirname,
       },

--- a/src/loaders/markdown/transformer/remarkMeta.ts
+++ b/src/loaders/markdown/transformer/remarkMeta.ts
@@ -1,4 +1,8 @@
-import { getTabKeyFromFile, isTabRouteFile } from '@/features/tabs';
+import {
+  getHostForTabRouteFile,
+  getTabKeyFromFile,
+  isTabRouteFile,
+} from '@/features/tabs';
 import fs from 'fs';
 import yaml from 'js-yaml';
 import type { Root } from 'mdast';
@@ -21,12 +25,9 @@ let toString: typeof import('mdast-util-to-string').toString;
  * guess atom id from filename
  */
 function getGuessAtomId(opts: IRemarkMetaOpts) {
-  const parsed = path.parse(opts.fileAbsPath);
-  // strip modifier from markdown filename, such as $tab-xx, zh-CN & etc.
-  const clearFileName = parsed.name.replace(
-    /(?:\.$tab-[^.]+)?(?:\.[^.]+)?(\.[^.]+)$/,
-    '$1',
-  );
+  const parsed = path.parse(opts.fileLocaleLessPath);
+  // strip modifier from markdown filename, such as $tab-xx
+  const clearFileName = getHostForTabRouteFile(parsed.name);
   // find same name component file
   const atomFile = ['.tsx', '.jsx']
     .map((ext) => path.join(parsed.dir, `${clearFileName}${ext}`))
@@ -52,7 +53,7 @@ function getGuessAtomId(opts: IRemarkMetaOpts) {
 type IRemarkMetaOpts = Pick<
   IMdTransformerOptions,
   'cwd' | 'fileAbsPath' | 'resolve'
->;
+> & { fileLocaleLessPath: string };
 
 export default function remarkMeta(opts: IRemarkMetaOpts): Transformer<Root> {
   return (tree, vFile) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ interface IDumiExtendsConfig {
   extraRemarkPlugins?: (string | Function | [string | Function, object])[];
   extraRehypePlugins?: (string | Function | [string | Function, object])[];
 }
-export type IDumiConfig = IUmiConfig & IDumiExtendsConfig;
+export type IDumiConfig = Omit<IUmiConfig, 'locales'> & IDumiExtendsConfig;
 
 export type IDumiUserConfig = Subset<Omit<IDumiConfig, 'locales'>> & {
   locales?:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,10 +7,8 @@ import { lodash, logger, winPath } from 'umi/plugin-utils';
 /**
  * get route path from file-system path
  */
-export function getRoutePathFromFsPath(fsPath: string) {
-  return lodash.kebabCase(
-    winPath(fsPath).replace(/((\/|^)index(\.[a-zA-Z-]+)?)?\.\w+$/g, ''),
-  );
+export function getFileIdFromFsPath(fsPath: string) {
+  return lodash.kebabCase(winPath(fsPath).replace(/((\/|^)index)?\.\w+$/g, ''));
 }
 
 /**


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1780 

### 💡 需求背景和解决方案 / Background or solution

修复代码块 demo 在相同路由的不同 locale 或 tab 中会冲突的问题，例如 `docs/test`、`en-US/docs/test`、`docs/test?tab=other` 这 3 个路由下的代码块 demo 会冲突，原因是生成的 demo id 重复了

解决方案：给代码块 demo 的 id 中加上 locale 和 tab 的后缀，例如 `docs-test-demo-0-en-us` 或 `docs-test-demo-0-other`

除此之外顺便修复了自动 `atomId` 在带 locale 或 $tab 后缀的原子资产 Markdown 文件中生成失败的问题，这会导致 `src/Foo/index.md` 以 `foo-` 作为 demo id 前缀，而 `src/Foo/index.en-US.md` 却以 `src-foo-` 作为 demo id 前缀，天然区分开来了，这可能也是此前该问题没有用户反馈的原因之一

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix code block demos conflict bug in different locale route |
| 🇨🇳 Chinese | 修复代码块 demo 在不同 locale 路由中会冲突的问题 |
