### PR TITLE
fix: style compatibility for content footer navigation

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -138,10 +138,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: npm install
-      # 文档编译命令，如果是 react 模板需要修改为 npm run docs:build
-      - run: npm run build
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # 如果配置 themeConfig.lastUpdated 为 false，则不需要添加该参数以加快检出速度
+          fetch-depth: 0
+      - name: Install dependencies
+        run: npm install
+      - name: Build with dumi
+        # 文档编译命令，如果是 react 模板需要修改为 npm run docs:build
+        run: npm run build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docs/theme/default.md
+++ b/docs/theme/default.md
@@ -30,6 +30,8 @@ dumi 内置了一套完善的默认主题，默认主题的呈现效果与 dumi 
 
 配置是否在 Markdown 页面内容区域底部展示当前文档的最后更新时间。
 
+文档最后更新时间来源于 Git 提交记录，如果 Markdown 文档还未被 Git 追踪，那么则会展示构建时间；如果你的文档通过 GitHub Action 进行部署，还需要在 [actions/checkout](https://github.com/actions/checkout) 步骤中加上 `fetch-depth: 0` 参数以检出所有 Git 提交记录，确保可以 dumi 可以拿到正确的最后更新时间，具体可参考 [FAQ - 自动部署](../guide/faq.md#自动部署)。
+
 ### logo
 
 - 类型：`string | false`

--- a/src/client/theme-default/slots/ContentFooter/index.less
+++ b/src/client/theme-default/slots/ContentFooter/index.less
@@ -94,28 +94,36 @@
       }
 
       &[data-prev] {
-        float: inline-start;
+        float: left;
         padding-inline-end: 24px;
 
         svg {
           margin-inline-end: 4px;
+        }
 
-          [data-direction='rtl'] & {
+        [data-direction='rtl'] & {
+          float: right;
+
+          svg {
             transform: rotate(180deg);
           }
         }
       }
 
       &[data-next] {
-        float: inline-end;
+        float: right;
         text-align: end;
         padding-inline-start: 24px;
 
         svg {
           margin-inline-start: 4px;
           transform: rotate(180deg);
+        }
 
-          [data-direction='rtl'] & {
+        [data-direction='rtl'] & {
+          float: left;
+
+          svg {
             transform: rotate(0);
           }
         }

--- a/src/loaders/markdown/transformer/rehypeDemo.ts
+++ b/src/loaders/markdown/transformer/rehypeDemo.ts
@@ -1,6 +1,5 @@
 import parseBlockAsset from '@/assetParsers/block';
 import type { IDumiDemoProps } from '@/client/theme-api/DumiDemo';
-import { getTabKeyFromFile, isTabRouteFile } from '@/features/tabs';
 import { getFileIdFromFsPath } from '@/utils';
 import type { sync } from 'enhanced-resolve';
 import type { Element, Root } from 'hast';
@@ -286,10 +285,7 @@ export default function rehypeDemo(
                 path.relative(opts.cwd, parseOpts.fileAbsPath),
               );
             } else {
-              const tabKey = isTabRouteFile(opts.fileAbsPath)
-                ? getTabKeyFromFile(opts.fileAbsPath)
-                : '';
-              const localId = [tabKey, opts.fileLocale, String(index++)]
+              const localId = [opts.fileLocale, String(index++)]
                 .filter(Boolean)
                 .join('-');
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1796 

### 💡 需求背景和解决方案 / Background or solution

修复内容区域底部上一篇/下一篇链接在 Chrome 下的样式问题，原因是用了 `float` 的 `inline-start/inline-end` 值便于实现 RTL 模式，但该规范目前只有 Firefox 和 Safari 支持，参考：https://developer.mozilla.org/zh-CN/docs/Web/CSS/float#%E6%B5%8F%E8%A7%88%E5%99%A8%E5%85%BC%E5%AE%B9%E6%80%A7

另外顺便改了 2.2.2 的另外两个问题，不希望用户感知，不新提 PR 了：
1. 完善 `lastUpdated` 的配置项文档说明，并补充在 GitHub Action 中部署的注意点
2. 把 #1796 中对 tab 页 demo id 生成时的冗余调整去掉，避免 demo id 中包含两遍 tab key

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix style compatibility bug for content footer navigation |
| 🇨🇳 Chinese | 修复内容区域底部导航的样式兼容性问题 |
