### PR TITLE
fix: type error of INavItem， INavItem should support the activePath a…

### DIFF
--- a/src/client/theme-api/types.ts
+++ b/src/client/theme-api/types.ts
@@ -186,7 +186,7 @@ export type SocialTypes =
 
 export type INavItems = (INavItem & { children?: INavItem[] })[];
 export type INav = INavItems | Record<string, INavItems>;
-type IUserNavItem = Pick<INavItem, 'title' | 'link'>;
+type IUserNavItem = Pick<INavItem, 'title' | 'link' | 'activePath'>;
 export type IUserNavMode = 'override' | 'append' | 'prepend';
 export type IUserNavItems = (IUserNavItem & { children?: IUserNavItem[] })[];
 export type IUserNavValue = IUserNavItems | Record<string, IUserNavItems>;


### PR DESCRIPTION
…ttribute

<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

一个非常简单的类型bug，一级nav应该支持 activePath 实现高亮。 例如：
```
    {
        title: '生态',
        activePath: '/related',
        children: [
          {
            title: 'sub1',
            link: '/related/sub1'
          },
          {
            title: 'sub2',
            link: '/related/sub2'
          },
         
        ],
      },
```

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
