### PR TITLE
fix: cannot customize SearchResult slot

### DIFF
--- a/src/client/theme-default/slots/SearchBar/index.tsx
+++ b/src/client/theme-default/slots/SearchBar/index.tsx
@@ -3,7 +3,7 @@ import { ReactComponent as IconArrowUp } from '@ant-design/icons-svg/inline-svg/
 import { ReactComponent as IconSearch } from '@ant-design/icons-svg/inline-svg/outlined/search.svg';
 import { useSiteSearch } from 'dumi';
 import React, { useEffect, useRef, useState, type FC } from 'react';
-import SearchResult from '../SearchResult';
+import SearchResult from 'dumi/theme/slots/SearchResult';
 import './index.less';
 import { Input } from './Input';
 import { Mask } from './Mask';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

https://github.com/umijs/dumi/blob/master/src/client/theme-default/slots/SearchBar/index.tsx#L6C44-L6C44
在 `SearchBar` 中 引入 `SearchResult` 的方式有问题， 导致无法通过主题自定义 `SearchResult` 组件

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix: support to custom SearchResult     |
| 🇨🇳 Chinese |     修复：支持自定义SearchResult组件      |
