### PR TITLE
fix: babel compile failed for demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - master
+      - 1.x
 
 jobs:
   build:

--- a/packages/preset-dumi/package.json
+++ b/packages/preset-dumi/package.json
@@ -19,11 +19,11 @@
     "PeachScript <scdzwyxst@gmail.com> (https://github.com/PeachScript)"
   ],
   "dependencies": {
-    "@babel/core": "^7.7.2",
-    "@babel/generator": "^7.7.2",
-    "@babel/plugin-transform-modules-commonjs": "^7.7.2",
-    "@babel/traverse": "^7.7.2",
-    "@babel/types": "^7.7.2",
+    "@babel/core": "7.18.6",
+    "@babel/generator": "7.18.6",
+    "@babel/plugin-transform-modules-commonjs": "7.18.6",
+    "@babel/traverse": "7.18.6",
+    "@babel/types": "7.18.6",
     "@mapbox/hast-util-to-jsx": "1.0.0",
     "@umijs/babel-preset-umi": "^3.5.27",
     "@umijs/core": "^3.5.27",

--- a/packages/preset-dumi/src/index.test.ts
+++ b/packages/preset-dumi/src/index.test.ts
@@ -331,6 +331,10 @@ describe('preset-dumi', () => {
       presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
     });
 
+    // disable dist hash
+    await service.init();
+    service.config!.hash = false;
+
     // add UMI_DIR to avoid alias error
     process.env.UMI_DIR = path.dirname(require.resolve('umi/package'));
 
@@ -338,7 +342,7 @@ describe('preset-dumi', () => {
     process.env.BABEL_CACHE = 'none';
 
     // execute build
-    await service.run({ name: 'build' });
+    await service.runCommand({ name: 'build' });
     delete process.env.BABEL_CACHE;
 
     // expect css not be tree shaked
@@ -394,10 +398,14 @@ describe('preset-dumi', () => {
       presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
     });
 
+    // disable dist hash
+    await service.init();
+    service.config!.hash = false;
+
     // add UMI_DIR to avoid alias error
     process.env.UMI_DIR = path.dirname(require.resolve('umi/package'));
 
-    await service.run({
+    await service.runCommand({
       name: 'build',
     });
 
@@ -441,10 +449,14 @@ describe('preset-dumi', () => {
       presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
     });
 
+    // disable dist hash
+    await service.init();
+    service.config!.hash = false;
+
     // add UMI_DIR to avoid alias error
     process.env.UMI_DIR = path.dirname(require.resolve('umi/package'));
 
-    await service.run({
+    await service.runCommand({
       name: 'build',
     });
 
@@ -463,10 +475,14 @@ describe('preset-dumi', () => {
       presets: [require.resolve('@umijs/preset-built-in'), require.resolve('./index.ts')],
     });
 
+    // disable dist hash
+    await service.init();
+    service.config!.hash = false;
+
     // add UMI_DIR to avoid alias error
     process.env.UMI_DIR = path.dirname(require.resolve('umi/package'));
 
-    await service.run({
+    await service.runCommand({
       name: 'build',
     });
 

--- a/packages/preset-dumi/src/plugins/features/compile.ts
+++ b/packages/preset-dumi/src/plugins/features/compile.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import * as types from '@babel/types';
 import type { IApi } from '@umijs/types';
+import * as babel from '@babel/core';
 import type { PluginObj } from '@babel/core';
 import ctx from '../../context';
 
@@ -24,6 +25,7 @@ function dumiIsomorphicReactEffectPlugin(): PluginObj {
           callPathNode.imported.name === 'useLayoutEffect'
         ) {
           callPath.replaceWith(
+            // @ts-ignore
             types.importSpecifier(callPathNode.local, types.identifier('useEffect')),
           );
         }
@@ -41,6 +43,7 @@ function dumiIsomorphicReactEffectPlugin(): PluginObj {
           callPathNode.property.name === 'useLayoutEffect'
         ) {
           callPath.replaceWith(
+            // @ts-ignore
             types.memberExpression(callPathNode.object, types.identifier('useEffect')),
           );
         }
@@ -96,8 +99,8 @@ export default (api: IApi) => {
       .use('dumi-loader')
       .loader(require.resolve('../../loader'))
       .options({
-        previewLangs: ctx.opts.resolve.previewLangs,
-        passivePreview: ctx.opts.resolve.passivePreview
+        previewLangs: ctx.opts!.resolve.previewLangs,
+        passivePreview: ctx.opts!.resolve.passivePreview
       });
 
     // set asset type to javascript/auto to skip webpack internal json loader
@@ -118,8 +121,8 @@ export default (api: IApi) => {
 
   // watch .md files
   api.addTmpGenerateWatcherPaths(() => [
-    ...ctx.opts.resolve.includes.map(key => path.join(api.paths.cwd, key, '**/*.md')),
-    ...ctx.opts.resolve.examples.map(key => path.join(api.paths.cwd, key, '*.{tsx,jsx}')),
+    ...ctx.opts!.resolve.includes.map(key => path.join(api.paths.cwd!, key, '**/*.md')),
+    ...ctx.opts!.resolve.examples.map(key => path.join(api.paths.cwd!, key, '*.{tsx,jsx}')),
   ]);
 
   // replace all useLayoutEffect to useEffect for ssr

--- a/packages/preset-dumi/src/transformer/demo/index.ts
+++ b/packages/preset-dumi/src/transformer/demo/index.ts
@@ -115,6 +115,7 @@ export default (raw: string, opts: IDemoOpts): IDemoTransformResult => {
         if (isDynamicEnable() && !isHeaderHelpers) {
           // transform require('react') to await import ('react')
           callPath.replaceWith(
+            // @ts-ignore
             types.awaitExpression(
               types.callExpression(types.import(), [
                 types.stringLiteral(callPathNode.arguments[0].value),
@@ -165,6 +166,7 @@ export default (raw: string, opts: IDemoOpts): IDemoTransformResult => {
   }
 
   return {
+    // @ts-ignore
     content: generator(demoFunction, {}, raw).code,
   };
 };

--- a/packages/preset-dumi/src/transformer/fixtures/expect/demo-await-import.js
+++ b/packages/preset-dumi/src/transformer/fixtures/expect/demo-await-import.js
@@ -1,12 +1,17 @@
 dynamic({
   loader: async function () {
     var _interopRequireDefault = require("$CWD/node_modules/@umijs/babel-preset-umi/node_modules/@babel/runtime/helpers/interopRequireDefault.js")["default"];
+
     var _react = _interopRequireDefault(await import("react"));
+
     var _antd = await import("antd");
+
     await import("$CWD/packages/preset-dumi/src/transformer/fixtures/raw/index.less");
+
     var _default = function _default() {
       return /*#__PURE__*/_react["default"].createElement(_antd.Button, null);
     };
+
     return _default;
   },
   loading: () => null


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

https://github.com/ant-design/ant-design-pro/issues/10829

### 💡 需求背景和解决方案 / Background or solution

dumi v1 没有锁定 babel 版本但 Umi 3 预打包变相锁定了 babel 及相关插件的版本，而 `@babel/core@^7.22.6` 和 Umi 3 预打包的插件不兼容，会导致 demo 编译报错

解决方案：考虑到 Umi 3 升级 babel 的改动影响不好评估，所以锁定 dumi v1 版本的 babel 依赖与 Umi 3 预打包的 babel 保持一致，以修复该问题

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix babel compile failed for demo |
| 🇨🇳 Chinese | 修复 babel 编译 demo 失败的问题 |
