### PR TITLE
fix: ignore browserslist config when compiling demo in v1

### DIFF
--- a/packages/preset-dumi/src/transformer/demo/options.ts
+++ b/packages/preset-dumi/src/transformer/demo/options.ts
@@ -15,6 +15,7 @@ export const getBabelOptions = ({ isTSX, fileAbsPath, transformRuntime }: IDemoO
       {
         reactRequire: false,
         typescript: isTSX,
+        env: { ignoreBrowserslistConfig: true },
         ...(transformRuntime === undefined ? {} : { transformRuntime }),
       },
     ],


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1817 
https://github.com/ant-design/ant-design-pro/issues/10829

### 💡 需求背景和解决方案 / Background or solution

修复 dumi v1 在 package.json 包含 `browserslist` 配置时，demo 编译可能报错的问题。

该 PR 是 #1817 的补充，锁定 babel 版本只能解一小部分问题，在 ant-design-pro 项目中报错的真正原因是 package.json 配置中的 `browserslist` 配置值为百分比，但 browserslist 版本和 babel 版本对不上导致 targets 校验报错，解法是为 demo 编译的 babel 配置启用 `ignoreBrowserslistConfig` 配置项。

补充：
dumi demo 编译也是使用的 Umi 的 babel 配置，为什么 Umi 的 babel 编译不会报错而 dumi 的 demo 编译会报错？因为 babel 仅在未配置 `targets` 时才会尝试读取 `browserslist` 配置，Umi 层默认有 `targets` 所以不受影响，而 dumi demo 编译为了提升编译效率，没有配置 `targets` 所以走了自动读取 `browserslist` 的逻辑。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Ignore browserslist config when compiling demo |
| 🇨🇳 Chinese | 编译 demo 时忽略 browserslist 配置 |
