### PR TITLE
fix: incorrect tab query in memory history

### DIFF
--- a/src/client/theme-api/useTabMeta.ts
+++ b/src/client/theme-api/useTabMeta.ts
@@ -14,7 +14,7 @@ export const useTabQueryState = (): [string | null, (val?: string) => void] => {
 
       history.push({
         pathname,
-        search: params.toString(),
+        search: `?${params.toString()}`,
       });
     },
     [params],


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复在 MemoryHistory 场景下，页面 Tab 切换后 query 更新不正确的问题，这会导致 `useLocation` 拿到的 `search` 值不正确，影响包含 TOC 链接地址在内的其他功能。

原因是 MemoryHistory 的 push 方法不会自动对 `params` 参数加上 `?` 前缀，与 BrowserHistory 的行为不一致，复现链接：https://codesandbox.io/s/quirky-fast-xgvcyy?file=/src/App.js

解法是手动补上 `?` 前缀确保无论在 MemoryHistory 还是 BrowserHistory 下都可以工作。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect tab query in memory history |
| 🇨🇳 Chinese | 修复 memory history 下 tab query 参数不正确的问题 |
