### PR TITLE
fix: toc lost bug when page is full reload

### DIFF
--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -392,7 +392,7 @@ const entryExports = {
 
 export default function DumiContextWrapper() {
   const outlet = useOutlet();
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const prev = useRef(history.location.pathname);
 
   useEffect(() => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1816 

### 💡 需求背景和解决方案 / Background or solution

修复页面整体重新加载（例如刷新浏览器标签页）时，toc 不展示的问题，原因是 #1793 改了 loading 状态更新的逻辑，非前端路由切换不再更新 loading 状态，所以默认的 loading 状态需要从 `true` 调整为 `false`。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix toc lost bug when page is full reload |
| 🇨🇳 Chinese | 修复页面整体重新加载时 TOC 丢失的问题 |
