### PR TITLE
feat: omit prefix symbol automatically when copying shell code

### DIFF
--- a/src/client/theme-default/builtins/SourceCode/index.tsx
+++ b/src/client/theme-default/builtins/SourceCode/index.tsx
@@ -28,10 +28,16 @@ const SourceCode: FC<SourceCodeProps> = (props) => {
   const [isCopied, setIsCopied] = useState(false);
   const { themeConfig } = useSiteData();
 
+  let text = '';
+  const isShell = /shellscript|shell|bash|sh|zsh/.test(lang);
+  if (isShell) {
+    text = children.replace(/^ *(\$|>) /gm, '');
+  }
+  
   return (
     <div className="dumi-default-source-code">
       <CopyToClipboard
-        text={children}
+        text={text}
         onCopy={() => {
           setIsCopied(true);
           clearTimeout(timer.current);

--- a/src/client/theme-default/builtins/SourceCode/index.tsx
+++ b/src/client/theme-default/builtins/SourceCode/index.tsx
@@ -31,7 +31,7 @@ const SourceCode: FC<SourceCodeProps> = (props) => {
   let text = '';
   const isShell = /shellscript|shell|bash|sh|zsh/.test(lang);
   if (isShell) {
-    text = children.replace(/^ *(\$|>) /gm, '');
+    text = children.replace(/^(\$|>)\s/gm, '');
   }
   
   return (

--- a/src/client/theme-default/builtins/SourceCode/index.tsx
+++ b/src/client/theme-default/builtins/SourceCode/index.tsx
@@ -26,15 +26,16 @@ const SourceCode: FC<SourceCodeProps> = (props) => {
   const { children = '', lang, highlightLines = [] } = props;
   const timer = useRef<number>();
   const [isCopied, setIsCopied] = useState(false);
+  const [text, setText] = useState(children);
   const { themeConfig } = useSiteData();
 
-  let text = '';
   useEffect(() => {
     const isShell = /shellscript|shell|bash|sh|zsh/.test(lang);
     if (isShell) {
-      text = children.replace(/^(\$|>)\s/gm, '');
+      const text = children.replace(/^(\$|>)\s/gm, '');
+      setText(text);
     }
-  }, [lang]);
+  }, [lang, children]);
     
   return (
     <div className="dumi-default-source-code">

--- a/src/client/theme-default/builtins/SourceCode/index.tsx
+++ b/src/client/theme-default/builtins/SourceCode/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { useSiteData } from 'dumi';
 import Highlight, { defaultProps, type Language } from 'prism-react-renderer';
 import 'prism-themes/themes/prism-one-light.css';
-import React, { useRef, useState, type FC } from 'react';
+import React, { useRef, useState, useEffect, type FC } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import './index.less';
 
@@ -29,11 +29,13 @@ const SourceCode: FC<SourceCodeProps> = (props) => {
   const { themeConfig } = useSiteData();
 
   let text = '';
-  const isShell = /shellscript|shell|bash|sh|zsh/.test(lang);
-  if (isShell) {
-    text = children.replace(/^(\$|>)\s/gm, '');
-  }
-  
+  useEffect(() => {
+    const isShell = /shellscript|shell|bash|sh|zsh/.test(lang);
+    if (isShell) {
+      text = children.replace(/^(\$|>)\s/gm, '');
+    }
+  }, [lang]);
+    
   return (
     <div className="dumi-default-source-code">
       <CopyToClipboard


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

Taking [Ant Design's docs](https://ant.design/docs/react/use-with-create-react-app#import-antd) as an example:

```bash
$ npm install antd --save
```

When you click the "Copy" button, the result will be:

`$ npm install antd --save`

After applying the code from this commit, the result will be:

`npm install antd --save`

This is more in line with expectations.


### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | remove leading spaces and specific characters when copying shell code in `SourceCode` |
| 🇨🇳 Chinese | 在 `SourceCode` 中复制 shell 代码时，去除行首的空格和特定字符 |
