### PR TITLE
fix: routes not updated when atom md file is changed

### DIFF
--- a/src/features/routes.ts
+++ b/src/features/routes.ts
@@ -107,17 +107,15 @@ function getAliasLayoutFile({
 }
 
 export default (api: IApi) => {
-  const extraWatchPaths = [
-    ...(api.userConfig.resolve?.atomDirs || []),
-    ...(api.userConfig.resolve?.docDirs?.map(normalizeDocDir) || [
-      { dir: 'docs' },
-    ]),
-  ].map(({ dir }) => path.join(api.cwd, dir, '**/*.md'));
-
   api.describe({ key: 'dumi:routes' });
 
   // watch docs paths to re-generate routes
-  api.addTmpGenerateWatcherPaths(() => extraWatchPaths);
+  api.addTmpGenerateWatcherPaths(() =>
+    [
+      ...api.config.resolve.atomDirs,
+      ...api.config.resolve.docDirs.map(normalizeDocDir),
+    ].map(({ dir }) => path.join(api.cwd, dir, '**/*.md')),
+  );
 
   api.modifyDefaultConfig((memo) => {
     // support to disable docDirs & atomDirs by empty array


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复默认配置情况下，在原子资产目录（`src`）下的 Markdown 文件变化时路由表不会更新的问题，原因是生成 watch 目录的逻辑不对，应该在钩子函数里取 `api.config` 基于最终配置生成 watch 目录。

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix routes not updated when atom md file is changed |
| 🇨🇳 Chinese | 修复原子资产 md 文件变更时路由表不更新的问题 |
