### PR TITLE
fix: incorrect conventional 2-level nav in localized routes

### DIFF
--- a/src/client/theme-api/useNavData.ts
+++ b/src/client/theme-api/useNavData.ts
@@ -6,6 +6,7 @@ import type {
   IUserNavItems,
   IUserNavMode,
 } from './types';
+import { getLocaleClearPath } from './useSidebarData';
 import {
   getLocaleNav,
   pickRouteSortMeta,
@@ -64,7 +65,10 @@ export const useNavData = () => {
         .sort(([a], [b]) => a.split('/').length - b.split('/').length)
         // convert sidebar data to nav data
         .reduce<Record<string, INavItems[0]>>((ret, [link, groups]) => {
-          const [, parentPath, restPath] = link.match(/^(\/[^/]+)([^]+)?$/)!;
+          const [, parentPath, restPath] = `/${getLocaleClearPath(
+            link.replace(/^\//, ''),
+            locale,
+          )}`.match(/^(\/[^/]+)([^]+)?$/)!;
           const isNestedNav = Boolean(restPath) && is2LevelNav;
           const [firstMeta, secondMeta] = Object.values(routes).reduce<
             {

--- a/src/client/theme-api/useSidebarData.ts
+++ b/src/client/theme-api/useSidebarData.ts
@@ -15,7 +15,10 @@ import {
 
 const DEFAULT_GROUP_STUB_TITLE = '$default-group-title';
 
-const getLocaleClearPath = (routePath: string, locale: ILocalesConfig[0]) => {
+export const getLocaleClearPath = (
+  routePath: string,
+  locale: ILocalesConfig[0],
+) => {
   return 'base' in locale
     ? routePath.replace(locale.base.slice(1), '').replace(/^\//, '')
     : routePath;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

- #1815 

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

在英文下，`src` 目录的路由名称被解析成了分组的名称

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     the resolution of the src directory does not work in english      |
| 🇨🇳 Chinese |     英文下 src 目录解析失效      |
