### PR TITLE
fix: toc may lost when visiting loaded pages

### DIFF
--- a/src/client/theme-default/slots/Toc/index.tsx
+++ b/src/client/theme-default/slots/Toc/index.tsx
@@ -23,7 +23,6 @@ const Toc: FC = () => {
   const { loading } = useSiteData();
   const prevIndexRef = useRef(0);
   const [sectionRefs, setSectionRefs] = useState<RefObject<HTMLElement>[]>([]);
-
   const memoToc = React.useMemo(() => {
     let toc = meta.toc;
     if (tabMeta) {
@@ -43,7 +42,7 @@ const Toc: FC = () => {
 
       setSectionRefs(refs as any);
     }
-  }, [pathname, search, loading]);
+  }, [pathname, search, loading, memoToc]);
 
   return sectionRefs.length ? (
     <ScrollSpy sectionRefs={sectionRefs}>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1842

### 💡 需求背景和解决方案 / Background or solution

修复二次访问加载过的页面时，TOC 可能会丢失的问题；原因是 useEffect 没有响应 `memoToc` 数据的变更

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix toc may lost when visiting loaded pages |
| 🇨🇳 Chinese | 修复二次访问加载过的页面时 TOC 可能会丢失的问题 |
