### PR TITLE
feat: page-tab default tab supports internationalized interpolation

### DIFF
--- a/src/client/theme-default/slots/ContentTabs/index.tsx
+++ b/src/client/theme-default/slots/ContentTabs/index.tsx
@@ -16,6 +16,7 @@ const ContentTabs: FC<IContentTabsProps> = ({
   onChange,
 }) => {
   const intl = useIntl();
+  const { frontmatter: fm } = useRouteMeta();
 
   // TODO: tab.Extra & tab.Action render
 
@@ -23,7 +24,7 @@ const ContentTabs: FC<IContentTabsProps> = ({
     <ul className="dumi-default-content-tabs">
       <li onClick={() => onChange()} data-active={!key || undefined}>
         <button type="button">
-          {intl.formatMessage({ id: 'content.tabs.default' })}
+          {fm.title || intl.formatMessage({ id: 'content.tabs.default' })}
         </button>
       </li>
       {tabs!.map((tab) => (

--- a/src/client/theme-default/slots/ContentTabs/index.tsx
+++ b/src/client/theme-default/slots/ContentTabs/index.tsx
@@ -16,7 +16,7 @@ const ContentTabs: FC<IContentTabsProps> = ({
   onChange,
 }) => {
   const intl = useIntl();
-  const { frontmatter: fm } = useRouteMeta();
+  const { frontmatter } = useRouteMeta();
 
   // TODO: tab.Extra & tab.Action render
 
@@ -24,7 +24,7 @@ const ContentTabs: FC<IContentTabsProps> = ({
     <ul className="dumi-default-content-tabs">
       <li onClick={() => onChange()} data-active={!key || undefined}>
         <button type="button">
-          {fm.title || intl.formatMessage({ id: 'content.tabs.default' })}
+          {intl.formatMessage({ id: 'content.tabs.default' }, frontmatter)}
         </button>
       </li>
       {tabs!.map((tab) => (


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

#### 需求背景

社区反馈群反馈 tabs 第一个按钮标题无法修改。 

<img width="1043" alt="image" src="https://github.com/umijs/dumi/assets/32004925/a9d8925d-aeed-4970-9763-ade2f164a65c">

#### 解决方案

~~读取当前页面 frontmatter 信息。优先使用 title ，其次使用国际化 title~~

在默认 tab 保持国际化语言情况下，支持国际化插值来自定义第一个标题。

**example:**

https://github.com/umijs/dumi/blob/0ec05deea399efd013c8336a186e277fd7e99592/src/client/theme-default/locales/en-US.json#L35

```json
"content.tabs.default": "Doc-{title}",
```
**proview:**

<img width="606" alt="image" src="https://github.com/umijs/dumi/assets/32004925/4658b917-3bb9-42f4-81a1-234d0c737dc1">


<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     page-tab default tab prioritizes frontmatter title      |
| 🇨🇳 Chinese |     页面 tab 默认选项优先采用当前    frontmatter title   |
