### PR TITLE
fix: unexpected transform for tags within attribute

### DIFF
--- a/src/loaders/markdown/transformer/fixtures/react-component/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/react-component/expect.ts
@@ -6,4 +6,8 @@ export default (ret: IMdTransformerResult) => {
   expect(ret.content).toContain('bar2=""');
   expect(ret.content).toContain('<HelloWorld>');
   expect(ret.content).toContain('<invalid />');
+
+  // don't transform tagName which is part of attr value
+  expect(ret.content).toContain('value="Array<Function>"');
+  expect(ret.content).toContain('html="<Some a></Some>"');
 };

--- a/src/loaders/markdown/transformer/fixtures/react-component/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/react-component/expect.ts
@@ -10,4 +10,6 @@ export default (ret: IMdTransformerResult) => {
   // don't transform tagName which is part of attr value
   expect(ret.content).toContain('value="Array<Function>"');
   expect(ret.content).toContain('html="<Some a></Some>"');
+  expect(ret.content).toContain('value="<Some a></Some>"');
+  expect(ret.content).toContain('html=&quot;<Other a></Other>&quot');
 };

--- a/src/loaders/markdown/transformer/fixtures/react-component/index.md
+++ b/src/loaders/markdown/transformer/fixtures/react-component/index.md
@@ -7,3 +7,6 @@
 <API value="Array<Function>">
   <APIField html="<Some a></Some>"></APIField>
 </API>
+
+<input value='<Some a></Some>' />
+<input value='<Some html="<Other a></Other>"></Some>' />

--- a/src/loaders/markdown/transformer/fixtures/react-component/index.md
+++ b/src/loaders/markdown/transformer/fixtures/react-component/index.md
@@ -3,3 +3,7 @@
 <HelloWorld>dumi</HelloWorld>
 
 <inValid></inValid>
+
+<API value="Array<Function>">
+  <APIField html="<Some a></Some>"></APIField>
+</API>

--- a/src/loaders/markdown/transformer/rehypeRaw.ts
+++ b/src/loaders/markdown/transformer/rehypeRaw.ts
@@ -5,7 +5,7 @@ import type { IMdTransformerOptions } from '.';
 
 let raw: typeof import('hast-util-raw').raw;
 let visit: typeof import('unist-util-visit').visit;
-const COMPONENT_NAME_REGEX = /<[A-Z][a-zA-Z\d]*/g;
+const COMPONENT_NAME_REGEX = /(<)([A-Z][a-zA-Z\d]*)([\s|>])/g;
 const COMPONENT_PROP_REGEX = /\s[a-z][a-z\d]*[A-Z]+[a-zA-Z\d]*(=|\s|>)/g;
 const COMPONENT_STUB_ATTR = '$tag-name';
 const PROP_STUB_ATTR = '-$u';
@@ -29,11 +29,19 @@ export default function rehypeRaw(opts: IRehypeRawOptions): Transformer<Root> {
       if (node.type === 'raw' && COMPONENT_NAME_REGEX.test(node.value)) {
         // mark tagName for all custom react component
         // because the parse5 within hast-util-raw will lowercase all tag names
-        node.value = node.value.replace(COMPONENT_NAME_REGEX, (str) => {
-          const tagName = str.slice(1);
+        node.value = node.value.replace(
+          COMPONENT_NAME_REGEX,
+          (str, bracket, tagName, next, i, full) => {
+            const isWithinQuotes =
+              /="[^"]*$/.test(full.slice(0, i)) &&
+              /^[^"]*"/.test(full.slice(i));
 
-          return `${str} ${COMPONENT_STUB_ATTR}="${tagName}"`;
-        });
+            // skip if tagName is part of attr value
+            return isWithinQuotes
+              ? str
+              : `${bracket}${tagName} ${COMPONENT_STUB_ATTR}="${tagName}"${next}`;
+          },
+        );
         // mark all camelCase props for all custom react component
         // because the parse5 within hast-util-raw will lowercase all attr names
         node.value = node.value.replace(COMPONENT_PROP_REGEX, (str) => {
@@ -55,7 +63,7 @@ File: ${opts.fileAbsPath}`);
       }
     });
 
-    const newTree = raw(tree, vFile) as Root;
+    const newTree = raw(tree, { file: vFile }) as Root;
 
     visit<Root, 'element'>(newTree, 'element', (node) => {
       if (node.properties?.[COMPONENT_STUB_ATTR]) {

--- a/src/loaders/markdown/transformer/rehypeRaw.ts
+++ b/src/loaders/markdown/transformer/rehypeRaw.ts
@@ -33,8 +33,10 @@ export default function rehypeRaw(opts: IRehypeRawOptions): Transformer<Root> {
           COMPONENT_NAME_REGEX,
           (str, bracket, tagName, next, i, full) => {
             const isWithinQuotes =
-              /="[^"]*$/.test(full.slice(0, i)) &&
-              /^[^"]*"/.test(full.slice(i));
+              (/="[^"]*$/.test(full.slice(0, i)) &&
+                /^[^"]*"/.test(full.slice(i))) ||
+              (/='[^']*$/.test(full.slice(0, i)) &&
+                /^[^']*'/.test(full.slice(i)));
 
             // skip if tagName is part of attr value
             return isWithinQuotes


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1836 
Ref: #1861 

### 💡 需求背景和解决方案 / Background or solution

修复 Markdown 组件属性上的标签被意外转换的 bug，解法有两个：

1. 参考 #1861 对正则做优化，仅 `<Foo ` 或 `<Foo>` 的匹配才被认定为是组件，这样可以直接过滤掉类似 `Array<Function>` 的类型声明
2. 在正则匹配替换时，对匹配字符串的前后内容做识别，如果发现是 `="...{匹配值}..."` 就认定是在属性内的值不做处理，这样可以覆盖类似 `<CodeEditor value="<Foo bar></Foo>"></CodeEditor>` 的场景

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix unexpected transform for tags within attribute |
| 🇨🇳 Chinese | 修复属性内的标签字符串被意外转换的问题 |
