### PR TITLE
fix: tsconfig include default value and warning msg

### DIFF
--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -149,8 +149,10 @@ export default (api: IApi) => {
           `Please append ${expected
             .map((e) => `\`${e}\``)
             .join(
-              ' & ',
-            )} into \`include\` option of \`tsconfig.json\`, to make sure the types exported by framework works.`,
+              ', ',
+            )} into \`include\` option of \`tsconfig.json\`, to make sure the type prompt works for ${
+            expected.length > 1 ? 'them' : 'it'
+          }.`,
         );
       }
     } catch {}

--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -112,6 +112,16 @@ export default (api: IApi) => {
       const configFileName = api.service.configManager?.mainConfigFile;
       const expected = [];
 
+      // remove wrong .dumi/**/* include from previous dumi version
+      if (tsconfig.include?.includes('.dumi/**/*')) {
+        tsconfig.include = tsconfig.include.filter((i) => i !== '.dumi/**/*');
+        fs.writeFileSync(
+          tsconfigPath,
+          JSON.stringify(tsconfig, null, 2),
+          'utf-8',
+        );
+      }
+
       // only .dumirc.ts need to be included, because the dot files will be excluded by default
       if (configFileName && /[\\/]\.[^\\/]+\.ts$/.test(configFileName)) {
         expected.push(winPath(path.relative(api.cwd, configFileName)));

--- a/suites/boilerplate/templates/react/tsconfig.json.tpl
+++ b/suites/boilerplate/templates/react/tsconfig.json.tpl
@@ -12,5 +12,5 @@
       "{{{ name }}}/*": ["src/*", "*"]
     }
   },
-  "include": [".dumi/**/*", ".dumirc.ts", "src/**/*"]
+  "include": [".dumirc.ts", "src/**/*"]
 }

--- a/suites/boilerplate/templates/site/tsconfig.json.tpl
+++ b/suites/boilerplate/templates/site/tsconfig.json.tpl
@@ -8,5 +8,5 @@
       "@@/*": [".dumi/tmp/*"]
     }
   },
-  "include": [".dumi/**/*", ".dumirc.ts"]
+  "include": [".dumirc.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     },
     "types": ["vitest/globals"]
   },
-  "include": [".dumi/**/*", ".dumirc.ts", "src/**/*"]
+  "include": [".dumi/theme/**/*", ".dumi/app.tsx", ".dumirc.ts", "src/**/*"]
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

之前 tsconfig.json `include` 配置项的脚手架默认值和框架警告提示都包含 `.dumi/**/*`，示例：

```bash
warn  - Please append `.dumi/**/*` & `.dumirc.ts` into `include` option of `tsconfig.json`, to make sure the types exported by framework works.
```

如果用户照做的话，会导致 dumi 的临时文件目录 `.dumi/tmp` 也被包含进去，在项目执行 tsc 时将会包含不必要的检查，甚至可能抛出不该用户关心的类型错误。

所以该 PR 做了 3 处改动：
1. 对脚手架的 tsconfig.json 均去除 `.dumi/**/*`
2. 对存量 tsconfig.json 检测到 `.dumi/**/*`（用户已修复过）会自动帮用户去除，并根据需要把 `.dumi` 下的其他文件加进去，尽可能让已经处理过的用户或通过新脚手架创建的用户不感知这个二次修复
3. 对存量 tsconfig.json 未检测到 `.dumi/**/*`（用户还没修复过），但同时又使用到 `.dumi` 文件夹下的 TypeScript 约定式文件（比如 `.dumi/app.tsx`、`.dumi/theme/**/*`）做针对性警告提示，建议用户将它们添加到 tsconfig.json include 中

额外说明：为什么需要额外将 `.dumi` 下的 TypeScript 文件添加到 `include` 中？因为 `include` 的默认值是 `**/*`，不包含 `.` 开头的隐藏文件，如果不添加的话会导致相关文件丢失 TypeScript 类型提示

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix tsconfig include default value and warning msg |
| 🇨🇳 Chinese | 修复 tsconfig include 的值及相关警告信息 |
