### PR TITLE
perf: loadSearchData on focus & show loading only once

### DIFF
--- a/src/client/theme-api/useSiteSearch/index.ts
+++ b/src/client/theme-api/useSiteSearch/index.ts
@@ -38,9 +38,7 @@ if (typeof window !== 'undefined') {
 
 export const useSiteSearch = () => {
   const debounceTimer = useRef<number>();
-  // const routes = useLocaleDocRoutes();
-  // const { demos } = useSiteData();
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [keywords, setKeywords] = useState('');
   const [enabled, setEnabled] = useState(false);
   const navData = useNavData();

--- a/src/client/theme-default/slots/SearchBar/index.tsx
+++ b/src/client/theme-default/slots/SearchBar/index.tsx
@@ -80,6 +80,7 @@ const SearchBar: FC = () => {
       <Input
         onFocus={() => {
           setFocusing(true);
+          loadSearchData();
         }}
         onMouseEnter={() => {
           loadSearchData();

--- a/src/client/theme-default/slots/SearchResult/index.tsx
+++ b/src/client/theme-default/slots/SearchResult/index.tsx
@@ -119,6 +119,13 @@ const SearchResult: FC<{
 }> = (props) => {
   const [data, histsCount] = useFlatSearchData(props.data);
   const [activeIndex, setActiveIndex] = useState(-1);
+  const [loading, setLoading] = useState(props.loading);
+
+  useEffect(() => {
+    if (!props.loading) {
+      setLoading(false);
+    }
+  }, [props.loading]);
 
   useEffect(() => {
     const handler = (ev: KeyboardEvent) => {
@@ -149,7 +156,7 @@ const SearchResult: FC<{
 
   let returnNode: React.ReactNode = null;
 
-  if (props.loading) {
+  if (loading) {
     returnNode = (
       <div className="dumi-default-search-empty">
         <IconInbox />


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [x] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
1. 搜索框聚焦时同样会加载异步 chunk（通过键盘搜索）
2. 只在初次输入时显示 loading
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |      -     |
