### PR TITLE
refactor: use content hash as cache key for md loader

### DIFF
--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -1,8 +1,8 @@
 import { isTabRouteFile } from '@/features/tabs';
 import type { IThemeLoadResult } from '@/features/theme/loader';
-import { getCache } from '@/utils';
+import { getCache, getContentHash } from '@/utils';
 import fs from 'fs';
-import { lodash, Mustache, winPath } from 'umi/plugin-utils';
+import { Mustache, lodash, winPath } from 'umi/plugin-utils';
 import transform, {
   type IMdTransformerOptions,
   type IMdTransformerResult,
@@ -135,9 +135,11 @@ export default DumiMarkdownContent;`;
   }
 }
 
-function getDepsCacheKey(deps: typeof depsMapping['0'] = []) {
+function getDepsCacheKey(deps: (typeof depsMapping)['0'] = []) {
   return JSON.stringify(
-    deps.map((file) => `${file}:${fs.statSync(file).mtimeMs}`),
+    deps.map(
+      (file) => `${file}:${getContentHash(fs.readFileSync(file, 'utf-8'))}`,
+    ),
   );
 }
 
@@ -149,13 +151,13 @@ export default function mdLoader(this: any, content: string) {
   const cb = this.async();
 
   const cache = getCache('md-loader');
-  // format: {path:mtime:loaderOpts}
+  // format: {path:contenthash:loaderOpts}
   const baseCacheKey = [
     this.resourcePath,
-    fs.statSync(this.resourcePath).mtimeMs,
+    getContentHash(content),
     JSON.stringify(lodash.omit(opts, ['mode', 'builtins', 'onResolveDemos'])),
   ].join(':');
-  // format: {baseCacheKey:{deps:mtime}[]}
+  // format: {baseCacheKey:{deps:contenthash}[]}
   const cacheKey = [
     baseCacheKey,
     getDepsCacheKey(depsMapping[this.resourcePath]),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import Cache from 'file-system-cache';
 import fs from 'fs';
 import yaml from 'js-yaml';
@@ -82,7 +83,7 @@ export function parseCodeFrontmatter(raw: string) {
  */
 const caches: Record<string, ReturnType<typeof Cache>> = {};
 const CACHE_PATH = 'node_modules/.cache/dumi';
-export function getCache(ns: string): typeof caches['0'] {
+export function getCache(ns: string): (typeof caches)['0'] {
   // return fake cache if cache disabled
   if (process.env.DUMI_CACHE === 'none') {
     return { set() {}, get() {}, setSync() {}, getSync() {} } as any;
@@ -155,4 +156,11 @@ export function getProjectRoot(cwd: string) {
   }
 
   return winPath(cwd);
+}
+
+/**
+ * generate hash for string
+ */
+export function getContentHash(content: string, length = 8) {
+  return createHash('md5').update(content).digest('hex').slice(0, length);
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

Markdown loader 编译的缓存 key 从 mtime 变为 contenthash，这样可以实现在 CI/CD 平台中复用缓存，因为这类平台拉取代码时通常不会保留 git history，mtime 是不可靠的

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Use content hash as cache key for markdown loader |
| 🇨🇳 Chinese | Markdown loader 改用 content hash 作为缓存键 |
