### PR TITLE
fix: unexpected exports in demo pre-compiling result

### DIFF
--- a/packages/preset-dumi/src/transformer/demo/index.ts
+++ b/packages/preset-dumi/src/transformer/demo/index.ts
@@ -59,7 +59,7 @@ export default (raw: string, opts: IDemoOpts): IDemoTransformResult => {
         callPathNode.left.object.name === 'exports'
       ) {
         // remove original export expression
-        if (types.isIdentifier(callPathNode.right)) {
+        if (types.isIdentifier(callPathNode.right) || types.isFunctionExpression(callPathNode.right)) {
           // save export function as return statement arg
           if (isDynamicEnable()) {
             // for dynamic({ loader }), transform to return _default;

--- a/packages/preset-dumi/src/transformer/fixtures/expect/demo-await-import.js
+++ b/packages/preset-dumi/src/transformer/fixtures/expect/demo-await-import.js
@@ -8,11 +8,11 @@ dynamic({
 
     await import("$CWD/packages/preset-dumi/src/transformer/fixtures/raw/index.less");
 
-    var _default = function _default() {
+    var _default;
+
+    return function _default() {
       return /*#__PURE__*/_react["default"].createElement(_antd.Button, null);
     };
-
-    return _default;
   },
   loading: () => null
 })


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Close #1920

### 💡 需求背景和解决方案 / Background or solution

修复 dumi v1 demo 预编译结果中包含非预期 `exports` 导致编译报错的问题。

大致原因：
- 虽然 dumi 锁了 babel，但非预打包的方式锁不了间接依赖，由 @babel/plugin-transform-modules-commonjs 间接引用到了更新的 babel 版本，和 @umijs/babel-preset-umi 用到的预打包的 babel 版本对不上
- 使用 [Babel REPL](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=KYDwDg9gTgLgBAE2AMwIYFcA28AUBKOAXgD44BvAXyA&debug=false&forceAllTransforms=false&modules=commonjs&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2&prettier=false&targets=&version=7.23.1&externalPlugins=&assumptions=%7B%7D) 测试最新版本是正常的（不会出现类似 `exports['default'] = function _default() {}` 的语句）
- 所以推测该问题是因为间接使用不同版本的 babel 生态包（7.23.0 与 7.18.6），导致 AST 结果异常
考虑到 dumi 1 已经不再迭代，精力有限上述猜想就不继续验证了

解决方案：
- 本质解是 Umi 3 的 @umijs/deps 把 dumi 需要的 @babel/plugin-transform-modules-commonjs 一起预打包，这样间接依赖也被打进去了，但 Umi 3 做预打包的改动风险比较高，预打包脚本很久没有维护了，加上对 Umi 3 的项目造成的影响是未知的，收益又不算高，只影响 dumi 1（Bigfish 3 组件库）应用，所以放弃本质解
- 平衡解是 dumi 1 对 `exports['default'] = function _default() {}` 也做转换，目前只转了 `exports['default'] = _default`，该方案的好处是代码改动量很小，加上 Babel 8 已经进入 alpha 阶段，v7 未来再出现类似影响的概率较小，所以选择平衡解

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix unexpected exports in demo pre-compiling result |
| 🇨🇳 Chinese | 修复 demo 预编译结果中意外出现 exports 的问题 |
