### PR TITLE
fix: conventional 2-level nav lost in localized routes

### DIFF
--- a/src/client/theme-api/useSidebarData.ts
+++ b/src/client/theme-api/useSidebarData.ts
@@ -27,12 +27,18 @@ export const getLocaleClearPath = (
 /**
  * get parent path from route path
  */
-function getRouteParentPath(
+export function getRouteParentPath(
   path: string,
-  { meta, is2LevelNav }: { meta: IRouteMeta; is2LevelNav: boolean },
+  {
+    meta,
+    is2LevelNav,
+    locale,
+  }: { meta?: IRouteMeta; is2LevelNav: boolean; locale: ILocalesConfig[0] },
 ) {
+  const indexDocRegex = new RegExp(`/index(\\.${locale.id})?.md$`);
   const isIndexDocRoute =
-    meta.frontmatter.filename?.endsWith('index.md') &&
+    meta?.frontmatter.filename &&
+    indexDocRegex.test(meta.frontmatter.filename) &&
     !meta._atom_route &&
     is2LevelNav;
   const paths = path
@@ -82,7 +88,7 @@ export const useFullSidebarData = () => {
         //   a/b => /a/b (if route file is a/b/index.md)
         //   a/b/c => /a/b
         const parentPath = `/${route.path!.replace(clearPath, (s) =>
-          getRouteParentPath(s, { is2LevelNav, meta: route.meta! }),
+          getRouteParentPath(s, { is2LevelNav, meta: route.meta!, locale }),
         )}`;
         const { title, order } = pickRouteSortMeta(
           { order: 0 },
@@ -224,7 +230,7 @@ export const useSidebarData = () => {
   // /en-US/a/b/ => /en-US/a (also strip trailing /)
   const parentPath = clearPath
     ? pathname.replace(clearPath, (s) =>
-        getRouteParentPath(s, { is2LevelNav, meta }),
+        getRouteParentPath(s, { is2LevelNav, meta, locale }),
       )
     : pathname;
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

修复在非默认语言下，约定式二级导航菜单可能丢失的问题，也会出现默认语言和非默认语言下导航二级菜单不一致的情况

后续：约定式路由相关逻辑的复杂度较高，需要补充用例确保迭代过程中的功能稳定

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix conventional 2-level nav lost in localized routes |
| 🇨🇳 Chinese | 修复非默认语言下二级导航丢失的问题 |
