### PR TITLE
feat: Automatically convert the CHANGELOG in the same directory as th…

### DIFF
--- a/src/features/tabs.ts
+++ b/src/features/tabs.ts
@@ -14,14 +14,20 @@ export interface IContentTab {
 }
 
 export function isTabRouteFile(file: string) {
-  return file.includes('$tab-');
+  return file.includes('$tab-') || file.includes('CHANGELOG');
 }
 
 export function getTabKeyFromFile(file: string) {
+  if (file.includes('CHANGELOG')) {
+    return 'changelog';
+  }
   return file.match(/\$tab-([^.]+)/)![1];
 }
 
 export function getHostForTabRouteFile(file: string) {
+  if (file.includes('CHANGELOG')) {
+    return file.replace('CHANGELOG', 'README');
+  }
   return file.replace(/\$tab-[^.]+\./, '');
 }
 
@@ -71,7 +77,7 @@ export default (api: IApi) => {
         const rtlFile = winPath(path.relative(api.cwd, route.file));
         const routeId = createRouteId(rtlFile);
         const tabKey = getTabKeyFromFile(rtlFile);
-        const parentFile = route.file.replace(/\$tab-[^.]+\./, '');
+        const parentFile = getHostForTabRouteFile(route.file);
 
         tabs.push({
           index: tabs.length,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- 自动将 README 同级目录下的 CHANGELOG 转换为 Tab
- Automatically convert the CHANGELOG in the same directory as the README to Tab.

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

在 monorepo 时开发组件/库类，多个子包时，菜单聚合后 没有 changelog 的入口，
如果单独把所有changelog作为导航，则导致搜索时会出现同样的两个结果，无法判断是日志页面和文档页面 让人迷惑
所以此改动是为了更方便的查看单个包的更新日志

考虑到不是所有人都需要的功能，看是否需要通过 增加 config 来开启开关

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Automatically convert the CHANGELOG in the same directory as the README to Tab. |
| 🇨🇳 Chinese |  自动将 README 同级目录下的 CHANGELOG 转换为 Tab |
