### PR TITLE
fix: 修复h5下，切换版本和主题会冒泡造成：未选择option就关闭popup了

### DIFF
--- a/.dumi/theme/slots/HeaderExtra/index.tsx
+++ b/.dumi/theme/slots/HeaderExtra/index.tsx
@@ -12,6 +12,9 @@ const HeaderExtra: FC = () => {
             window.open('https://v1.d.umijs.org/', '_blank');
           }
         }}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
       >
         <option value={process.env.DUMI_VERSION}>
           {process.env.DUMI_VERSION}

--- a/src/client/theme-default/slots/ColorSwitch/index.tsx
+++ b/src/client/theme-default/slots/ColorSwitch/index.tsx
@@ -48,6 +48,7 @@ const ColorSwitch: FC = () => {
       <select
         onChange={(ev) => setPrefersColor(ev.target.value as any)}
         value={prefersColor}
+        onClick={(e) => e.stopPropagation()}
       >
         {['light', 'dark', 'auto'].map((c) => (
           <option value={c} key={c}>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->
https://github.com/umijs/dumi/issues/1923

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->
修复在h5下，版本切换和主题选择，点击后直接关闭弹窗，导致不能选择选项的问题
### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fixed an issue in h5 where version switching and theme selection would close the popup window directly after clicking, resulting in the option not being selected      |
| 🇨🇳 Chinese |     修复在h5下，版本切换和主题选择，点击后直接关闭弹窗，导致不能选择选项的问题      |
