### PR TITLE
fix: wrong search scroll position of 1-level heading in current page

### DIFF
--- a/src/client/theme-default/layouts/DocLayout/index.tsx
+++ b/src/client/theme-default/layouts/DocLayout/index.tsx
@@ -46,12 +46,6 @@ const DocLayout: FC = () => {
           });
         }
       }, 1);
-    } else {
-      setTimeout(() => {
-        animateScrollTo(0, {
-          maxDuration: 300,
-        });
-      }, 1);
     }
   }, [loading, hash]);
 

--- a/src/client/theme-default/layouts/DocLayout/index.tsx
+++ b/src/client/theme-default/layouts/DocLayout/index.tsx
@@ -46,6 +46,12 @@ const DocLayout: FC = () => {
           });
         }
       }, 1);
+    } else {
+      setTimeout(() => {
+        animateScrollTo(0, {
+          maxDuration: 300,
+        });
+      }, 1);
     }
   }, [loading, hash]);
 

--- a/src/client/theme-default/slots/SearchResult/index.tsx
+++ b/src/client/theme-default/slots/SearchResult/index.tsx
@@ -1,5 +1,12 @@
 import { ReactComponent as IconInbox } from '@ant-design/icons-svg/inline-svg/outlined/inbox.svg';
-import { FormattedMessage, history, Link, type useSiteSearch } from 'dumi';
+import animateScrollTo from 'animated-scroll-to';
+import {
+  FormattedMessage,
+  history,
+  Link,
+  useLocation,
+  type useSiteSearch,
+} from 'dumi';
 import React, {
   Fragment,
   useCallback,
@@ -119,6 +126,20 @@ const SearchResult: FC<{
 }> = (props) => {
   const [data, histsCount] = useFlatSearchData(props.data);
   const [activeIndex, setActiveIndex] = useState(-1);
+  const { pathname } = useLocation();
+
+  const onItemSelect = (item: ISearchResult[0]['hints'][0]) => {
+    props.onItemSelect?.(item);
+
+    const url = new URL(item?.link, location.origin);
+    if (url?.pathname === pathname && !url.hash) {
+      setTimeout(() => {
+        animateScrollTo(0, {
+          maxDuration: 300,
+        });
+      }, 1);
+    }
+  };
 
   useEffect(() => {
     const handler = (ev: KeyboardEvent) => {
@@ -133,7 +154,7 @@ const SearchResult: FC<{
         )!.value as ISearchResult[0]['hints'][0];
 
         history.push(item.link);
-        props.onItemSelect?.(item);
+        onItemSelect?.(item);
         (document.activeElement as HTMLInputElement).blur();
       }
 
@@ -167,7 +188,7 @@ const SearchResult: FC<{
                 <Link
                   to={item.value.link}
                   data-active={activeIndex === item.activeIndex || undefined}
-                  onClick={() => props.onItemSelect?.(item.value)}
+                  onClick={() => onItemSelect?.(item.value)}
                 >
                   {React.createElement(ICONS_MAPPING[item.value.type])}
                   <h4>


### PR DESCRIPTION
…ng position

<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
**背景**：
搜索内容时(h1)，hash被清空后，没有滚动到对应的区域
![start](https://github.com/umijs/dumi/assets/29519985/b9c1038e-ac22-467c-b4e0-0b5e992355ca)

<!--
解决的具体问题。
The specific problem solved.
-->
**解决方案**：
当hash被清空后，滚动到h1对应位置，对应顶部

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fixed the hash was cleared and did not scroll to the corresponding position.     |
| 🇨🇳 Chinese |      修复hash被清空，没有滚动到对应位置     |
