### PR TITLE
fix: handle unexpected oneof and allof for api metadata

### DIFF
--- a/src/features/parser.ts
+++ b/src/features/parser.ts
@@ -17,9 +17,15 @@ function filterIgnoredProps(
     } else if (prop.type === 'object' && 'properties' in prop) {
       prop.properties = filterIgnoredProps(prop.properties!);
     } else if (prop.oneOf) {
-      prop.oneOf = prop.oneOf.map((item) => filterIgnoredProps({ _: item })._);
+      // oneOf may be [null] with unknown reason
+      prop.oneOf = prop.oneOf
+        .filter(Boolean)
+        .map((item) => filterIgnoredProps({ _: item })._);
     } else if (prop.allOf) {
-      prop.allOf = prop.allOf.map((item) => filterIgnoredProps({ _: item })._);
+      // allOf may be [null] with unknown reason
+      prop.allOf = prop.allOf
+        .filter(Boolean)
+        .map((item) => filterIgnoredProps({ _: item })._);
     } else if ('hidden' in prop) {
       isHidden = true;
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1981 

### 💡 需求背景和解决方案 / Background or solution

修复过滤 API 元数据时未处理异常 `oneOf` 和 `allOf` 导致报错的问题

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Handle unexpected oneOf and allOf for api metadata |
| 🇨🇳 Chinese | 处理 API 元数据中异常的 oneOf 和 allOf 值 |
