### PR TITLE
refactor: use async way to parse theme modules

### DIFF
--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -6,7 +6,7 @@ import {
   VERSION_2_LEVEL_NAV,
 } from '@/constants';
 import type { IApi } from '@/types';
-import { parseModuleSync } from '@umijs/bundler-utils';
+import { parseModule } from '@umijs/bundler-utils';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import hostedGit from 'hosted-git-info';
@@ -67,11 +67,13 @@ function getPkgThemePath(api: IApi) {
 /**
  * get exports for module
  */
-function getModuleExports(modulePath: string) {
-  return parseModuleSync({
+async function getModuleExports(modulePath: string) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_, exports] = await parseModule({
     path: modulePath,
     content: fs.readFileSync(modulePath, 'utf-8'),
-  })[1];
+  });
+  return exports || [];
 }
 
 /**
@@ -329,16 +331,17 @@ export default DumiLoading;
     },
   });
 
-  api.onGenerateFiles(() => {
+  api.onGenerateFiles(async () => {
     // write shadow theme files to tmp dir
-    themeMapKeys.forEach((key) => {
-      Object.values(originalThemeData[key] || {}).forEach((item) => {
+    const pAll = themeMapKeys.flatMap((key) =>
+      Object.values(originalThemeData[key] || {}).map(async (item) => {
         // skip write internal components
         if (item.source === 'dumi') return;
 
-        let contents = [];
         // parse exports for theme module
-        const exports = getModuleExports(item.source);
+        const exports = await getModuleExports(item.source);
+
+        const contents = [];
 
         // export default
         if (exports.includes('default')) {
@@ -355,13 +358,15 @@ export default DumiLoading;
           path: `dumi/theme/${key}/${item.specifier}.ts`,
           content: contents.join('\n'),
         });
-      });
-    });
+      }),
+    );
+
+    await Promise.all(pAll);
 
     const entryFile =
       api.config.resolve.entryFile &&
       [path.resolve(api.cwd, api.config.resolve.entryFile)].find(fs.existsSync);
-    const entryExports = entryFile ? getModuleExports(entryFile) : [];
+    const entryExports = entryFile ? await getModuleExports(entryFile) : [];
     const hasDefaultExport = entryExports.includes('default');
     const hasNamedExport = entryExports.some((exp) => exp !== 'default');
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     parseModuleSync to parseModule Fix for some scenarios where uninitialized results returned a promise      |
| 🇨🇳 Chinese |     parseModuleSync 改为 parseModule 修复 某些场景下未初始化导致结果返回 promise 的问题      |
