### PR TITLE
refactor: cache dir config can control compile fs cache location

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,3 +27,5 @@ export const USELESS_TMP_FILES = ['tsconfig.json', 'typings.d.ts'];
 export const VERSION_2_LEVEL_NAV = '^2.2.0';
 
 export const VERSION_2_DEPRECATE_SOFT_BREAKS = '^2.2.0';
+
+export const FS_CACHE_DIR = 'node_modules/.cache/dumi';

--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -2,6 +2,8 @@ import type { IDemoLoaderOptions } from '@/loaders/demo';
 import type { IMdLoaderOptions } from '@/loaders/markdown';
 import ReactTechStack from '@/techStacks/react';
 import type { IApi, IDumiTechStack } from '@/types';
+import { _setFSCacheDir } from '@/utils';
+import path from 'path';
 import { addAtomMeta, addExampleAssets } from '../assets';
 
 export default (api: IApi) => {
@@ -14,17 +16,26 @@ export default (api: IApi) => {
     fn: () => new ReactTechStack(),
   });
 
-  // add customize option for babel-loader, to avoid collect wrong deps result in MFSU
-  api.modifyConfig((memo) => {
-    if (memo.babelLoaderCustomize) {
-      api.logger.warn(
-        'Config `babelLoaderCustomize` will be override by dumi, please report issue if you need it.',
-      );
-    }
+  api.modifyConfig({
+    stage: Infinity,
+    fn: (memo) => {
+      // add customize option for babel-loader, to avoid collect wrong deps result in MFSU
+      if (memo.babelLoaderCustomize) {
+        api.logger.warn(
+          'Config `babelLoaderCustomize` will be override by dumi, please report issue if you need it.',
+        );
+      }
 
-    memo.babelLoaderCustomize = require.resolve('./babelLoaderCustomize');
+      memo.babelLoaderCustomize = require.resolve('./babelLoaderCustomize');
 
-    return memo;
+      // configure dumi fs cache dir
+      const cacheDirPath =
+        api.userConfig.cacheDirectoryPath || memo.cacheDirectoryPath;
+
+      if (cacheDirPath) _setFSCacheDir(path.join(cacheDirPath, 'dumi'));
+
+      return memo;
+    },
   });
 
   // configure loader to compile markdown

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import { lodash, logger, winPath } from 'umi/plugin-utils';
+import { FS_CACHE_DIR } from './constants';
 
 /**
  * get route path from file-system path
@@ -81,14 +82,17 @@ export function parseCodeFrontmatter(raw: string) {
 /**
  * get file-system cache for specific namespace
  */
+let cacheDir = FS_CACHE_DIR;
 const caches: Record<string, ReturnType<typeof Cache>> = {};
-const CACHE_PATH = 'node_modules/.cache/dumi';
+export function _setFSCacheDir(dir: string) {
+  cacheDir = dir;
+}
 export function getCache(ns: string): (typeof caches)['0'] {
   // return fake cache if cache disabled
   if (process.env.DUMI_CACHE === 'none') {
     return { set() {}, get() {}, setSync() {}, getSync() {} } as any;
   }
-  return (caches[ns] ??= Cache({ basePath: path.join(CACHE_PATH, ns) }));
+  return (caches[ns] ??= Cache({ basePath: path.resolve(cacheDir, ns) }));
 }
 
 /**


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

支持通过 `cacheDirectoryPath` 配置项控制 dumi 编译的持久缓存位置

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Control compile fs cache location by `cacheDirectoryDir` config |
| 🇨🇳 Chinese | 支持通过 `cacheDirectoryDir` 控制编译持久缓存位置 |
