### PR TITLE
fix: multi-instance problem and styles of live demo feature

### DIFF
--- a/src/client/pages/Demo/index.ts
+++ b/src/client/pages/Demo/index.ts
@@ -5,25 +5,25 @@ import './index.less';
 const DemoRenderPage: FC = () => {
   const { id } = useParams();
   const { component } = useDemo(id!) || {};
-  const { node: liveDemoNode, setSources } = useLiveDemo(id!);
+  const { node: liveDemoNode, setSource } = useLiveDemo(id!);
   const finalNode = liveDemoNode || (component && createElement(component));
 
   useEffect(() => {
     const handler = (
       ev: MessageEvent<{
         type: string;
-        value: Parameters<typeof setSources>[0];
+        value: Parameters<typeof setSource>[0];
       }>,
     ) => {
-      if (ev.data.type === 'dumi.liveDemo.setSources') {
-        setSources(ev.data.value);
+      if (ev.data.type === 'dumi.liveDemo.setSource') {
+        setSource(ev.data.value);
       }
     };
 
     window.addEventListener('message', handler);
 
     return () => window.removeEventListener('message', handler);
-  }, [setSources]);
+  }, [setSource]);
 
   return finalNode;
 };

--- a/src/client/theme-api/useLiveDemo.ts
+++ b/src/client/theme-api/useLiveDemo.ts
@@ -12,14 +12,14 @@ export const useLiveDemo = (id: string) => {
   const { context, asset } = useDemo(id)!;
   const [demoNode, setDemoNode] = useState<ReactNode>();
   const [error, setError] = useState<Error | null>(null);
-  const setSources = useCallback(
-    (sources: Record<string, string>) => {
+  const setSource = useCallback(
+    (source: Record<string, string>) => {
       const entryFileName = Object.keys(asset.dependencies).find(
         (k) => asset.dependencies[k].type === 'FILE',
       )!;
-      const entryFileCode = sources[entryFileName];
+      const entryFileCode = source[entryFileName];
       const require = (v: string) => {
-        if (v in context) return context[v];
+        if (v in context!) return context![v];
         throw new Error(`Cannot find module: ${v}`);
       };
       const exports: { default?: ComponentType } = {};
@@ -50,7 +50,7 @@ export const useLiveDemo = (id: string) => {
           renderToStaticMarkup(newDemoNode);
           console.error = oError;
 
-          // set new demo node with passing sources
+          // set new demo node with passing source
           setDemoNode(newDemoNode);
           setError(null);
         } catch (err: any) {
@@ -61,5 +61,5 @@ export const useLiveDemo = (id: string) => {
     [context],
   );
 
-  return { node: demoNode, error, setSources };
+  return { node: demoNode, error, setSource };
 };

--- a/src/client/theme-default/builtins/Previewer/index.less
+++ b/src/client/theme-default/builtins/Previewer/index.less
@@ -1,6 +1,8 @@
 @import (reference) '../../styles/variables.less';
 
 .@{prefix}-previewer {
+  @error-bar-height: 30px;
+
   margin: 24px 0 32px;
   border: 1px solid @c-border-light;
   border-radius: 4px;
@@ -76,16 +78,26 @@
     &[data-compact] {
       padding: 0;
     }
+
+    // error status
+    &[data-error][data-compact] {
+      min-height: @error-bar-height;
+
+      + .@{prefix}-previewer-demo-error {
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+      }
+    }
   }
 
   &-demo-error {
-    @height: 30px;
     @color: darken(desaturate(@c-error, 20%), 1%);
 
-    margin-top: -@height;
-    height: @height;
+    position: relative;
+    margin-top: -@error-bar-height;
+    height: @error-bar-height;
     padding: 0 24px;
-    line-height: @height;
+    line-height: @error-bar-height;
     color: @color;
     font-size: 13px;
     white-space: nowrap;

--- a/src/client/theme-default/builtins/Previewer/index.tsx
+++ b/src/client/theme-default/builtins/Previewer/index.tsx
@@ -12,7 +12,7 @@ const Previewer: FC<IPreviewerProps> = (props) => {
   const {
     node: liveDemoNode,
     error: liveDemoError,
-    setSources: setLiveDemoSources,
+    setSource: setLiveDemoSource,
   } = useLiveDemo(props.asset.id);
   const [editorError, setEditorError] = useState<Error | null>(null);
   const combineError = liveDemoError || editorError;
@@ -71,19 +71,19 @@ const Previewer: FC<IPreviewerProps> = (props) => {
         )}
         <PreviewerActions
           {...props}
-          onSourcesTranspile={({ err, sources }) => {
+          onSourceTranspile={({ err, source }) => {
             if (err) {
               setEditorError(err);
             } else {
               setEditorError(null);
-              setLiveDemoSources(sources);
+              setLiveDemoSource(source);
 
               if (props.iframe) {
                 demoContainer
                   .current!.querySelector('iframe')!
                   .contentWindow!.postMessage({
-                    type: 'dumi.liveDemo.setSources',
-                    value: sources,
+                    type: 'dumi.liveDemo.setSource',
+                    value: source,
                   });
               }
             }

--- a/src/client/theme-default/builtins/Previewer/index.tsx
+++ b/src/client/theme-default/builtins/Previewer/index.tsx
@@ -31,6 +31,7 @@ const Previewer: FC<IPreviewerProps> = (props) => {
         data-compact={props.compact || undefined}
         data-transform={props.transform || undefined}
         data-iframe={props.iframe || undefined}
+        data-error={Boolean(combineError) || undefined}
         ref={demoContainer}
       >
         {props.iframe ? (

--- a/src/client/theme-default/slots/PreviewerActions/index.tsx
+++ b/src/client/theme-default/slots/PreviewerActions/index.tsx
@@ -26,10 +26,10 @@ export interface IPreviewerActionsProps extends IPreviewerProps {
   extra?: ReactNode;
   forceShowCode?: boolean;
   demoContainer: HTMLDivElement | HTMLIFrameElement;
-  onSourcesTranspile?: (
+  onSourceTranspile?: (
     args:
-      | { err: Error; sources?: null }
-      | { err?: null; sources: Record<string, string> },
+      | { err: Error; source?: null }
+      | { err?: null; source: Record<string, string> },
   ) => void;
 }
 
@@ -200,10 +200,10 @@ const PreviewerActions: FC<IPreviewerActionsProps> = (props) => {
                       initialValue={files[i][1].value.trim()}
                       onTranspile={({ err, code }) => {
                         if (err) {
-                          props.onSourcesTranspile?.({ err });
+                          props.onSourceTranspile?.({ err });
                         } else {
-                          props.onSourcesTranspile?.({
-                            sources: { [files[i][0]]: code },
+                          props.onSourceTranspile?.({
+                            source: { [files[i][0]]: code },
                           });
                         }
                       }}

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -47,5 +47,7 @@ export function getSchemas(): Record<string, (Joi: JoiRoot) => any> {
     extraRehypePlugins: getUnifiedPluginSchema,
     themeConfig: (Joi) => Joi.object().optional(),
     logo: (Joi) => Joi.string(),
+    // FIXME: remove before 2.3.0
+    live: (Joi) => Joi.bool().optional(),
   };
 }

--- a/src/features/derivative.ts
+++ b/src/features/derivative.ts
@@ -175,6 +175,13 @@ export default (api: IApi) => {
         );
       }
     } catch {}
+
+    // FIXME: remove before 2.3.0
+    if ('live' in api.config) {
+      logger.warn(
+        '`live` config is deprecated and live demo is always enabled now, please remove it.',
+      );
+    }
   });
 
   // skip mfsu for client api, to avoid circular resolve in mfsu mode

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -304,7 +304,7 @@ export default function mdLoader(this: any, content: string) {
         getDemoSourceFiles(ret.meta.demos),
       );
 
-      // re-generate cache key with latest embeds & sources data
+      // re-generate cache key with latest embeds & source data
       const finalCacheKey = [
         baseCacheKey,
         getDepsCacheKey(depsMapping[this.resourcePath]),

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -142,14 +142,15 @@ export const demos = {
 
         // use raw-loader to load all source files
         Object.keys(this.resolveMap).forEach((file: string) => {
-          // handle un-existed source file, e.g. custom tech-stack return custom dependencies
-          if (!asset.dependencies[file]) return;
-
-          // to avoid modify original asset object
-          asset = lodash.cloneDeep(asset);
-          asset.dependencies[
-            file
-          ].value = `{{{require('-!${resolveMap[file]}?dumi-raw').default}}}`;
+          // skip un-existed source file, e.g. custom tech-stack return custom dependencies
+          // skip non-file asset because resolveMap will contains all dependencies since 2.3.0
+          if (asset.dependencies[file]?.type === 'FILE') {
+            // to avoid modify original asset object
+            asset = lodash.cloneDeep(asset);
+            asset.dependencies[
+              file
+            ].value = `{{{require('-!${resolveMap[file]}?dumi-raw').default}}}`;
+          }
         });
 
         return JSON.stringify(asset, null, 2).replace(/"{{{|}}}"/g, '');

--- a/src/loaders/markdown/transformer/index.ts
+++ b/src/loaders/markdown/transformer/index.ts
@@ -117,6 +117,7 @@ export default async (raw: string, opts: IMdTransformerOptions) => {
     'rehype-remove-comments'
   );
   const resolver = enhancedResolve.create.sync({
+    mainFields: ['browser', 'module', 'main'],
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     alias: opts.alias,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,10 +101,10 @@ export abstract class IDumiTechStack {
     | Promise<IDumiDemoProps['previewerProps']>
     | IDumiDemoProps['previewerProps'];
   /**
-   * generator for return file path of demo sources
+   * generator for return file path of demo source
    */
   abstract generateSources?(
-    sources: IParsedBlockAsset['resolveMap'],
+    source: IParsedBlockAsset['resolveMap'],
     opts: Parameters<NonNullable<IDumiTechStack['generateMetadata']>>[1],
   ): Promise<IParsedBlockAsset['resolveMap']> | IParsedBlockAsset['resolveMap'];
 }


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1992 

### 💡 需求背景和解决方案 / Background or solution

修复 #1992 引入的几处 bug，分别是：
1. 由于 demo parser 与编译 resolver 的 `mainFields` 不一致引起的多实例问题（同时引入某个依赖的 cjs 和 esm 产物）
2. live demo 错误状态在 compact demo 中溢出容器的问题， from @jeffwcx 
3. resolveMap 包含依赖解析路径导致运行时的 demo 依赖元数据出现错乱的问题，from @jeffwcx 

另外做了两个改进：
1. 恢复 `live` 配置项并添加警告，避免 Ant Design 的 CI 报错，等正式版再移除
2. `useLiveDemo` 的 API 调整，`setSources` 变成 `setSource`，设置 demo 的源码，把源码文件当做一个整体更合适

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
