### PR TITLE
refactor: avoid breaking change for useRouteMeta api

### DIFF
--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -87,7 +87,7 @@ function checkMinor2ByPkg(pkg: IApi['pkg']) {
   const ver =
     pkg.peerDependencies?.dumi || pkg.devDependencies?.dumi || '^2.0.0';
 
-  return semver.subset(ver, VERSION_2_LEVEL_NAV);
+  return semver.subset(ver, VERSION_2_LEVEL_NAV, { includePrerelease: true });
 }
 
 export default (api: IApi) => {

--- a/src/loaders/markdown/transformer/index.ts
+++ b/src/loaders/markdown/transformer/index.ts
@@ -83,7 +83,9 @@ function keepSoftBreak(pkg: IApi['pkg']) {
   if (pkg?.name?.startsWith('@examples/') || pkg?.name === 'dumi') return false;
 
   const ver = pkg?.devDependencies?.dumi ?? pkg?.dependencies?.dumi ?? '^2.0.0';
-  return !semver.subset(ver, VERSION_2_DEPRECATE_SOFT_BREAKS);
+  return !semver.subset(ver, VERSION_2_DEPRECATE_SOFT_BREAKS, {
+    includePrerelease: true,
+  });
 }
 
 async function applyUnifiedPlugin(opts: {

--- a/src/templates/meta/exports.ts.tpl
+++ b/src/templates/meta/exports.ts.tpl
@@ -109,7 +109,7 @@ export function getRouteMetaById<T extends { syncOnly?: boolean }>(
   ? undefined | IRouteMeta
   : Promise<undefined | IRouteMeta> | undefined {
   if (filesMeta[id]) {
-    const { frontmatter, toc, textGetter, tabs = [] } = filesMeta[id];
+    const { frontmatter, toc, textGetter, tabs } = filesMeta[id];
     const routeMeta: IRouteMeta = {
       frontmatter,
       toc: toc,
@@ -117,25 +117,30 @@ export function getRouteMetaById<T extends { syncOnly?: boolean }>(
     };
 
     if (opts?.syncOnly) {
-      routeMeta.tabs = tabs.map((tabId) =>
-        genTab(tabId, getRouteMetaById(tabId, opts)),
-      );
+      if (tabs) {
+        routeMeta.tabs = tabs.map((tabId) =>
+          genTab(tabId, getRouteMetaById(tabId, opts)),
+        );
+      }
+
+      return routeMeta;
     } else {
       return new Promise(async (resolve) => {
         if (textGetter) {
           ({ texts: routeMeta.texts } = await textGetter());
         }
 
-        routeMeta.tabs = await Promise.all(
-          tabs.map(async (tabId) =>
-            genTab(tabId, await getRouteMetaById(tabId, opts)),
-          ),
-        );
+        if (tabs) {
+          routeMeta.tabs = await Promise.all(
+            tabs.map(async (tabId) =>
+              genTab(tabId, await getRouteMetaById(tabId, opts)),
+            ),
+          );
+        }
+
         resolve(routeMeta);
       });
     }
-
-    return routeMeta;
   }
 }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1974 

### 💡 需求背景和解决方案 / Background or solution

在 #1974 中 `useRouteMeta` 的返回值无意中从 `{ tabs?: IRouteTabMeta[], ... }` 变成了 `{ tabs: IRouteTabMeta[], ... }`，没有 tab 的时候也有空数组，这本质上是 Breaking Change，会导致基于 `tabs` 字段是否存在来做差异化逻辑的项目运行异常（比如 Ant Design 官网），所以将返回值重新调回去

另外顺便改了两个 warning 版本的警告判断逻辑，避免 2.3.0 非正式版的应用也收到错误

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
