### PR TITLE
feat: live demo support custom tech stack

### DIFF
--- a/src/client/misc/reactDemoCompiler.ts
+++ b/src/client/misc/reactDemoCompiler.ts
@@ -1,0 +1,10 @@
+import { transform } from 'sucrase';
+import type { IDemoCompileFn } from '../theme-api/types';
+
+const compile: IDemoCompileFn = async (code) => {
+  return transform(code, {
+    transforms: ['typescript', 'jsx', 'imports'],
+  }).code;
+};
+
+export default compile;

--- a/src/client/theme-api/types.ts
+++ b/src/client/theme-api/types.ts
@@ -237,9 +237,20 @@ export type IRoutesById = Record<
   }
 >;
 
+export type IDemoCompileFn = (
+  code: string,
+  opts: { filename: string },
+) => Promise<string>;
+
 export type IDemoData = {
   component: ComponentType;
   asset: IPreviewerProps['asset'];
   routeId: string;
   context?: Record<string, unknown>;
+  renderOpts?: {
+    /**
+     * provide a runtime compile function for compile demo code for live preview
+     */
+    compile?: IDemoCompileFn;
+  };
 };

--- a/src/client/theme-api/useLiveDemo.ts
+++ b/src/client/theme-api/useLiveDemo.ts
@@ -3,71 +3,94 @@ import throttle from 'lodash.throttle';
 import {
   createElement,
   useCallback,
+  useRef,
   useState,
   type ComponentType,
   type ReactNode,
 } from 'react';
 import DemoErrorBoundary from './DumiDemo/DemoErrorBoundary';
 
+const THROTTLE_WAIT = 500;
+
 export const useLiveDemo = (id: string) => {
   const { context, asset, renderOpts } = useDemo(id)!;
+  const [loading, setLoading] = useState(false);
+  const loadingTimer = useRef<number>();
   const [demoNode, setDemoNode] = useState<ReactNode>();
   const [error, setError] = useState<Error | null>(null);
   const setSource = useCallback(
-    throttle(async (source: Record<string, string>) => {
-      const entryFileName = Object.keys(asset.dependencies).find(
-        (k) => asset.dependencies[k].type === 'FILE',
-      )!;
-      const require = (v: string) => {
-        if (v in context!) return context![v];
-        throw new Error(`Cannot find module: ${v}`);
-      };
-      const exports: { default?: ComponentType } = {};
-      const module = { exports };
-      let entryFileCode = source[entryFileName];
-
-      try {
-        // load renderToStaticMarkup in async way
-        const renderToStaticMarkupDeferred = import('react-dom/server').then(
-          ({ renderToStaticMarkup }) => renderToStaticMarkup,
+    throttle(
+      async (source: Record<string, string>) => {
+        // set loading status if still compiling after 499ms
+        loadingTimer.current = window.setTimeout(
+          () => {
+            setLoading(true);
+          },
+          // make sure timer be fired before next throttle
+          THROTTLE_WAIT - 1,
         );
 
-        // compile entry file code
-        entryFileCode = await renderOpts!.compile!(entryFileCode, {
-          filename: entryFileName,
-        });
+        const entryFileName = Object.keys(asset.dependencies).find(
+          (k) => asset.dependencies[k].type === 'FILE',
+        )!;
+        const require = (v: string) => {
+          if (v in context!) return context![v];
+          throw new Error(`Cannot find module: ${v}`);
+        };
+        const exports: { default?: ComponentType } = {};
+        const module = { exports };
+        let entryFileCode = source[entryFileName];
 
-        // initial component with fake runtime
-        new Function('module', 'exports', 'require', entryFileCode)(
-          module,
-          exports,
-          require,
-        );
+        try {
+          // load renderToStaticMarkup in async way
+          const renderToStaticMarkupDeferred = import('react-dom/server').then(
+            ({ renderToStaticMarkup }) => renderToStaticMarkup,
+          );
 
-        const newDemoNode = createElement(
-          DemoErrorBoundary,
-          null,
-          createElement(exports.default!),
-        );
-        const oError = console.error;
+          // compile entry file code
+          entryFileCode = await renderOpts!.compile!(entryFileCode, {
+            filename: entryFileName,
+          });
 
-        // hijack console.error to avoid useLayoutEffect error
-        console.error = (...args) =>
-          !args[0].includes('useLayoutEffect does nothing on the server') &&
-          oError.apply(console, args);
+          // initial component with fake runtime
+          new Function('module', 'exports', 'require', entryFileCode)(
+            module,
+            exports,
+            require,
+          );
 
-        // check component is able to render, to avoid show react overlay error
-        (await renderToStaticMarkupDeferred)(newDemoNode);
-        console.error = oError;
+          const newDemoNode = createElement(
+            DemoErrorBoundary,
+            null,
+            createElement(exports.default!),
+          );
+          const oError = console.error;
 
-        // set new demo node with passing source
-        setDemoNode(newDemoNode);
-      } catch (err: any) {
-        setError(err);
-      }
-    }, 500) as (source: Record<string, string>) => Promise<void>,
+          // hijack console.error to avoid useLayoutEffect error
+          console.error = (...args) =>
+            !args[0].includes('useLayoutEffect does nothing on the server') &&
+            oError.apply(console, args);
+
+          // check component is able to render, to avoid show react overlay error
+          (await renderToStaticMarkupDeferred)(newDemoNode);
+          console.error = oError;
+
+          // set new demo node with passing source
+          setDemoNode(newDemoNode);
+          setError(null);
+        } catch (err: any) {
+          setError(err);
+        }
+
+        // reset loading status
+        clearTimeout(loadingTimer.current);
+        setLoading(false);
+      },
+      THROTTLE_WAIT,
+      { leading: true },
+    ) as (source: Record<string, string>) => Promise<void>,
     [context],
   );
 
-  return { node: demoNode, error, setSource };
+  return { node: demoNode, loading, error, setSource };
 };

--- a/src/client/theme-api/useLiveDemo.ts
+++ b/src/client/theme-api/useLiveDemo.ts
@@ -1,4 +1,5 @@
 import { useDemo } from 'dumi';
+import throttle from 'lodash.throttle';
 import {
   createElement,
   useCallback,
@@ -9,55 +10,62 @@ import {
 import DemoErrorBoundary from './DumiDemo/DemoErrorBoundary';
 
 export const useLiveDemo = (id: string) => {
-  const { context, asset } = useDemo(id)!;
+  const { context, asset, renderOpts } = useDemo(id)!;
   const [demoNode, setDemoNode] = useState<ReactNode>();
   const [error, setError] = useState<Error | null>(null);
   const setSource = useCallback(
-    (source: Record<string, string>) => {
+    throttle(async (source: Record<string, string>) => {
       const entryFileName = Object.keys(asset.dependencies).find(
         (k) => asset.dependencies[k].type === 'FILE',
       )!;
-      const entryFileCode = source[entryFileName];
       const require = (v: string) => {
         if (v in context!) return context![v];
         throw new Error(`Cannot find module: ${v}`);
       };
       const exports: { default?: ComponentType } = {};
       const module = { exports };
+      let entryFileCode = source[entryFileName];
 
-      // lazy load react-dom/server
-      import('react-dom/server').then(({ renderToStaticMarkup }) => {
-        try {
-          // initial component with fake runtime
-          new Function('module', 'exports', 'require', entryFileCode)(
-            module,
-            exports,
-            require,
-          );
-          const newDemoNode = createElement(
-            DemoErrorBoundary,
-            null,
-            createElement(exports.default!),
-          );
-          const oError = console.error;
+      try {
+        // load renderToStaticMarkup in async way
+        const renderToStaticMarkupDeferred = import('react-dom/server').then(
+          ({ renderToStaticMarkup }) => renderToStaticMarkup,
+        );
 
-          // hijack console.error to avoid useLayoutEffect error
-          console.error = (...args) =>
-            !args[0].includes('useLayoutEffect does nothing on the server') &&
-            oError.apply(console, args);
+        // compile entry file code
+        entryFileCode = await renderOpts!.compile!(entryFileCode, {
+          filename: entryFileName,
+        });
 
-          // check component is renderable, to avoid show react overlay error
-          renderToStaticMarkup(newDemoNode);
-          console.error = oError;
+        // initial component with fake runtime
+        new Function('module', 'exports', 'require', entryFileCode)(
+          module,
+          exports,
+          require,
+        );
 
-          // set new demo node with passing source
-          setDemoNode(newDemoNode);
-          setError(null);
-        } catch (err: any) {
-          setError(err);
-        }
-      });
-    },
+        const newDemoNode = createElement(
+          DemoErrorBoundary,
+          null,
+          createElement(exports.default!),
+        );
+        const oError = console.error;
+
+        // hijack console.error to avoid useLayoutEffect error
+        console.error = (...args) =>
+          !args[0].includes('useLayoutEffect does nothing on the server') &&
+          oError.apply(console, args);
+
+        // check component is able to render, to avoid show react overlay error
+        (await renderToStaticMarkupDeferred)(newDemoNode);
+        console.error = oError;
+
+        // set new demo node with passing source
+        setDemoNode(newDemoNode);
+      } catch (err: any) {
+        setError(err);
+      }
+    }, 500) as (source: Record<string, string>) => Promise<void>,
     [context],
   );
 

--- a/src/client/theme-api/useSiteSearch/useSearchData.ts
+++ b/src/client/theme-api/useSiteSearch/useSearchData.ts
@@ -34,9 +34,11 @@ export default function useSearchData(): [
       });
 
       // omit demo component for postmessage
-      Object.entries(demos).forEach(([id, { component, context, ...demo }]) => {
-        demos[id] = demo;
-      });
+      Object.entries(demos).forEach(
+        ([id, { renderOpts, component, context, ...demo }]) => {
+          demos[id] = demo;
+        },
+      );
 
       setData([mergedRoutes, demos]);
       loading.current = false;

--- a/src/client/theme-default/builtins/Previewer/index.less
+++ b/src/client/theme-default/builtins/Previewer/index.less
@@ -40,17 +40,11 @@
     &[data-iframe] {
       position: relative;
       padding: 0;
-      overflow: hidden;
+      border-top: 24px solid @c-border-light;
+      box-sizing: border-box;
 
-      &::before {
-        content: '';
-        display: block;
-        height: 24px;
-        background-color: @c-border-light;
-
-        @{dark-selector} & {
-          background-color: @c-border-less-dark;
-        }
+      @{dark-selector} & {
+        border-top-color: @c-border-less-dark;
       }
 
       &::after {
@@ -59,7 +53,7 @@
 
         content: '';
         position: absolute;
-        top: 5px;
+        top: -19px;
         left: @btn-gap;
         display: inline-block;
         width: @btn-width;
@@ -86,6 +80,44 @@
       + .@{prefix}-previewer-demo-error {
         border-top-left-radius: 3px;
         border-top-right-radius: 3px;
+      }
+    }
+
+    // loading status
+    &[data-loading] {
+      position: relative;
+
+      &::before {
+        @size: 28px;
+
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        content: '';
+        display: block;
+        height: @size;
+        max-height: 90%;
+        aspect-ratio: 1;
+        border-radius: 50%;
+        border: (@size / 10) solid;
+        border-color: @c-primary transparent;
+        box-sizing: border-box;
+        animation: dumi-previewer-loading 1s infinite;
+        transform: translate(-50%, -50%);
+
+        @{dark-selector} & {
+          border-color: @c-primary-dark transparent;
+        }
+
+        @keyframes dumi-previewer-loading {
+          to {
+            transform: translate(-50%, -50%) rotate(0.5turn);
+          }
+        }
+      }
+
+      > * {
+        opacity: 0.3 !important;
       }
     }
   }

--- a/src/client/theme-default/builtins/Previewer/index.tsx
+++ b/src/client/theme-default/builtins/Previewer/index.tsx
@@ -2,7 +2,7 @@ import { ReactComponent as IconError } from '@ant-design/icons-svg/inline-svg/fi
 import classnames from 'classnames';
 import { useLiveDemo, useLocation, type IPreviewerProps } from 'dumi';
 import PreviewerActions from 'dumi/theme/slots/PreviewerActions';
-import React, { useRef, useState, type FC } from 'react';
+import React, { useRef, type FC } from 'react';
 import './index.less';
 
 const Previewer: FC<IPreviewerProps> = (props) => {
@@ -14,8 +14,6 @@ const Previewer: FC<IPreviewerProps> = (props) => {
     error: liveDemoError,
     setSource: setLiveDemoSource,
   } = useLiveDemo(props.asset.id);
-  const [editorError, setEditorError] = useState<Error | null>(null);
-  const combineError = liveDemoError || editorError;
 
   return (
     <div
@@ -31,7 +29,7 @@ const Previewer: FC<IPreviewerProps> = (props) => {
         data-compact={props.compact || undefined}
         data-transform={props.transform || undefined}
         data-iframe={props.iframe || undefined}
-        data-error={Boolean(combineError) || undefined}
+        data-error={Boolean(liveDemoError) || undefined}
         ref={demoContainer}
       >
         {props.iframe ? (
@@ -47,10 +45,10 @@ const Previewer: FC<IPreviewerProps> = (props) => {
           liveDemoNode || props.children
         )}
       </div>
-      {combineError && (
+      {liveDemoError && (
         <div className="dumi-default-previewer-demo-error">
           <IconError />
-          {combineError.toString()}
+          {liveDemoError.toString()}
         </div>
       )}
       <div className="dumi-default-previewer-meta">
@@ -72,21 +70,16 @@ const Previewer: FC<IPreviewerProps> = (props) => {
         )}
         <PreviewerActions
           {...props}
-          onSourceTranspile={({ err, source }) => {
-            if (err) {
-              setEditorError(err);
-            } else {
-              setEditorError(null);
-              setLiveDemoSource(source);
+          onSourceChange={(source) => {
+            setLiveDemoSource(source);
 
-              if (props.iframe) {
-                demoContainer
-                  .current!.querySelector('iframe')!
-                  .contentWindow!.postMessage({
-                    type: 'dumi.liveDemo.setSource',
-                    value: source,
-                  });
-              }
+            if (props.iframe) {
+              demoContainer
+                .current!.querySelector('iframe')!
+                .contentWindow!.postMessage({
+                  type: 'dumi.liveDemo.setSource',
+                  value: source,
+                });
             }
           }}
           demoContainer={

--- a/src/client/theme-default/builtins/Previewer/index.tsx
+++ b/src/client/theme-default/builtins/Previewer/index.tsx
@@ -12,6 +12,7 @@ const Previewer: FC<IPreviewerProps> = (props) => {
   const {
     node: liveDemoNode,
     error: liveDemoError,
+    loading: liveDemoLoading,
     setSource: setLiveDemoSource,
   } = useLiveDemo(props.asset.id);
 
@@ -30,6 +31,7 @@ const Previewer: FC<IPreviewerProps> = (props) => {
         data-transform={props.transform || undefined}
         data-iframe={props.iframe || undefined}
         data-error={Boolean(liveDemoError) || undefined}
+        data-loading={liveDemoLoading || undefined}
         ref={demoContainer}
       >
         {props.iframe ? (

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -126,7 +126,8 @@ export const demos = {
   '{{{id}}}': {
     component: {{{component}}},
     asset: {{{renderAsset}}},
-    context: {{{renderContext}}}
+    context: {{{renderContext}}},
+    renderOpts: {{{renderRenderOpts}}},
   },
   {{/demos}}
 };`,
@@ -171,6 +172,21 @@ export const demos = {
         );
 
         return JSON.stringify(context, null, 2).replace(/"{{{|}}}"/g, '');
+      },
+      renderRenderOpts: function renderRenderOpts(
+        this: NonNullable<typeof demos>[0],
+      ) {
+        if (!('renderOpts' in this) || !this.renderOpts.compilePath) {
+          return 'undefined';
+        }
+
+        return `{
+          compile: async (...args) => {
+            return (await import('${winPath(
+              this.renderOpts.compilePath,
+            )}')).default(...args);
+          },
+        }`;
       },
     },
   );

--- a/src/loaders/markdown/transformer/index.ts
+++ b/src/loaders/markdown/transformer/index.ts
@@ -1,7 +1,12 @@
 import type { IParsedBlockAsset } from '@/assetParsers/block';
 import type { ILocalesConfig, IRouteMeta } from '@/client/theme-api/types';
 import { VERSION_2_DEPRECATE_SOFT_BREAKS } from '@/constants';
-import type { IApi, IDumiConfig, IDumiTechStack } from '@/types';
+import type {
+  IApi,
+  IDumiConfig,
+  IDumiTechStack,
+  IDumiTechStackRuntimeOpts,
+} from '@/types';
 import enhancedResolve from 'enhanced-resolve';
 import type { IRoute } from 'umi';
 import { semver } from 'umi/plugin-utils';
@@ -43,6 +48,7 @@ declare module 'vfile' {
           component: string;
           asset: IParsedBlockAsset['asset'];
           resolveMap: IParsedBlockAsset['resolveMap'];
+          renderOpts: Pick<IDumiTechStackRuntimeOpts, 'compilePath'>;
         }
       | {
           id: string;

--- a/src/loaders/markdown/transformer/rehypeDemo.ts
+++ b/src/loaders/markdown/transformer/rehypeDemo.ts
@@ -428,6 +428,9 @@ export default function rehypeDemo(
                           techStackOpts,
                         )
                       : resolveMap,
+                    renderOpts: {
+                      compilePath: techStack.runtimeOpts?.compilePath,
+                    },
                   };
                 },
               ),

--- a/src/techStacks/react.ts
+++ b/src/techStacks/react.ts
@@ -4,6 +4,10 @@ import { transformSync } from '@swc/core';
 export default class ReactTechStack implements IDumiTechStack {
   name = 'react';
 
+  runtimeOpts?: IDumiTechStack['runtimeOpts'] = {
+    compilePath: require.resolve('../client/misc/reactDemoCompiler'),
+  };
+
   isSupported(...[, lang]: Parameters<IDumiTechStack['isSupported']>) {
     return ['jsx', 'tsx'].includes(lang);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,11 +63,22 @@ export type IDumiUserConfig = Subset<Omit<IDumiConfig, 'locales'>> & {
   [key: string]: any;
 };
 
+export interface IDumiTechStackRuntimeOpts {
+  /**
+   * path to runtime compile function module
+   */
+  compilePath?: string;
+}
+
 export abstract class IDumiTechStack {
   /**
    * tech stack name, such as 'react'
    */
   abstract name: string;
+  /**
+   * runtime options
+   */
+  abstract runtimeOpts?: IDumiTechStackRuntimeOpts;
   /**
    * transform code
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

#1922 

### 💡 需求背景和解决方案 / Background or solution

支持自定义技术栈实现 live demo 特性，主要改动点：
1. `techStack` 类新增 `runtimeOpts` 属性，声明 `compilePath` 指向运行时编译 demo 的函数模块即可，该模块需要 default 导出编译函数，dumi 会在用户编辑 demo 时自动按需加载它
2. 没有声明 `compilePath` 的自定义技术栈代表不支持 live demo，dumi 不会为对应 demo 展示编辑态
3. 内置的 React 技术栈也重构为同样的 `runtimeOpts` 属性模式，并将 `SourceCodeEditor` 中的代码编译逻辑挪到 `useLiveDemo` API 中，减少开发者/用户覆盖 `SourceCodeEditor` 的成本
4. `useLiveDemo` API 新增 `loading` 状态，Vue 技术栈目前的 compile 模块产物较大，超过 500ms 没编译成功则会展示 loading 态

cc @jeffwcx 

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
