### PR TITLE
feat: useLiveDemo support iframe demo

### DIFF
--- a/src/client/pages/Demo/index.ts
+++ b/src/client/pages/Demo/index.ts
@@ -5,9 +5,14 @@ import './index.less';
 const DemoRenderPage: FC = () => {
   const { id } = useParams();
   const { component } = useDemo(id!) || {};
-  const { node: liveDemoNode, setSource } = useLiveDemo(id!);
+  const {
+    node: liveDemoNode,
+    error: liveDemoError,
+    setSource,
+  } = useLiveDemo(id!);
   const finalNode = liveDemoNode || (component && createElement(component));
 
+  // listen message event for setSource
   useEffect(() => {
     const handler = (
       ev: MessageEvent<{
@@ -24,6 +29,16 @@ const DemoRenderPage: FC = () => {
 
     return () => window.removeEventListener('message', handler);
   }, [setSource]);
+
+  // notify parent window that compile done
+  useEffect(() => {
+    if (liveDemoNode || liveDemoError) {
+      window.postMessage({
+        type: 'dumi.liveDemo.compileDone',
+        value: { err: liveDemoError },
+      });
+    }
+  }, [liveDemoNode, liveDemoError]);
 
   return finalNode;
 };

--- a/src/client/theme-api/useLiveDemo.ts
+++ b/src/client/theme-api/useLiveDemo.ts
@@ -20,6 +20,7 @@ export const useLiveDemo = (
   const { context, asset, renderOpts } = useDemo(id)!;
   const [loading, setLoading] = useState(false);
   const loadingTimer = useRef<number>();
+  const taskToken = useRef<number>();
   const [demoNode, setDemoNode] = useState<ReactNode>();
   const [error, setError] = useState<Error | null>(null);
   const setSource = useCallback(
@@ -68,6 +69,7 @@ export const useLiveDemo = (
           };
           const exports: { default?: ComponentType } = {};
           const module = { exports };
+          const token = (taskToken.current = Math.random());
           let entryFileCode = source[entryFileName];
 
           try {
@@ -80,6 +82,9 @@ export const useLiveDemo = (
             entryFileCode = await renderOpts!.compile!(entryFileCode, {
               filename: entryFileName,
             });
+
+            // skip current task if another task is running
+            if (token !== taskToken.current) return;
 
             // initial component with fake runtime
             new Function('module', 'exports', 'require', entryFileCode)(

--- a/src/client/theme-api/useLiveDemo.ts
+++ b/src/client/theme-api/useLiveDemo.ts
@@ -7,12 +7,16 @@ import {
   useState,
   type ComponentType,
   type ReactNode,
+  type RefObject,
 } from 'react';
 import DemoErrorBoundary from './DumiDemo/DemoErrorBoundary';
 
 const THROTTLE_WAIT = 500;
 
-export const useLiveDemo = (id: string) => {
+export const useLiveDemo = (
+  id: string,
+  opts?: { containerRef?: RefObject<HTMLElement>; iframe?: boolean },
+) => {
   const { context, asset, renderOpts } = useDemo(id)!;
   const [loading, setLoading] = useState(false);
   const loadingTimer = useRef<number>();
@@ -30,56 +34,82 @@ export const useLiveDemo = (id: string) => {
           THROTTLE_WAIT - 1,
         );
 
-        const entryFileName = Object.keys(asset.dependencies).find(
-          (k) => asset.dependencies[k].type === 'FILE',
-        )!;
-        const require = (v: string) => {
-          if (v in context!) return context![v];
-          throw new Error(`Cannot find module: ${v}`);
-        };
-        const exports: { default?: ComponentType } = {};
-        const module = { exports };
-        let entryFileCode = source[entryFileName];
+        if (opts?.iframe && opts?.containerRef?.current) {
+          const iframeWindow =
+            opts.containerRef.current.querySelector('iframe')!.contentWindow!;
 
-        try {
-          // load renderToStaticMarkup in async way
-          const renderToStaticMarkupDeferred = import('react-dom/server').then(
-            ({ renderToStaticMarkup }) => renderToStaticMarkup,
-          );
+          await new Promise<void>((resolve) => {
+            const handler = (
+              ev: MessageEvent<{
+                type: string;
+                value: { err: null | Error };
+              }>,
+            ) => {
+              if (ev.data.type.startsWith('dumi.liveDemo.compileDone')) {
+                iframeWindow.removeEventListener('message', handler);
+                setError(ev.data.value.err);
+                resolve();
+              }
+            };
 
-          // compile entry file code
-          entryFileCode = await renderOpts!.compile!(entryFileCode, {
-            filename: entryFileName,
+            iframeWindow.addEventListener('message', handler);
+            iframeWindow.postMessage({
+              type: 'dumi.liveDemo.setSource',
+              value: source,
+            });
           });
+        } else {
+          const entryFileName = Object.keys(asset.dependencies).find(
+            (k) => asset.dependencies[k].type === 'FILE',
+          )!;
+          const require = (v: string) => {
+            if (v in context!) return context![v];
+            throw new Error(`Cannot find module: ${v}`);
+          };
+          const exports: { default?: ComponentType } = {};
+          const module = { exports };
+          let entryFileCode = source[entryFileName];
 
-          // initial component with fake runtime
-          new Function('module', 'exports', 'require', entryFileCode)(
-            module,
-            exports,
-            require,
-          );
+          try {
+            // load renderToStaticMarkup in async way
+            const renderToStaticMarkupDeferred = import(
+              'react-dom/server'
+            ).then(({ renderToStaticMarkup }) => renderToStaticMarkup);
 
-          const newDemoNode = createElement(
-            DemoErrorBoundary,
-            null,
-            createElement(exports.default!),
-          );
-          const oError = console.error;
+            // compile entry file code
+            entryFileCode = await renderOpts!.compile!(entryFileCode, {
+              filename: entryFileName,
+            });
 
-          // hijack console.error to avoid useLayoutEffect error
-          console.error = (...args) =>
-            !args[0].includes('useLayoutEffect does nothing on the server') &&
-            oError.apply(console, args);
+            // initial component with fake runtime
+            new Function('module', 'exports', 'require', entryFileCode)(
+              module,
+              exports,
+              require,
+            );
 
-          // check component is able to render, to avoid show react overlay error
-          (await renderToStaticMarkupDeferred)(newDemoNode);
-          console.error = oError;
+            const newDemoNode = createElement(
+              DemoErrorBoundary,
+              null,
+              createElement(exports.default!),
+            );
+            const oError = console.error;
 
-          // set new demo node with passing source
-          setDemoNode(newDemoNode);
-          setError(null);
-        } catch (err: any) {
-          setError(err);
+            // hijack console.error to avoid useLayoutEffect error
+            console.error = (...args) =>
+              !args[0].includes('useLayoutEffect does nothing on the server') &&
+              oError.apply(console, args);
+
+            // check component is able to render, to avoid show react overlay error
+            (await renderToStaticMarkupDeferred)(newDemoNode);
+            console.error = oError;
+
+            // set new demo node with passing source
+            setDemoNode(newDemoNode);
+            setError(null);
+          } catch (err: any) {
+            setError(err);
+          }
         }
 
         // reset loading status
@@ -89,7 +119,7 @@ export const useLiveDemo = (id: string) => {
       THROTTLE_WAIT,
       { leading: true },
     ) as (source: Record<string, string>) => Promise<void>,
-    [context],
+    [context, asset, renderOpts],
   );
 
   return { node: demoNode, loading, error, setSource };

--- a/src/client/theme-default/builtins/Previewer/index.tsx
+++ b/src/client/theme-default/builtins/Previewer/index.tsx
@@ -14,7 +14,10 @@ const Previewer: FC<IPreviewerProps> = (props) => {
     error: liveDemoError,
     loading: liveDemoLoading,
     setSource: setLiveDemoSource,
-  } = useLiveDemo(props.asset.id);
+  } = useLiveDemo(props.asset.id, {
+    iframe: Boolean(props.iframe),
+    containerRef: demoContainer,
+  });
 
   return (
     <div
@@ -72,18 +75,7 @@ const Previewer: FC<IPreviewerProps> = (props) => {
         )}
         <PreviewerActions
           {...props}
-          onSourceChange={(source) => {
-            setLiveDemoSource(source);
-
-            if (props.iframe) {
-              demoContainer
-                .current!.querySelector('iframe')!
-                .contentWindow!.postMessage({
-                  type: 'dumi.liveDemo.setSource',
-                  value: source,
-                });
-            }
-          }}
+          onSourceChange={setLiveDemoSource}
           demoContainer={
             props.iframe
               ? (demoContainer.current?.firstElementChild as HTMLIFrameElement)

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -160,13 +160,20 @@ export const demos = {
         this: NonNullable<typeof demos>[0],
       ) {
         // do not render context for inline demo
-        if (!('resolveMap' in this)) return 'undefined';
+        if (!('resolveMap' in this) || !('asset' in this)) return 'undefined';
+
+        const entryFileName = Object.keys(this.asset.dependencies)[0];
 
         // render context for normal demo
         const context = Object.entries(this.resolveMap).reduce(
           (acc, [key, path]) => ({
             ...acc,
-            [key]: `{{{require('${path}')}}}`,
+            // omit entry file
+            ...(key !== entryFileName
+              ? {
+                  [key]: `{{{require('${path}')}}}`,
+                }
+              : {}),
           }),
           {},
         );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

将 iframe demo 的通信逻辑集成到 `useLiveDemo` 的实现中，外部不再关心通信的细节，只需要把 iframe 的父级 DOM ref 扔进去，该改动可降低自定义主题的开发者使用 `useLiveDemo` 及覆写 `Previewer` 的成本。

另外顺便做了两个优化：
1. demo context 不再包含 demo entry 自己，这会导致产物出现重复（因为 demo 有 techStack 的 require query，webpack 会认为是两个不同的模块）
2. 在 `useLiveDemo` 的异步 chunk 加载过程中如果 pending 了多个编译任务，在 chunk 加载完成后 `useLiveDemo` 会跳过已经过期的任务

cc @MadCcc antd 又要改一波了 👀 

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
