### PR TITLE
fix: overflow for source code editor

### DIFF
--- a/examples/normal/.dumirc.ts
+++ b/examples/normal/.dumirc.ts
@@ -7,5 +7,4 @@ export default {
   mfsu: false,
   apiParser: {},
   resolve: { entryFile: './src/index.ts' },
-  ssr: {},
 };

--- a/examples/normal/.dumirc.ts
+++ b/examples/normal/.dumirc.ts
@@ -7,4 +7,5 @@ export default {
   mfsu: false,
   apiParser: {},
   resolve: { entryFile: './src/index.ts' },
+  ssr: {},
 };

--- a/src/client/theme-default/builtins/SourceCode/index.less
+++ b/src/client/theme-default/builtins/SourceCode/index.less
@@ -32,6 +32,9 @@
     line-height: 1.58;
     direction: ltr;
     background: transparent;
+    white-space: pre-wrap;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 
     // remove shadow from coy theme
     &::before,

--- a/src/client/theme-default/builtins/SourceCode/index.less
+++ b/src/client/theme-default/builtins/SourceCode/index.less
@@ -25,16 +25,31 @@
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
 
-  > pre.prism-code {
+  &-scroll-container {
+    overflow: auto;
+    width: 100%;
+    height: 100%;
+  }
+
+  &-scroll-content {
+    position: relative;
+    width: max-content;
+    height: max-content;
+    min-width: 100%;
+    min-height: 100%;
+  }
+
+  > pre.prism-code,
+  &-scroll-content > pre.prism-code {
     margin: 0;
     padding: 18px 24px;
     font-size: 14px;
     line-height: 1.58;
     direction: ltr;
     background: transparent;
-    white-space: pre-wrap;
-    word-break: keep-all;
-    overflow-wrap: break-word;
+    overflow: visible;
+    width: max-content;
+    position: relative;
 
     // remove shadow from coy theme
     &::before,

--- a/src/client/theme-default/builtins/SourceCode/index.less
+++ b/src/client/theme-default/builtins/SourceCode/index.less
@@ -37,6 +37,16 @@
     height: max-content;
     min-width: 100%;
     min-height: 100%;
+
+    > pre.prism-code {
+      width: max-content;
+      position: relative;
+      overflow: visible;
+    }
+  }
+
+  > pre.prism-code {
+    overflow: auto;
   }
 
   > pre.prism-code,
@@ -47,9 +57,6 @@
     line-height: 1.58;
     direction: ltr;
     background: transparent;
-    overflow: visible;
-    width: max-content;
-    position: relative;
 
     // remove shadow from coy theme
     &::before,

--- a/src/client/theme-default/builtins/SourceCode/index.tsx
+++ b/src/client/theme-default/builtins/SourceCode/index.tsx
@@ -27,6 +27,7 @@ interface SourceCodeProps {
   lang: Language;
   highlightLines?: number[];
   extra?: ReactNode;
+  textarea?: ReactNode;
 }
 
 const SourceCode: FC<SourceCodeProps> = (props) => {
@@ -43,6 +44,48 @@ const SourceCode: FC<SourceCodeProps> = (props) => {
       setText(text);
     }
   }, [lang, children]);
+
+  const code = (
+    <Highlight
+      {...defaultProps}
+      code={children}
+      language={SIMILAR_DSL[lang] || lang}
+      theme={undefined}
+    >
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={className} style={style}>
+          {tokens.map((line, i) => (
+            <div
+              key={String(i)}
+              className={classNames({
+                highlighted: highlightLines.includes(i + 1),
+                wrap: themeConfig.showLineNum,
+              })}
+            >
+              {themeConfig.showLineNum && (
+                <span className="token-line-num">{i + 1}</span>
+              )}
+              <div
+                {...getLineProps({
+                  line,
+                  key: i,
+                })}
+                className={classNames({
+                  'line-cell': themeConfig.showLineNum,
+                })}
+              >
+                {line.map((token, key) => (
+                  // getTokenProps 返回值包含 key
+                  // eslint-disable-next-line react/jsx-key
+                  <span {...getTokenProps({ token, key })} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </pre>
+      )}
+    </Highlight>
+  );
 
   return (
     <div className="dumi-default-source-code">
@@ -62,45 +105,16 @@ const SourceCode: FC<SourceCodeProps> = (props) => {
           {isCopied ? <IconCheck /> : <IconCopy />}
         </button>
       </CopyToClipboard>
-      <Highlight
-        {...defaultProps}
-        code={children}
-        language={SIMILAR_DSL[lang] || lang}
-        theme={undefined}
-      >
-        {({ className, style, tokens, getLineProps, getTokenProps }) => (
-          <pre className={className} style={style}>
-            {tokens.map((line, i) => (
-              <div
-                key={String(i)}
-                className={classNames({
-                  highlighted: highlightLines.includes(i + 1),
-                  wrap: themeConfig.showLineNum,
-                })}
-              >
-                {themeConfig.showLineNum && (
-                  <span className="token-line-num">{i + 1}</span>
-                )}
-                <div
-                  {...getLineProps({
-                    line,
-                    key: i,
-                  })}
-                  className={classNames({
-                    'line-cell': themeConfig.showLineNum,
-                  })}
-                >
-                  {line.map((token, key) => (
-                    // getTokenProps 返回值包含 key
-                    // eslint-disable-next-line react/jsx-key
-                    <span {...getTokenProps({ token, key })} />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </pre>
-        )}
-      </Highlight>
+      {props.textarea ? (
+        <div className="dumi-default-source-code-scroll-container">
+          <div className="dumi-default-source-code-scroll-content">
+            {code}
+            {props.textarea}
+          </div>
+        </div>
+      ) : (
+        code
+      )}
       {props.extra}
     </div>
   );

--- a/src/client/theme-default/slots/SourceCodeEditor/index.less
+++ b/src/client/theme-default/slots/SourceCodeEditor/index.less
@@ -13,6 +13,8 @@
     height: 100%;
     color: transparent;
     caret-color: @c-text;
+    overflow-wrap: normal;
+    white-space: pre;
     box-sizing: border-box;
     background: transparent;
     opacity: 1;
@@ -22,24 +24,36 @@
     overflow: hidden;
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
-    white-space: pre-wrap;
-    word-break: keep-all;
-    overflow-wrap: break-word;
 
     @{dark-selector} & {
       caret-color: @c-text-dark;
     }
 
     &:focus {
-      box-shadow: 0 0 0 1px lighten(@c-primary, 20%) inset;
-
       @{dark-selector} & {
-        box-shadow: 0 0 0 1px darken(@c-primary-dark, 20%) inset;
-
         // for firefox because its selection color is not translucent when color-scheme is dark
         &::selection {
           background-color: fade(@c-primary-dark, 30%);
         }
+      }
+    }
+  }
+
+  &:focus-within {
+    &::after {
+      content: '';
+      position: absolute;
+      z-index: 0;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border-bottom-left-radius: 3px;
+      border-bottom-right-radius: 3px;
+      box-shadow: 0 0 0 1px @c-primary inset;
+
+      @{dark-selector} & {
+        box-shadow: 0 0 0 1px @c-primary-dark inset;
       }
     }
   }

--- a/src/client/theme-default/slots/SourceCodeEditor/index.less
+++ b/src/client/theme-default/slots/SourceCodeEditor/index.less
@@ -39,17 +39,20 @@
     }
   }
 
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+  }
+
   &:focus-within {
     &::after {
-      content: '';
-      position: absolute;
-      z-index: 0;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      border-bottom-left-radius: 3px;
-      border-bottom-right-radius: 3px;
       box-shadow: 0 0 0 1px @c-primary inset;
 
       @{dark-selector} & {

--- a/src/client/theme-default/slots/SourceCodeEditor/index.less
+++ b/src/client/theme-default/slots/SourceCodeEditor/index.less
@@ -13,8 +13,6 @@
     height: 100%;
     color: transparent;
     caret-color: @c-text;
-    overflow-wrap: normal;
-    white-space: pre;
     box-sizing: border-box;
     background: transparent;
     opacity: 1;
@@ -24,6 +22,9 @@
     overflow: hidden;
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
+    white-space: pre-wrap;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 
     @{dark-selector} & {
       caret-color: @c-text-dark;

--- a/src/client/theme-default/slots/SourceCodeEditor/index.tsx
+++ b/src/client/theme-default/slots/SourceCodeEditor/index.tsx
@@ -51,45 +51,43 @@ const SourceCodeEditor: FC<ISourceCodeEditorProps> = (props) => {
     <div className="dumi-default-source-code-editor" ref={elm}>
       <SourceCode
         {...props}
-        extra={
+        textarea={
           style && (
-            <>
-              <textarea
-                className="dumi-default-source-code-editor-textarea"
-                style={style}
-                value={code}
-                onChange={(ev) => {
-                  setCode(ev.target.value);
-                  props.onChange?.(ev.target.value);
-                  // FIXME: remove before publish
-                  props.onTranspile?.({ err: null, code: ev.target.value });
-                }}
-                onKeyDown={(ev) => {
-                  // support tab to space
-                  if (ev.key === 'Tab') {
-                    ev.preventDefault();
+            <textarea
+              className="dumi-default-source-code-editor-textarea"
+              style={style}
+              value={code}
+              onChange={(ev) => {
+                setCode(ev.target.value);
+                props.onChange?.(ev.target.value);
+                // FIXME: remove before publish
+                props.onTranspile?.({ err: null, code: ev.target.value });
+              }}
+              onKeyDown={(ev) => {
+                // support tab to space
+                if (ev.key === 'Tab') {
+                  ev.preventDefault();
 
-                    const elm = ev.currentTarget;
-                    const { selectionStart: start, selectionEnd: end } = elm;
-                    const before = elm.value.substring(0, start);
-                    const after = elm.value.substring(end);
-                    const spaces = '  ';
-                    const pos = spaces.length + start;
+                  const elm = ev.currentTarget;
+                  const { selectionStart: start, selectionEnd: end } = elm;
+                  const before = elm.value.substring(0, start);
+                  const after = elm.value.substring(end);
+                  const spaces = '  ';
+                  const pos = spaces.length + start;
 
-                    setCode(`${before}${spaces}${after}`);
-                    setTimeout(() => {
-                      elm.setSelectionRange(pos, pos);
-                    });
-                  }
-                }}
-                autoComplete="off"
-                autoCorrect="off"
-                autoSave="off"
-              />
-              {props.extra}
-            </>
+                  setCode(`${before}${spaces}${after}`);
+                  setTimeout(() => {
+                    elm.setSelectionRange(pos, pos);
+                  });
+                }
+              }}
+              autoComplete="off"
+              autoCorrect="off"
+              autoSave="off"
+            />
           )
         }
+        extra={style && props.extra}
       >
         {code}
       </SourceCode>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [x] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
close https://github.com/ant-design/ant-design/issues/46992
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
由于代码展示和编辑分别由两个不同的元素完成，如果要同时滚动的话可能做虚拟滚动会好些，成本略高。
简单套用 react-simple-code-editor 的方式让代码换行。
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix SourceCode that cannot scroll.      |
| 🇨🇳 Chinese |    修复 SourceCode 无法滚动的问题。       |
