### PR TITLE
fix: assets metadata may lost when enable fs cache in prod

### DIFF
--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -71,22 +71,28 @@ export default (api: IApi) => {
       .end()
       .use('md-meta-loader')
       .loader(loaderPath)
-      .options({
-        ...loaderBaseOpts,
-        mode: 'meta',
-        onResolveDemos(demos) {
-          const assets = demos.reduce<Parameters<typeof addExampleAssets>[0]>(
-            (ret, demo) => {
-              if ('asset' in demo) ret.push(demo.asset);
-              return ret;
-            },
-            [],
-          );
+      .options(
+        (api.isPluginEnable('assets') || api.isPluginEnable('exportStatic')
+          ? {
+              ...loaderBaseOpts,
+              mode: 'meta',
+              onResolveDemos(demos) {
+                const assets = demos.reduce<
+                  Parameters<typeof addExampleAssets>[0]
+                >((ret, demo) => {
+                  if ('asset' in demo) ret.push(demo.asset);
+                  return ret;
+                }, []);
 
-          addExampleAssets(assets);
-        },
-        onResolveAtomMeta: addAtomMeta,
-      } as IMdLoaderOptions)
+                addExampleAssets(assets);
+              },
+              onResolveAtomMeta: addAtomMeta,
+            }
+          : {
+              ...loaderBaseOpts,
+              mode: 'meta',
+            }) as IMdLoaderOptions,
+      )
       .end()
       .end()
       // get page component for each markdown file

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -150,6 +150,15 @@ export default function mdLoader(this: any, content: string) {
   const opts: IMdLoaderOptions = this.getOptions();
   const cb = this.async();
 
+  // disable cache for avoid assets metadata lost
+  // because the onResolveDemos and onResolveAtomMeta hook does not be fired when cache hit
+  if (
+    process.env.NODE_ENV === 'production' &&
+    ['onResolveDemos', 'onResolveAtomMeta'].some((k) => k in opts)
+  ) {
+    this.cacheable(false);
+  }
+
   const cache = getCache('md-loader');
   // format: {path:contenthash:loaderOpts}
   const baseCacheKey = [


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

https://github.com/umijs/dumi/pull/1649
https://github.com/umijs/dumi/pull/1659

### 💡 需求背景和解决方案 / Background or solution

md-loader 在生产构建且应用启用资产元数据相关能力时禁用缓存，以避免命中 webpack loader 缓存 -> hook 不执行 -> 资产元数据缺失 -> 相关能力异常

仅在 prod 开启是因为 dev 禁用 loader 缓存会影响编译性能，且 dev 场景下用户不直接消费资产元数据，在准确性和性能中选择了后者

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix assets metadata lost bug when enable fs cache |
| 🇨🇳 Chinese | 修复启用持久缓存时资产元数据可能丢失的问题 |
