### PR TITLE
fix: unexpected suspense from useRouteMeta

### DIFF
--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -7,7 +7,7 @@ import {
 } from 'dumi';
 import { useCallback, useState } from 'react';
 import type { IRouteMeta, IRoutesById } from './types';
-import { use, useIsomorphicLayoutEffect } from './utils';
+import { useIsomorphicLayoutEffect } from './utils';
 
 const cache = new Map<string, IRouteMeta | Promise<IRouteMeta>>();
 const EMPTY_META = {
@@ -95,5 +95,5 @@ export const useRouteMeta = () => {
     setMatchedRoute(getter);
   }, [clientRoutes.length, pathname]);
 
-  return meta instanceof Promise ? use(meta) : meta;
+  return meta;
 };

--- a/src/client/theme-api/utils.ts
+++ b/src/client/theme-api/utils.ts
@@ -146,36 +146,3 @@ export const pickRouteSortMeta = (
 export function getLocaleNav(nav: IUserNavValue | INav, locale: ILocale) {
   return Array.isArray(nav) ? nav : nav[locale.id];
 }
-
-// Copy from React official demo.
-type ReactPromise<T> = Promise<T> & {
-  status?: 'pending' | 'fulfilled' | 'rejected';
-  value?: T;
-  reason?: any;
-};
-
-/**
- * @private Internal usage. Safe to remove
- */
-export function use<T>(promise: ReactPromise<T>): T {
-  if (promise.status === 'fulfilled') {
-    return promise.value!;
-  } else if (promise.status === 'rejected') {
-    throw promise.reason;
-  } else if (promise.status === 'pending') {
-    throw promise;
-  } else {
-    promise.status = 'pending';
-    promise.then(
-      (result) => {
-        promise.status = 'fulfilled';
-        promise.value = result;
-      },
-      (reason) => {
-        promise.status = 'rejected';
-        promise.reason = reason;
-      },
-    );
-    throw promise;
-  }
-}

--- a/src/features/exports.ts
+++ b/src/features/exports.ts
@@ -1,5 +1,4 @@
 import type { IApi } from '@/types';
-import path from 'path';
 import { winPath } from 'umi/plugin-utils';
 
 export default (api: IApi) => {
@@ -8,7 +7,6 @@ export default (api: IApi) => {
   // allow import from dumi
   api.modifyConfig((memo) => {
     memo.alias['dumi$'] = '@@/dumi/exports';
-    memo.alias['dumi/dist'] = winPath(path.join(__dirname, '..'));
 
     return memo;
   });

--- a/src/templates/meta/exports.ts.tpl
+++ b/src/templates/meta/exports.ts.tpl
@@ -1,6 +1,38 @@
 import { filesMeta, tabsMeta } from '.';
 import type { IDemoData, IRouteMeta } from 'dumi/dist/client/theme-api/types';
-import { use } from 'dumi/dist/client/theme-api/utils';
+
+// Copy from React official demo.
+type ReactPromise<T> = Promise<T> & {
+  status?: 'pending' | 'fulfilled' | 'rejected';
+  value?: T;
+  reason?: any;
+};
+
+/**
+ * @private Internal usage. Safe to remove
+ */
+export function use<T>(promise: ReactPromise<T>): T {
+  if (promise.status === 'fulfilled') {
+    return promise.value!;
+  } else if (promise.status === 'rejected') {
+    throw promise.reason;
+  } else if (promise.status === 'pending') {
+    throw promise;
+  } else {
+    promise.status = 'pending';
+    promise.then(
+      (result) => {
+        promise.status = 'fulfilled';
+        promise.value = result;
+      },
+      (reason) => {
+        promise.status = 'rejected';
+        promise.reason = reason;
+      },
+    );
+    throw promise;
+  }
+}
 
 const demoIdMap = Object.keys(filesMeta).reduce((total, current) => {
   if (filesMeta[current].demoIndex) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

https://github.com/ant-design/ant-design/issues/47058

### 💡 需求背景和解决方案 / Background or solution

修复 `useRouteMeta` 引发意外 suspense 导致出现不必要的 loading 状态的问题，这也会导致 `Helmet` 工作不正常，比如 Ant Design 官网在路由切换时网页标题可能不会更新

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
