### PR TITLE
feat: tech stack supports declare runtime plugin

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,10 @@ export interface IDumiTechStackRuntimeOpts {
    * path to runtime compile function module
    */
   compilePath?: string;
+  /**
+   * path to runtime plugin for this tech stack
+   */
+  pluginPath?: string;
 }
 
 export abstract class IDumiTechStack {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

无

### 💡 需求背景和解决方案 / Background or solution

自定义技术栈支持声明关联的运行时插件，该插件通常用来定义与技术栈对应的自定义运行时配置（比如 `modifyCodeSandboxData` 等），是比 `api.addRuntimePlugin` 关联性更高的注册方式，未来也可能会用于框架识别技术栈的运行时能力（比如是否支持在 CodeSandbox 中打开）

cc @jeffwcx 

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
