### PR TITLE
fix: code editor scroll bar should be draggable

### DIFF
--- a/src/client/theme-default/slots/SourceCodeEditor/index.less
+++ b/src/client/theme-default/slots/SourceCodeEditor/index.less
@@ -49,6 +49,7 @@
     height: 100%;
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
+    pointer-events: none;
   }
 
   &:focus-within {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
close https://github.com/ant-design/ant-design/issues/47230
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
代码可以滚动时滚动条被 focus 的伪类挡住了，无法拖拽。处理一下伪类。
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix code editor that scroll bar couldn't be dragged.         |
| 🇨🇳 Chinese |     修复代码编辑器滚动条无法拖拽的问题。      |
