### PR TITLE
feat: contentTabs order support

### DIFF
--- a/src/client/theme-default/slots/ContentTabs/index.tsx
+++ b/src/client/theme-default/slots/ContentTabs/index.tsx
@@ -25,19 +25,24 @@ const ContentTabs: FC<IContentTabsProps> = ({
           {intl.formatMessage({ id: 'content.tabs.default' })}
         </button>
       </li>
-      {tabs!.map((tab) => (
-        <li
-          key={tab.key}
-          onClick={() => onChange(tab)}
-          data-active={key === tab.key || undefined}
-        >
-          <button type="button">
-            {tab.titleIntlId
-              ? intl.formatMessage({ id: tab.titleIntlId })
-              : tab.meta.frontmatter.title}
-          </button>
-        </li>
-      ))}
+      {tabs!
+        .sort(
+          (a, b) =>
+            (b.meta.frontmatter.order || 0) - (a.meta.frontmatter.order - 0),
+        )
+        .map((tab) => (
+          <li
+            key={tab.key}
+            onClick={() => onChange(tab)}
+            data-active={key === tab.key || undefined}
+          >
+            <button type="button">
+              {tab.titleIntlId
+                ? intl.formatMessage({ id: tab.titleIntlId })
+                : tab.meta.frontmatter.title}
+            </button>
+          </li>
+        ))}
     </ul>
   ) : null;
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

支持页面tab根据order自定义排序，order大的在前

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Support page tabs can be customized in accordance with their order, with higher orders prioritized      |
| 🇨🇳 Chinese |      支持页面tab根据order自定义排序，order大的在前     |
