### PR TITLE
fix: active position for toc scrolling highlight

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://registry.npmjs.org/
+registry=https://registry.npmmirror.com/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://registry.npmmirror.com/
+registry=https://registry.npmjs.org/

--- a/src/client/theme-default/slots/Toc/index.tsx
+++ b/src/client/theme-default/slots/Toc/index.tsx
@@ -23,6 +23,8 @@ const Toc: FC = () => {
   const { loading } = useSiteData();
   const prevIndexRef = useRef(0);
   const [sectionRefs, setSectionRefs] = useState<RefObject<HTMLElement>[]>([]);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
   const memoToc = React.useMemo(() => {
     let toc = meta.toc;
     if (tabMeta) {
@@ -44,8 +46,17 @@ const Toc: FC = () => {
     }
   }, [pathname, search, loading, memoToc]);
 
+  useEffect(() => {
+    if (sectionRefs.length > 0) {
+      // find the header height, and set it to scrollspy offset
+      // because the header is sticky, so we need to set the offset to avoid the active item is hidden by the header
+      const header = document.querySelector('.dumi-default-header');
+      setHeaderHeight(header ? header.clientHeight : 0);
+    }
+  }, [sectionRefs]);
+
   return sectionRefs.length ? (
-    <ScrollSpy sectionRefs={sectionRefs}>
+    <ScrollSpy sectionRefs={sectionRefs} offset={-headerHeight}>
       {({ currentElementIndexInViewport }) => {
         // for keep prev item active when no item in viewport
         if (currentElementIndexInViewport > -1)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
fix https://github.com/umijs/dumi/issues/2007

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
由于header 的布局是`sticky`, 当点击左侧sidebar时，`核心 API` 这个锚点内容还是处于可视状态，即`currentElementIndexInViewport` 还是在当前的key中， 所以这里需要用-offset (header的高度)，触发它的激活状态

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
