### PR TITLE
docs: fix umi docs sync script

### DIFF
--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -279,6 +279,9 @@ const FILE_LIST = [
       { type: 'replace', value: [/@(\/extraRoutes)/g, '.$1'] },
       // remove args from title
       { type: 'replace', value: [/(#+\s\w+)\([^)]+\)/g, '$1'] },
+      // remove HashAnchorCompat
+      // ref: https://github.com/umijs/umi/blob/8bfd4c761b3cc6209b9203c705842568c3ccbe62/docs/docs/docs/api/runtime-config.md#L183
+      { type: 'replace', value: [/<HashAnchorCompat.+?<\/HashAnchorCompat>\n/g, ''] },
     ],
   },
   {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [x] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

修复 Umi 文档同步脚本，去掉 `HashAnchorCompat` 全局 anchor 兼容组件

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
