### PR TITLE
chore: update docs sync source

### DIFF
--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -180,7 +180,7 @@ const FILE_LIST = [
   },
   {
     localname: 'plugin.md',
-    repoPath: 'docs/docs/docs/api/plugin.md',
+    repoPath: 'docs/docs/docs/guides/plugins.md',
     actions: [
       RM_FM_ACTION,
       // remove head content

--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -329,7 +329,6 @@ FILE_LIST.forEach((file) => {
   const localPath = path.join(UMI_DOC_DIR, file.localname);
 
   const protocol = file.upstream.startsWith('https') ? https : http;
-  console.log('sync', file.upstream, 'to', localPath);
 
   // get file from upstream
   protocol.get(file.upstream, (res) => {
@@ -360,7 +359,12 @@ FILE_LIST.forEach((file) => {
 
       // write back to file
       fs.writeFileSync(localPath, content);
-      console.log('sync', file.localname, 'from upstream successfully!');
+      console.log(
+        '🔁',
+        file.upstream,
+        '->',
+        path.relative(process.cwd(), localPath),
+      );
     });
   });
 });

--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -360,10 +360,9 @@ FILE_LIST.forEach((file) => {
       // write back to file
       fs.writeFileSync(localPath, content);
       console.log(
-        '🔁',
-        file.upstream,
-        '->',
-        path.relative(process.cwd(), localPath),
+        `🔁 ${file.upstream} -> ${path.relative(process.cwd(), localPath)} [${(
+          content.length / 1024
+        ).toFixed(2)}KB]`,
       );
     });
   });

--- a/scripts/sync-from-umi.js
+++ b/scripts/sync-from-umi.js
@@ -7,12 +7,15 @@ const RM_FM_ACTION = {
   type: 'replace',
   value: [/^---[^]+?---\n/, ''],
 };
+
+const JSDELIVR_PREFIX = 'https://cdn.jsdelivr.net/gh/umijs/umi@4/';
+const GITHUB_RAW_PREFIX = 'https://raw.githubusercontent.com/umijs/umi/master/';
+
 const FILE_LIST = [
   // config docs
   {
     localname: 'config.md',
-    upstream:
-      'https://cdn.jsdelivr.net/gh/umijs/umi@4/docs/docs/docs/api/config.md',
+    repoPath: 'docs/docs/docs/api/config.md',
     actions: [
       RM_FM_ACTION,
       // remove head content
@@ -152,8 +155,7 @@ const FILE_LIST = [
   },
   {
     localname: 'api.md',
-    upstream:
-      'https://cdn.jsdelivr.net/gh/umijs/umi@4/docs/docs/docs/api/api.md',
+    repoPath: 'docs/docs/docs/api/api.md',
     actions: [
       RM_FM_ACTION,
       // remove head content
@@ -177,8 +179,7 @@ const FILE_LIST = [
   },
   {
     localname: 'plugin.md',
-    upstream:
-      'https://cdn.jsdelivr.net/gh/umijs/umi@4/docs/docs/docs/guides/plugins.md',
+    repoPath: 'docs/docs/docs/api/plugin.md',
     actions: [
       RM_FM_ACTION,
       // remove head content
@@ -203,8 +204,7 @@ const FILE_LIST = [
   },
   {
     localname: 'plugin-api.md',
-    upstream:
-      'https://cdn.jsdelivr.net/gh/umijs/umi@4/docs/docs/docs/api/plugin-api.md',
+    repoPath: 'docs/docs/docs/api/plugin-api.md',
     actions: [
       RM_FM_ACTION,
       // remove head content
@@ -243,8 +243,7 @@ const FILE_LIST = [
   },
   {
     localname: 'runtime-config.md',
-    upstream:
-      'https://cdn.jsdelivr.net/gh/umijs/umi@4/docs/docs/docs/api/runtime-config.md',
+    repoPath: 'docs/docs/docs/api/runtime-config.md',
     actions: [
       RM_FM_ACTION,
       // replace jsx to jsx | pure
@@ -281,13 +280,15 @@ const FILE_LIST = [
       { type: 'replace', value: [/(#+\s\w+)\([^)]+\)/g, '$1'] },
       // remove HashAnchorCompat
       // ref: https://github.com/umijs/umi/blob/8bfd4c761b3cc6209b9203c705842568c3ccbe62/docs/docs/docs/api/runtime-config.md#L183
-      { type: 'replace', value: [/<HashAnchorCompat.+?<\/HashAnchorCompat>\n/g, ''] },
+      {
+        type: 'replace',
+        value: [/<HashAnchorCompat.+?<\/HashAnchorCompat>\n/g, ''],
+      },
     ],
   },
   {
     localname: 'env-config.md',
-    upstream:
-      'https://cdn.jsdelivr.net/gh/umijs/umi@4/docs/docs/docs/guides/env-variables.md',
+    repoPath: 'docs/docs/docs/guides/env-variables.md',
     actions: [
       RM_FM_ACTION,
       // remove head content
@@ -307,7 +308,17 @@ const FILE_LIST = [
       { type: 'replace', value: [/config\./g, '.dumirc.'] },
     ],
   },
-];
+].map((file) => ({
+  ...file,
+
+  upstream: [
+    // 可以完全自定义(也许是一个本地启动的服务)
+    process.env.SYNC_CUSTOM_UPSTREAM,
+    // 同步遇到 443 失败时, 可以尝试 `SYNC_USE_GITHUB=1 npm run docs:sync` 使用 GitHub 作为源
+    process.env.SYNC_USE_GITHUB && GITHUB_RAW_PREFIX,
+    JSDELIVR_PREFIX,
+  ].find(Boolean),
+}));
 
 if (!fs.existsSync(UMI_DOC_DIR)) {
   fs.mkdirSync(UMI_DOC_DIR);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [x] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

我本地还是遇到和去年反馈的问题一样，本地同步 umijs 文档经常失败
<img width="747" alt="image" src="https://github.com/umijs/dumi/assets/32004925/124261f8-522f-4a11-b377-a5fbbc31b445">

**使用 GitHub raw**

同步遇到 443 失败时, 可以尝试 `SYNC_USE_GITHUB=1 npm run docs:sync` 使用 GitHub 作为源
<img width="1251" alt="image" src="https://github.com/umijs/dumi/assets/32004925/95dc382e-a120-454b-b683-24b87bc92834">

**本地启动服务**

本地 clone 了 umijs 仓库，使用 http-server启动服务，`SYNC_CUSTOM_UPSTREAM=http://127.0.0.1:8080/ npm run docs:sync`

<img width="1512" alt="image" src="https://github.com/umijs/dumi/assets/32004925/8f28c960-1e7e-4423-b83f-63fcce4febc9">


<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Improve document synchronization logic and support source switching      |
| 🇨🇳 Chinese |    改进文档同步逻辑，支持切换源       |
