### PR TITLE
feat: builtin Tree component can recognizes empty ul as a folder

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -169,9 +169,12 @@ features:
 ```md
 <Tree>
   <ul>
+    <ul>components</ul>
     <li>
       src
+      <ul>hooks</ul>
       <ul>
+        <ul>components</ul>
         <li>index.md</li>
       </ul>
     </li>
@@ -184,9 +187,12 @@ features:
 
 <Tree>
   <ul>
+    <ul>components</ul>
     <li>
       src
+      <ul>hooks</ul>
       <ul>
+        <ul>components</ul>
         <li>index.md</li>
       </ul>
     </li>
@@ -199,10 +205,22 @@ features:
 ```diff
 <Tree>
   <ul>
+    <ul>
+      components
++     <small>这是 components 文件夹</small>
+    </ul>
     <li>
       src
 +     <small>这是 src 文件夹</small>
       <ul>
+        hooks
++       <small>这是 hooks 文件夹</small>
+      </ul>
+      <ul>
+        <ul>
+          components
++         <small>这是 components 文件夹</small>
+        </ul>
         <li>
           index.md
 +         <small>这是 index.md</small>
@@ -221,10 +239,22 @@ features:
 
 <Tree>
   <ul>
+    <ul>
+      components
+      <small>这是 components 文件夹</small>
+    </ul>
     <li>
       src
       <small>这是 src 文件夹</small>
       <ul>
+        hooks
+        <small>这是 hooks 文件夹</small>
+      </ul>
+      <ul>
+        <ul>
+          components
+          <small>这是 components 文件夹</small>
+        </ul>
         <li>
           index.md
           <small>这是 index.md</small>

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -169,12 +169,10 @@ features:
 ```md
 <Tree>
   <ul>
-    <ul>components</ul>
     <li>
       src
-      <ul>hooks</ul>
       <ul>
-        <ul>components</ul>
+        <li>directory <ul></ul></li>
         <li>index.md</li>
       </ul>
     </li>
@@ -187,12 +185,10 @@ features:
 
 <Tree>
   <ul>
-    <ul>components</ul>
     <li>
       src
-      <ul>hooks</ul>
       <ul>
-        <ul>components</ul>
+        <li>directory <ul></ul></li>
         <li>index.md</li>
       </ul>
     </li>
@@ -205,22 +201,15 @@ features:
 ```diff
 <Tree>
   <ul>
-    <ul>
-      components
-+     <small>这是 components 文件夹</small>
-    </ul>
     <li>
       src
 +     <small>这是 src 文件夹</small>
       <ul>
-        hooks
-+       <small>这是 hooks 文件夹</small>
-      </ul>
-      <ul>
-        <ul>
-          components
-+         <small>这是 components 文件夹</small>
-        </ul>
+        <li>
+          directory
++         <small>没有子项的文件夹</small>
+          <ul></ul>
+        </li>
         <li>
           index.md
 +         <small>这是 index.md</small>
@@ -239,22 +228,15 @@ features:
 
 <Tree>
   <ul>
-    <ul>
-      components
-      <small>这是 components 文件夹</small>
-    </ul>
     <li>
       src
       <small>这是 src 文件夹</small>
       <ul>
-        hooks
-        <small>这是 hooks 文件夹</small>
-      </ul>
-      <ul>
-        <ul>
-          components
-          <small>这是 components 文件夹</small>
-        </ul>
+        <li>
+          directory
+          <small>没有子项的文件夹</small>
+          <ul></ul>
+        </li>
         <li>
           index.md
           <small>这是 index.md</small>

--- a/src/client/theme-default/builtins/Tree/index.tsx
+++ b/src/client/theme-default/builtins/Tree/index.tsx
@@ -32,7 +32,7 @@ function getTreeFromList(nodes: ReactNode, prefix = '') {
       }
 
       case 'li': {
-        const hasEmptyUl = node.props?.children?.some?.(
+        const hasEmptyUl = node.props.children?.some?.(
           (child) => child.type === 'ul' && !child.props.children?.length,
         );
         const title = ([] as ReactNode[])
@@ -93,16 +93,16 @@ const getIcon = (props: TreeNodeProps<DataNode>) => {
 const renderSwitcherIcon = (props: TreeNodeProps<DataNode>) => {
   const { isLeaf, expanded } = props;
   if (isLeaf) {
-    return <span className={`tree-switcher-leaf-line`} />;
+    return <span className="tree-switcher-leaf-line" />;
   }
   return expanded ? (
-    <span className={`tree-switcher-line-icon`}>
+    <span className="tree-switcher-line-icon">
       <span className="dumi-default-tree-icon">
         <MinusSquareOutlined fill="currentColor" />
       </span>
     </span>
   ) : (
-    <span className={`tree-switcher-line-icon`}>
+    <span className="tree-switcher-line-icon">
       <span className="dumi-default-tree-icon">
         <PlusSquareOutlined fill="currentColor" />
       </span>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
https://github.com/umijs/dumi/issues/2071
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
tree支持空 ul 也判定为文件夹
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    The tree structure also treats empty ul as a folder       |
| 🇨🇳 Chinese |      Tree支持空 ul 也判定为文件夹     |
