### PR TITLE
fix: default column lost bug for API table

### DIFF
--- a/src/client/theme-default/builtins/API/index.tsx
+++ b/src/client/theme-default/builtins/API/index.tsx
@@ -329,7 +329,7 @@ const API: FC<{
             <th>{intl.formatMessage({ id: 'api.component.name' })}</th>
             <th>{intl.formatMessage({ id: 'api.component.description' })}</th>
             <th>{intl.formatMessage({ id: 'api.component.type' })}</th>
-            {props.type === 'props' && (
+            {type === 'props' && (
               <th>{intl.formatMessage({ id: 'api.component.default' })}</th>
             )}
           </tr>
@@ -349,7 +349,7 @@ const API: FC<{
                 <td>
                   <APIType {...prop} />
                 </td>
-                {props.type === 'props' && (
+                {type === 'props' && (
                   <td>
                     <code>
                       {definition.propsConfig.required?.includes(name)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Since #1922

### 💡 需求背景和解决方案 / Background or solution

修复 API 表格不传递 type 时默认值列始终不会展示的问题

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix default column lost bug for API table |
| 🇨🇳 Chinese | 修复 API 表格默认值列丢失的问题 |
