### PR TITLE
fix: fallback useRouteMeta logic and handle errors caused by custom routeMeta

### DIFF
--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -50,8 +50,9 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
           }
         }
         // throw promise to trigger suspense
-        if (asyncCache.get(cacheKey)) {
-          throw asyncCache.get(cacheKey);
+        const currentCache = asyncCache.get(cacheKey);
+        if (currentCache) {
+          throw currentCache;
         }
       }
 

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -49,9 +49,8 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
               ),
             );
           }
-        }
-        // throw promise to trigger suspense
-        if (currentCache) {
+        } else {
+          // throw promise to trigger suspense
           throw currentCache;
         }
       }

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -37,8 +37,7 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
     const meta = merge(getRouteMetaById(route.id, { syncOnly: true }));
     const proxyGetter = (target: any, prop: string) => {
       if (ASYNC_META_PROPS.includes(prop)) {
-        const currentCache = asyncCache.get(cacheKey);
-        if (!currentCache) {
+        if (!asyncCache.get(cacheKey)) {
           const routeMetaPromise = getRouteMetaById(route.id);
           // load async meta then replace cache
           if (routeMetaPromise) {
@@ -49,9 +48,10 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
               ),
             );
           }
-        } else {
-          // throw promise to trigger suspense
-          throw currentCache;
+        }
+        // throw promise to trigger suspense
+        if (asyncCache.get(cacheKey)) {
+          throw asyncCache.get(cacheKey);
         }
       }
 

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -52,7 +52,6 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
         // throw promise to trigger suspense
         const currentCache = asyncCache.get(cacheKey);
         if (currentCache) {
-          // @todo
           throw currentCache;
         }
       }

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -46,8 +46,11 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
               (full) => cache.set(cacheKey, merge(full)).get(cacheKey)!,
             ),
           );
-          // throw promise to trigger suspense
-          throw asyncCache.get(cacheKey);
+        }
+        // throw promise to trigger suspense
+        const currentCache = asyncCache.get(cacheKey);
+        if (currentCache) {
+          throw currentCache;
         }
       }
 

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -52,6 +52,7 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
         // throw promise to trigger suspense
         const currentCache = asyncCache.get(cacheKey);
         if (currentCache) {
+          // @todo
           throw currentCache;
         }
       }

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -37,18 +37,20 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
     const meta = merge(getRouteMetaById(route.id, { syncOnly: true }));
     const proxyGetter = (target: any, prop: string) => {
       if (ASYNC_META_PROPS.includes(prop)) {
-        const routeMetaPromise = getRouteMetaById(route.id);
-        if (!asyncCache.get(cacheKey) && routeMetaPromise) {
+        const currentCache = asyncCache.get(cacheKey);
+        if (!currentCache) {
+          const routeMetaPromise = getRouteMetaById(route.id);
           // load async meta then replace cache
-          asyncCache.set(
-            cacheKey,
-            routeMetaPromise.then(
-              (full) => cache.set(cacheKey, merge(full)).get(cacheKey)!,
-            ),
-          );
+          if (routeMetaPromise) {
+            asyncCache.set(
+              cacheKey,
+              routeMetaPromise.then(
+                (full) => cache.set(cacheKey, merge(full)).get(cacheKey)!,
+              ),
+            );
+          }
         }
         // throw promise to trigger suspense
-        const currentCache = asyncCache.get(cacheKey);
         if (currentCache) {
           throw currentCache;
         }

--- a/src/templates/meta/exports.ts.tpl
+++ b/src/templates/meta/exports.ts.tpl
@@ -138,17 +138,16 @@ export function getRouteMetaById<T extends { syncOnly?: boolean }>(
   id: string,
   opts?: T,
 ): T extends { syncOnly: true }
-  ? IRouteMeta
-  : Promise<IRouteMeta> {
-     const routeMeta: IRouteMeta = {
-      frontmatter: {},
-      toc: [],
-      texts: [],
-    };
+  ? IRouteMeta | undefined
+  : Promise<IRouteMeta> | undefined {
+     
   if (filesMeta[id]) {
     const { frontmatter, toc, textGetter, tabs } = filesMeta[id];
-    routeMeta.frontmatter = frontmatter;
-    routeMeta.toc = toc;
+    const routeMeta: IRouteMeta = {
+      frontmatter,
+      toc,
+      texts: [],
+    };
 
     if (opts?.syncOnly) {
       if (tabs) {
@@ -176,10 +175,6 @@ export function getRouteMetaById<T extends { syncOnly?: boolean }>(
       });
     }
   }
-  if (opts?.syncOnly) {
-    return routeMeta;
-  } 
-  return Promise.resolve(routeMeta);
 }
 
 /**


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
#2134 引入问题

1. 所有路由都返回 routeMeta 会导致路由表错乱, 首页 redirect 到404 页面, 回滚变更, 不触发 useRouteMeta 的 merge 逻辑.
2. 修复 ayncCache 遇到用户插件自定义 meta 导致的异常错误.

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fallback useRouteMeta logic and handle errors caused by custom routeMeta         |
| 🇨🇳 Chinese |   回滚 useRouteMeta 变更 & 解决用户自定义 meta导致的异常  |
