### PR TITLE
fix: mako feature query watch=parent make some techStack crash when webpack build

### DIFF
--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -92,19 +92,17 @@ export default (api: IApi) => {
       locales: api.config.locales,
       pkg: api.pkg,
     };
-
-    const mdRule = memo.module
-      .rule('dumi-md')
-      .type('javascript/auto')
-      .test(/\.md$/);
-
-    mdRule
-      .oneOf('md-null')
+    memo.module
+      .rule('watch-parent')
       .pre()
       .resourceQuery(/watch=parent/)
       .use('null-loader')
       .loader(require.resolve('../../loaders/null'))
       .end();
+    const mdRule = memo.module
+      .rule('dumi-md')
+      .type('javascript/auto')
+      .test(/\.md$/);
 
     // generate independent oneOf rules
     ['frontmatter', 'text', 'demo-index'].forEach((type) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    mako feature query watch = parent make some techStack crash when webpack build       |
| 🇨🇳 Chinese |     mako 特性 watch = parent 影响到了某些技术栈webapck构建     |
