### PR TITLE
feat: export useMatchedRoute hook for theme

### DIFF
--- a/docs/theme/api.md
+++ b/docs/theme/api.md
@@ -159,7 +159,7 @@ const Example = () => {
 ### useMatchedRoute
 
 - 作用：获取当前匹配的路由数据
-- 场景：搭配 getRouteMetaById API 自定义获取页面元数据时可能需要用到
+- 场景：搭配 getRouteMetaById API 可自定义获取页面元数据
 - 用法：
 
 ```ts

--- a/docs/theme/api.md
+++ b/docs/theme/api.md
@@ -156,20 +156,20 @@ const Example = () => {
 };
 ```
 
-### useMatchRoute
+### useMatchedRoute
 
 - 作用：获取当前匹配的路由数据
 - 场景：搭配 getRouteMetaById API 自定义获取页面元数据时可能需要用到
 - 用法：
 
 ```ts
-import { useMatchRoute, getRouteMetaById, type IRouteMeta } from 'dumi';
+import { useMatchedRoute, getRouteMetaById, type IRouteMeta } from 'dumi';
 import useSWR from 'swr';
 
 export function useMeta() {
-  const matched = useMatchRoute();
+  const route = useMatchedRoute();
 
-  useSWR(matched.id, getRouteMetaById, {
+  useSWR(route.id, getRouteMetaById, {
     onSuccess: (meta: IRouteMeta) => {
       // do something with meta
       globalThis.console.log(meta);

--- a/docs/theme/api.md
+++ b/docs/theme/api.md
@@ -156,6 +156,28 @@ const Example = () => {
 };
 ```
 
+### useMatchRoute
+
+- 作用：获取当前匹配的路由数据
+- 场景：搭配 getRouteMetaById API 自定义获取页面元数据时可能需要用到
+- 用法：
+
+```ts
+import { useMatchRoute, getRouteMetaById, type IRouteMeta } from 'dumi';
+import useSWR from 'swr';
+
+export function useMeta() {
+  const matched = useMatchRoute();
+
+  useSWR(matched.id, getRouteMetaById, {
+    onSuccess: (meta: IRouteMeta) => {
+      // do something with meta
+      globalThis.console.log(meta);
+    },
+  });
+}
+```
+
 ### useRouteMeta
 
 - 作用：获取当前路由的元数据

--- a/src/client/theme-api/index.ts
+++ b/src/client/theme-api/index.ts
@@ -31,7 +31,7 @@ export { useLiveDemo } from './useLiveDemo';
 export { useLocale } from './useLocale';
 export { useNavData } from './useNavData';
 export { usePrefersColor } from './usePrefersColor';
-export { useMatchRoute, useRouteMeta } from './useRouteMeta';
+export { useMatchedRoute, useRouteMeta } from './useRouteMeta';
 export { useFullSidebarData, useSidebarData } from './useSidebarData';
 export { useSiteSearch } from './useSiteSearch';
 export { useTabMeta } from './useTabMeta';

--- a/src/client/theme-api/index.ts
+++ b/src/client/theme-api/index.ts
@@ -31,7 +31,7 @@ export { useLiveDemo } from './useLiveDemo';
 export { useLocale } from './useLocale';
 export { useNavData } from './useNavData';
 export { usePrefersColor } from './usePrefersColor';
-export { useRouteMeta } from './useRouteMeta';
+export { useMatchRoute, useRouteMeta } from './useRouteMeta';
 export { useFullSidebarData, useSidebarData } from './useSidebarData';
 export { useSiteSearch } from './useSiteSearch';
 export { useTabMeta } from './useTabMeta';

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -78,7 +78,7 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
  * hook for get matched route
  * @internal internal use. Do not use in your production code.
  */
-export const useMatchRoute = () => {
+export const useMatchedRoute = () => {
   const { route } = useRouteData();
   const { pathname } = useLocation();
   const { clientRoutes } = useAppData();
@@ -110,7 +110,7 @@ export const useMatchRoute = () => {
  * hook for get matched route meta
  */
 export const useRouteMeta = () => {
-  const matchedRoute = useMatchRoute();
+  const route = useMatchedRoute();
 
-  return getCachedRouteMeta(matchedRoute);
+  return getCachedRouteMeta(route);
 };

--- a/src/client/theme-api/useRouteMeta.ts
+++ b/src/client/theme-api/useRouteMeta.ts
@@ -75,9 +75,10 @@ function getCachedRouteMeta(route: IRoutesById[string]) {
 }
 
 /**
- * hook for get matched route meta
+ * hook for get matched route
+ * @internal internal use. Do not use in your production code.
  */
-export const useRouteMeta = () => {
+export const useMatchRoute = () => {
   const { route } = useRouteData();
   const { pathname } = useLocation();
   const { clientRoutes } = useAppData();
@@ -95,12 +96,21 @@ export const useRouteMeta = () => {
 
     return ret;
   }, [clientRoutes.length, pathname]);
+
   const [matchedRoute, setMatchedRoute] = useState(getter);
-  const meta = getCachedRouteMeta(matchedRoute);
 
   useIsomorphicLayoutEffect(() => {
     setMatchedRoute(getter);
   }, [clientRoutes.length, pathname]);
 
-  return meta;
+  return matchedRoute;
+};
+
+/**
+ * hook for get matched route meta
+ */
+export const useRouteMeta = () => {
+  const matchedRoute = useMatchRoute();
+
+  return getCachedRouteMeta(matchedRoute);
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

fix: #2124

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

https://github.com/umijs/dumi/pull/1974 中对 useRouteMeta 返回结果进行了 Proxy , 并且在获取 texts 时抛出了一个 Promise

[dumi-theme-antd-style](https://github.com/arvinxx/dumi-theme-antd-style/) 主题包在 https://github.com/arvinxx/dumi-theme-antd-style/blob/7d6977a374a21be7399492522439e8005a7f7fda/src/components/StoreUpdater/index.tsx#L74 处引用了，导致页面一直卡白屏（未处理 Promise）.

主题侧准备 [用 SWR 自定义获取 RouterMeta](https://github.com/arvinxx/dumi-theme-antd-style/pull/122/files#r1612952871) 但是需要获取当前 router.id  并通过 dumi 的 `getRouteMetaById` 方法获取 meta 信息。

将逻辑提取为 `useMatchedRoute` 并对外暴露出来。

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     export `useMatchedRoute` feature hooks      |
| 🇨🇳 Chinese |      导出`useMatchedRoute` hooks     |
