### PR TITLE
fix: 修复非组件属性value被替换为$u问题

### DIFF
--- a/src/loaders/markdown/transformer/rehypeRaw.ts
+++ b/src/loaders/markdown/transformer/rehypeRaw.ts
@@ -6,7 +6,8 @@ import type { IMdTransformerOptions } from '.';
 let raw: typeof import('hast-util-raw').raw;
 let visit: typeof import('unist-util-visit').visit;
 const COMPONENT_NAME_REGEX = /(<)([A-Z][a-zA-Z\d]*)([\s|>])/g;
-const COMPONENT_PROP_REGEX = /\s[a-z][a-z\d]*[A-Z]+[a-zA-Z\d]*(=|\s|>)/g;
+const COMPONENT_PROP_REGEX =
+  /(<[^>]*\s)[a-z][a-z\d]*[A-Z]+[a-zA-Z\d]*(=|\s|>)/g;
 const COMPONENT_STUB_ATTR = '$tag-name';
 const PROP_STUB_ATTR = '-$u';
 const PROP_STUB_ATTR_REGEX = new RegExp(
@@ -46,11 +47,22 @@ export default function rehypeRaw(opts: IRehypeRawOptions): Transformer<Root> {
         );
         // mark all camelCase props for all custom react component
         // because the parse5 within hast-util-raw will lowercase all attr names
-        node.value = node.value.replace(COMPONENT_PROP_REGEX, (str) => {
-          return str.replace(
-            /[A-Z]/g,
-            (s) => `${PROP_STUB_ATTR}${s.toLowerCase()}`,
+        node.value = node.value.replace(COMPONENT_PROP_REGEX, (str, prefix) => {
+          const parts = str.match(
+            /(<[^>]*\s)([a-z][a-z\d]*)([A-Z]+[a-zA-Z\d]*)(=|\s|>)/,
           );
+          if (parts) {
+            const propName = parts[2];
+            const camelCasePart = parts[3];
+            const suffix = parts[4];
+            const addon = camelCasePart
+              ?.split(/(?=[A-Z])/)
+              ?.map((s) => PROP_STUB_ATTR + s?.toLowerCase())
+              ?.join('');
+            const newPropName = propName + addon;
+            return prefix + newPropName + suffix;
+          }
+          return str;
         });
       } else if (node.type === 'element' && node.data?.meta) {
         // save code meta to properties to avoid lost


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->
https://github.com/umijs/dumi/issues/2170

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->
非组件属性名称，被正则误替换为$u，造成例如Tree组件等content内容显示异常问题，只匹配组件的属性名称，replace属性

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fixed the issue where non-component attribute value was replaced with $u      |
| 🇨🇳 Chinese |     修复非组件属性value被替换为$u问题      |
