### PR TITLE
refactor: liveDemo context no longer uses require for imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumi",
-  "version": "2.4.8-beta.2",
+  "version": "2.4.8-beta.3",
   "description": "📖 Documentation Generator of React Component",
   "keywords": [
     "generator",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumi",
-  "version": "2.4.7",
+  "version": "2.4.8-beta.1",
   "description": "📖 Documentation Generator of React Component",
   "keywords": [
     "generator",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumi",
-  "version": "2.4.8-beta.1",
+  "version": "2.4.8-beta.2",
   "description": "📖 Documentation Generator of React Component",
   "keywords": [
     "generator",

--- a/src/client/theme-default/slots/SourceCodeEditor/index.tsx
+++ b/src/client/theme-default/slots/SourceCodeEditor/index.tsx
@@ -89,7 +89,7 @@ const SourceCodeEditor: FC<ISourceCodeEditorProps> = (props) => {
               autoComplete="off"
               autoCorrect="off"
               autoSave="off"
-              spellcheck="false"
+              spellCheck="false"
             />
           )
         }

--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -89,9 +89,9 @@ export default (api: IApi) => {
     const loaderPath = require.resolve('../../loaders/markdown');
 
     // support require mjs packages(eg. element-plus/es)
-    memo.resolve.byDependency.set('commonjs', {
-      conditionNames: ['require', 'node', 'import'],
-    });
+    // memo.resolve.byDependency.set('commonjs', {
+    //   conditionNames: ['require', 'node', 'import'],
+    // });
 
     const loaderBaseOpts: Partial<IMdLoaderOptions> = {
       techStacks,

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -142,9 +142,9 @@ function emitDemo(
   demos?.forEach((demo) => {
     if ('resolveMap' in demo && 'asset' in demo) {
       const entryFileName = Object.keys(demo.asset.dependencies)[0];
+      demoDepsMap[demo.id] ??= {};
       Object.keys(demo.resolveMap).forEach((key, index) => {
         if (key !== entryFileName) {
-          demoDepsMap[demo.id] ??= {};
           demoDepsMap[demo.id][key] = `${demo.id.replace(
             /-/g,
             '_',

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -218,7 +218,7 @@ export const demos = {
       renderContext: function renderContext(
         this: NonNullable<typeof demos>[0],
       ) {
-        // // do not render context for inline demo
+        // do not render context for inline demo
         if (!('resolveMap' in this) || !('asset' in this)) return 'undefined';
         const context = Object.entries(demoDepsMap[this.id]).reduce(
           (acc, [key, specifier]) => ({

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -172,7 +172,7 @@ function emitDemo(
         .map(([key, specifier]) => {
           const existingIndex = acc.findIndex((obj) => obj.key === key);
           if (existingIndex === -1) {
-            return { key, specifier };
+            return { key: isRelativePath(key) ? winPath(key) : key, specifier };
           }
           return undefined;
         })

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -158,7 +158,7 @@ function emitDemo(
             shareDepsMap[key] = specifier;
           }
         } else if (isRelativePath(key)) {
-          demoDepsMap[demo.id][demo.resolveMap[key]] = specifier;
+          demoDepsMap[demo.id][winPath(demo.resolveMap[key])] = specifier;
         }
       });
     }
@@ -172,7 +172,7 @@ function emitDemo(
         .map(([key, specifier]) => {
           const existingIndex = acc.findIndex((obj) => obj.key === key);
           if (existingIndex === -1) {
-            return { key: isRelativePath(key) ? winPath(key) : key, specifier };
+            return { key, specifier };
           }
           return undefined;
         })


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->
#2185 
#2183 

### 💡 需求背景和解决方案 / Background or solution
修改`cjs` resolve 存在太多问题, 这里不再改变用户源码导入规则.
遗留action: 目前全部采用`import * as` 导入,  `webpack` 与`mako` 对 `interop` 的处理目前来看存在差异, 之后遇到了再解决.

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   liveDemo context no longer uses require for imports        |
| 🇨🇳 Chinese |    liveDemo context 不再使用`require` 导入替换用户源码`imports `      |
