### PR TITLE
fix: relative import of `.` & `..` parsing error

### DIFF
--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -74,9 +74,7 @@ function getDemoSourceFiles(demos: IMdTransformerResult['meta']['demos'] = []) {
 }
 
 function isRelativePath(path: string) {
-  return (
-    path.startsWith('./') || path.startsWith('../') || path.startsWith('..')
-  );
+  return path.startsWith('./') || path.startsWith('../') || path === '..';
 }
 
 function emitDefault(

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -74,7 +74,9 @@ function getDemoSourceFiles(demos: IMdTransformerResult['meta']['demos'] = []) {
 }
 
 function isRelativePath(path: string) {
-  return path.startsWith('./') || path.startsWith('../');
+  return (
+    path.startsWith('./') || path.startsWith('../') || path.startsWith('..')
+  );
 }
 
 function emitDefault(

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -74,7 +74,7 @@ function getDemoSourceFiles(demos: IMdTransformerResult['meta']['demos'] = []) {
 }
 
 function isRelativePath(path: string) {
-  return path.startsWith('./') || path.startsWith('../') || path === '..';
+  return /^\.{1,2}(?!\w)/.test(path);
 }
 
 function emitDefault(


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution


Minimal Reproduction / 最小复现：

https://github.com/wzc520pyfm/dumi-relative-path-test

Using the relative path `..` in the demo will result in a parsing error:
demo中使用相对路径`..`会解析错误：

However, this works fine in 2.4.7.
然后，它在2.4.7中是正常工作的。

```tsx
import Foo from '..'
```
<img width="842" alt="image" src="https://github.com/user-attachments/assets/0edc2ad2-7f69-4079-ac9b-ffa183d00ee6">

Solution / 解决方式：

`..` should be recognized as a relative path.
`..` 应该被识别为相对路径。

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix relative path (`..`) parsing error |
| 🇨🇳 Chinese |  修复相对路径`..`解析错误  |
