### PR TITLE
fix: livedemo disabled when config babel-plugin-import

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -219,14 +219,13 @@ import './index.css';
 
 不支持。如果文档目录结构的复杂度超过 3 级，应该考虑优化文档整体结构而非使用三级导航。如果有特殊场景需要，可以自定义主题实现。
 
-## 为什么 live demo 和 按需加载配置(babel-plugin-import) 不能同时开启?
+## ## 为什么 live demo 和 babel-plugin-import 无法一起使用？
 
-先说结论, `live demo` 特性开启时, 组件皆是全量导入的, 按需配置是无效的。 `babel-plugin-import` 唯一的作用就是自动引入组件 `css` 文件, 如果你的按需加载配置是 `style: false`, 请放心移除按需加载配置, 即可开启 `dumi` 最新的 `live demo` 特性。
+live demo 需要的正是全量引入，和 babel-plugin-import 的工作逻辑有冲突。
 
-原因在于 `live demo` 是需要使用 `sucrase` 在浏览器编译的, 我们会把依赖在编译时准备好注入到 `context` 中, 结合用户代码在源码在运行时变更时进行重新编译. 但此时会出现以下几点问题:
+解决方案:
 
-1. 运行时重新编译并不会经过各类按需加载`插件loader`的流程处理, 和编译时行为不符。
-2. `babel-plugin-import` 会在编译时移除 `dumi` 注入的 `import * as antd from 'antd';` 等全量注入的`import`语句, 导致编译时变量缺失。
-3. 如果我们支持了按需的 `context` 依赖注入, 用户在运行时额外新增了 `input` 组件 -> `import { Button, Input } from 'antd';`, 也会发现 `Input` 组件未定义, 这不是预期内的结果。
-
-所以 `dumi` 不建议在编写 `demo` 时配置按需加载, 考虑到部分用户使用按需加载是为了导入组件样式文件, 所以我们不会禁用 `babel-plugin-import` 等按需加载插件, 只是禁用 `dumi` 本身的 `live demo` 特性。
+- 不需要 live demo：忽略警告即可
+- 希望开启 live demo：
+  - style: false 直接去掉插件即可
+  - 否则借助 .dumi/global.css 加载组件样式，可以参考 [and ssr 静态样式导出](https://ant.design/docs/blog/extract-ssr-cn#static-extract-style)提取`css`文件。

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -218,3 +218,15 @@ import './index.css';
 ## 是否支持三级导航？
 
 不支持。如果文档目录结构的复杂度超过 3 级，应该考虑优化文档整体结构而非使用三级导航。如果有特殊场景需要，可以自定义主题实现。
+
+## 为什么 live demo 和 按需加载配置(babel-plugin-import) 不能同时开启?
+
+先说结论, `live demo` 特性开启时, 组件皆是全量导入的, 按需配置是无效的。 `babel-plugin-import` 唯一的作用就是自动引入组件 `css` 文件, 如果你的按需加载配置是 `style: false`, 请放心移除按需加载配置, 即可开启 `dumi` 最新的 `live demo` 特性。
+
+原因在于 `live demo` 是需要使用 `sucrase` 在浏览器编译的, 我们会把依赖在编译时准备好注入到 `context` 中, 结合用户代码在源码在运行时变更时进行重新编译. 但此时会出现以下几点问题:
+
+1. 运行时重新编译并不会经过各类按需加载`插件loader`的流程处理, 和编译时行为不符。
+2. `babel-plugin-import` 会在编译时移除 `dumi` 注入的 `import * as antd from 'antd';` 等全量注入的`import`语句, 导致编译时变量缺失。
+3. 如果我们支持了按需的 `context` 依赖注入, 用户在运行时额外新增了 `input` 组件 -> `import { Button, Input } from 'antd';`, 也会发现 `Input` 组件未定义, 这不是预期内的结果。
+
+所以 `dumi` 不建议在编写 `demo` 时配置按需加载, 考虑到部分用户使用按需加载是为了导入组件样式文件, 所以我们不会禁用 `babel-plugin-import` 等按需加载插件, 只是禁用 `dumi` 本身的 `live demo` 特性。

--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import { addAtomMeta, addExampleAssets } from '../assets';
 import { getLoadHook } from './makoHooks';
+import { shouldDisabledLiveDemo } from './utils';
 export const techStacks: IDumiTechStack[] = [];
 export default (api: IApi) => {
   api.describe({ key: 'dumi:compile' });
@@ -87,12 +88,6 @@ export default (api: IApi) => {
     const babelInUmi = memo.module.rule('src').use('babel-loader').entries();
     if (!babelInUmi) return memo;
     const loaderPath = require.resolve('../../loaders/markdown');
-
-    // support require mjs packages(eg. element-plus/es)
-    // memo.resolve.byDependency.set('commonjs', {
-    //   conditionNames: ['require', 'node', 'import'],
-    // });
-
     const loaderBaseOpts: Partial<IMdLoaderOptions> = {
       techStacks,
       cwd: api.cwd,
@@ -103,6 +98,7 @@ export default (api: IApi) => {
       routes: api.appData.routes,
       locales: api.config.locales,
       pkg: api.pkg,
+      disableLiveDemo: shouldDisabledLiveDemo(api),
     };
     memo.module
       .rule('watch-parent')

--- a/src/features/compile/makoHooks.ts
+++ b/src/features/compile/makoHooks.ts
@@ -6,6 +6,7 @@ import url from 'url';
 import { techStacks } from '.';
 import { RunLoaderOption, runLoaders } from '../../utils';
 import { addAtomMeta, addExampleAssets } from '../assets';
+import { shouldDisabledLiveDemo } from './utils';
 
 interface ICustomerRunLoaderInterface extends RunLoaderOption {
   type?: 'css' | 'js' | 'jsx';
@@ -31,6 +32,7 @@ const customRunLoaders = async (options: ICustomerRunLoaderInterface) => {
 const mdLoaderPath = require.resolve('../../loaders/markdown');
 
 export const getLoadHook = (api: IApi) => {
+  const disableLiveDemo = shouldDisabledLiveDemo(api);
   return async (filePath: string) => {
     const loaderBaseOpts: Partial<IMdLoaderOptions> = {
       techStacks,
@@ -42,6 +44,7 @@ export const getLoadHook = (api: IApi) => {
       routes: api.appData.routes,
       locales: api.config.locales || [],
       pkg: api.pkg,
+      disableLiveDemo,
     };
 
     const requestUrl = url.parse(filePath);

--- a/src/features/compile/utils.ts
+++ b/src/features/compile/utils.ts
@@ -1,16 +1,16 @@
+import { logger } from '@umijs/utils';
 import { isArray } from '@umijs/utils/compiled/lodash';
 import { IApi } from 'umi';
-
 export const shouldDisabledLiveDemo = (api: IApi) => {
   const extraBabelPlugins = api.userConfig.extraBabelPlugins;
   const disableFlag =
     isArray(extraBabelPlugins) &&
-    extraBabelPlugins?.some((p: any) =>
+    extraBabelPlugins!.some((p: any) =>
       /^import$|babel-plugin-import/.test(p[0]),
     );
   if (disableFlag) {
-    api.logger.warn(
-      "dumi don't suggest to use babel-plugin-import, liveDemo will be disabled because of this config.",
+    logger.warn(
+      'live demo feature has been automatically disabled since babel-plugin-import be registered, if you want to enable live demo feature, checkout: https://d.umijs.org/guide/faq',
     );
   }
   return disableFlag;

--- a/src/features/compile/utils.ts
+++ b/src/features/compile/utils.ts
@@ -1,0 +1,17 @@
+import { isArray } from '@umijs/utils/compiled/lodash';
+import { IApi } from 'umi';
+
+export const shouldDisabledLiveDemo = (api: IApi) => {
+  const extraBabelPlugins = api.userConfig.extraBabelPlugins;
+  const disableFlag =
+    isArray(extraBabelPlugins) &&
+    extraBabelPlugins?.some((p: any) =>
+      /^import$|babel-plugin-import/.test(p[0]),
+    );
+  if (disableFlag) {
+    api.logger.warn(
+      "dumi don't suggest to use babel-plugin-import, liveDemo will be disabled because of this config.",
+    );
+  }
+  return disableFlag;
+};


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->
#2193 
### 💡 需求背景和解决方案 / Background or solution
用户配置按需加载后, `babel-plugin-import` 会擦除 `dumi` 注入 `livedemo context `的相关 `import * as` 语句, 导致 `context` 内的变量未定义

why 禁用 ?

浏览器用户源码编译是不经过 `babel-plugin` 处理的, 目前也没有必要改变这一现状.
禁用一不会报错, 二不会影响存量用户.


<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    livedemo disabled when config babel-plugin-import        |
| 🇨🇳 Chinese |    配置按需加载后禁用liveDemo       |
