### PR TITLE
fix: Fix handling of specific array types in auto API components

### DIFF
--- a/src/client/theme-default/builtins/API/index.tsx
+++ b/src/client/theme-default/builtins/API/index.tsx
@@ -100,9 +100,21 @@ const HANDLERS = {
       </span>
     );
   },
-  array(prop: Extract<PropertySchema, { type: 'array' }>): ReactNode {
+  array(prop: Extract<PropertySchema, { type: 'array' }> & { items?: any[] }): ReactNode {
     let arrayType: ReactNode = <span>any</span>;
     if (prop.items) {
+      if (Array.isArray(prop.items)) return (
+        <span>
+          <Token>{'['}</Token>
+          {prop.items.map((item: Extract<PropertySchema, { type: 'array' }>, i) => (
+            <span key={`${i}`}>
+                {i > 0 && ', '}
+                {this.toNode(item)}
+            </span>
+          ))}
+          <Token>{']'}</Token>
+        </span>
+      );
       const className = this.getValidClassName(prop.items);
       arrayType = className ?? this.toNode(prop.items);
     }

--- a/src/client/theme-default/builtins/API/index.tsx
+++ b/src/client/theme-default/builtins/API/index.tsx
@@ -106,7 +106,7 @@ const HANDLERS = {
       if (Array.isArray(prop.items)) return (
         <span>
           <Token>{'['}</Token>
-          {prop.items.map((item: Extract<PropertySchema, { type: 'array' }>, i) => (
+          {prop.items.map((item, i) => (
             <span key={`${i}`}>
                 {i > 0 && ', '}
                 {this.toNode(item)}


### PR DESCRIPTION
- Resolved logic errors when processing fixed-length tuple types such as [number, number].
- Enhanced type inference to ensure accurate handling of array types during component generation.

This update improves the compatibility and stability of auto API components with complex array types.

<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

在之前的版本中，自动 API 表格组件在处理固定长度的元组类型（例如 [number, number]）时，会错误地将其识别为 unknown[] 类型。

In the previous version, the auto API table component incorrectly treated fixed-length tuple types (e.g., [number, number]) as unknown[].

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix handling of specific array types in auto API components  |
| 🇨🇳 Chinese |  修复自动 API 组件中特定数组类型的处理问题 |
