### PR TITLE
fix: fix Previewer component under color scheme change with iframe key

### DIFF
--- a/src/client/theme-default/builtins/Previewer/index.tsx
+++ b/src/client/theme-default/builtins/Previewer/index.tsx
@@ -1,14 +1,22 @@
 import { ReactComponent as IconError } from '@ant-design/icons-svg/inline-svg/filled/close-circle.svg';
 import classnames from 'classnames';
-import { useLiveDemo, useLocation, type IPreviewerProps } from 'dumi';
+import {
+  useLiveDemo,
+  useLocation,
+  usePrefersColor,
+  type IPreviewerProps,
+} from 'dumi';
 import PreviewerActions from 'dumi/theme/slots/PreviewerActions';
-import React, { useRef, type FC } from 'react';
+import React, { useEffect, useRef, useState, type FC } from 'react';
 import './index.less';
 
 const Previewer: FC<IPreviewerProps> = (props) => {
   const demoContainer = useRef<HTMLDivElement>(null);
   const { hash } = useLocation();
   const link = `#${props.asset.id}`;
+
+  const [preferredColorScheme] = usePrefersColor();
+  const [iframeKey, setIframeKey] = useState(0);
 
   const {
     node: liveDemoNode,
@@ -19,6 +27,12 @@ const Previewer: FC<IPreviewerProps> = (props) => {
     iframe: Boolean(props.iframe || props._live_in_iframe),
     containerRef: demoContainer,
   });
+
+  useEffect(() => {
+    if (props.iframe) {
+      setIframeKey((key) => key + 1);
+    }
+  }, [preferredColorScheme, props.iframe]);
 
   return (
     <div
@@ -46,6 +60,7 @@ const Previewer: FC<IPreviewerProps> = (props) => {
                 : {}
             }
             src={props.demoUrl}
+            key={iframeKey}
           ></iframe>
         ) : (
           liveDemoNode || props.children


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] bug 修复 / Fix bug

### 🔗 相关 Issue / Related Issue
https://github.com/ant-design/ant-design/issues/55670

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

由于code demo使用iframe时和文档本身的隔离，使得demo内部无法获取到外部主题变更，导致切换主题时，demo主题颜色不变。

![dumi_previewer20251122_222006](https://github.com/user-attachments/assets/ff7c10e9-1e99-438e-b784-a3fcc1a05468)

本次修改监听主题偏好，并使用key在切换主题时强制刷新iframe，从而实现颜色同步。

测试：
![dumi_previewer_fix20251122_222137](https://github.com/user-attachments/assets/e7489320-f64f-4136-96f2-31e3f5bcd011)

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

修改了主题变更下使用iframe的组件demo的表现
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        fix Previewer component under color scheme change with iframe key   |
| 🇨🇳 Chinese |       使用key修改demo在颜色修改下的表现    |
