### PR TITLE
fix: last updated check error if file path contains space

### DIFF
--- a/src/loaders/markdown/transformer/remarkMeta.ts
+++ b/src/loaders/markdown/transformer/remarkMeta.ts
@@ -71,7 +71,7 @@ export default function remarkMeta(opts: IRemarkMetaOpts): Transformer<Root> {
     try {
       vFile.data.frontmatter.lastUpdated =
         parseInt(
-          execSync(`git log -1 --format=%at ${opts.fileAbsPath}`, {
+          execSync(`git log -1 --format=%at -- "${opts.fileAbsPath}"`, {
             stdio: 'pipe',
           }).toString(),
           10,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
如果当前项目的完整路径目录中包含空格，会导致lastUpdated配置项获取git提交时间时路径解析错误
Fix path parsing for lastUpdated when directory has whitespace

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix path parsing for lastUpdated when directory has whitespace |
| 🇨🇳 Chinese | 修复目录中存在空格时 lastUpdated 配置的路径解析错误 |
