### PR TITLE
chore: lock rust toolchain version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "build": "father build && npm run build:crates",
-    "build:crates": "cargo build --target wasm32-wasip1 -r --out-dir compiled/crates -Z unstable-options",
+    "build:crates": "cargo build --target wasm32-wasip1 -r --artifact-dir compiled/crates -Z unstable-options",
     "build:deps": "node scripts/pre-bundle-worker.js && father prebundle",
     "build:suites": "pnpm run --filter=\"./suites/**\" build",
     "dev": "father dev",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2026-02-05


### PR DESCRIPTION
lock rust toolchain version to avoild build failed.