### PR TITLE
fix(utoopack): tsx parser for techStack case

### DIFF
--- a/src/features/compile/utoopackLoaders.test.ts
+++ b/src/features/compile/utoopackLoaders.test.ts
@@ -1,0 +1,62 @@
+import Module from 'module';
+
+function registerTsResolveExtension() {
+  const extensions = (Module as any)._extensions as NodeJS.RequireExtensions;
+
+  extensions['.ts'] ??= extensions['.js'];
+}
+
+function createApi() {
+  return {
+    cwd: '/tmp/dumi-app',
+    paths: {
+      absTmpPath: '/tmp/dumi-app/.dumi/tmp',
+    },
+    config: {
+      alias: {},
+      locales: [],
+      resolve: {},
+    },
+    userConfig: {},
+    pkg: {},
+  } as any;
+}
+
+test('utoopack preserves external demo source language for parsing', async () => {
+  registerTsResolveExtension();
+
+  const { getUtoopackRules } = await import('./utoopackLoaders');
+  const rules = getUtoopackRules(createApi());
+  const wildcardRules = rules['**/*'] as any[];
+
+  const findDemoRuleByPath = (path: string) =>
+    wildcardRules.find((rule) =>
+      rule.condition?.all?.some(
+        (condition: any) => String(condition.path) === path,
+      ),
+    );
+
+  expect(findDemoRuleByPath('/\\.tsx$/')).toMatchObject({
+    as: '*.tsx',
+  });
+  expect(findDemoRuleByPath('/\\.ts$/')).toMatchObject({
+    as: '*.ts',
+  });
+  expect(findDemoRuleByPath('/\\.jsx$/')).toMatchObject({
+    as: '*.jsx',
+  });
+
+  const fallbackDemoRule = wildcardRules.find((rule) =>
+    rule.condition?.all?.some(
+      (condition: any) => String(condition.not?.path) === '/\\.(tsx?|jsx)$/',
+    ),
+  );
+  expect(fallbackDemoRule).toMatchObject({
+    as: '*.js',
+  });
+  expect(
+    fallbackDemoRule.condition.all.some(
+      (condition: any) => String(condition.query) === '/^\\?techStack=.*$/',
+    ),
+  ).toBe(true);
+});

--- a/src/features/compile/utoopackLoaders.ts
+++ b/src/features/compile/utoopackLoaders.ts
@@ -99,6 +99,14 @@ export const getUtoopackRules = (api: IApi): Record<string, unknown> => {
     [UTOOPACK_LOADER_CTX_KEY]: loaderContextPath,
   });
 
+  const externalDemoLoader = {
+    loader: require.resolve('../../loaders/demo'),
+    options: toSerializable({
+      cwd: api.cwd,
+      [UTOOPACK_LOADER_CTX_KEY]: loaderContextPath,
+    }),
+  };
+
   return {
     // handle ?watch=parent virtual module: return empty content to establish file-watching dependency
     '**/*': [
@@ -120,16 +128,34 @@ export const getUtoopackRules = (api: IApi): Record<string, unknown> => {
       // handle external demo component files (?techStack=xxx)
       // techStacks are NOT serializable; pass loaderContextPath and hydrate in the loader
       {
-        condition: { query: /^\?techStack=.*$/ },
-        loaders: [
-          {
-            loader: require.resolve('../../loaders/demo'),
-            options: toSerializable({
-              cwd: api.cwd,
-              [UTOOPACK_LOADER_CTX_KEY]: loaderContextPath,
-            }),
-          },
-        ],
+        condition: {
+          all: [{ query: /^\?techStack=.*$/ }, { path: /\.tsx$/ }],
+        },
+        loaders: [externalDemoLoader],
+        as: '*.tsx',
+      },
+      {
+        condition: {
+          all: [{ query: /^\?techStack=.*$/ }, { path: /\.ts$/ }],
+        },
+        loaders: [externalDemoLoader],
+        as: '*.ts',
+      },
+      {
+        condition: {
+          all: [{ query: /^\?techStack=.*$/ }, { path: /\.jsx$/ }],
+        },
+        loaders: [externalDemoLoader],
+        as: '*.jsx',
+      },
+      {
+        condition: {
+          all: [
+            { query: /^\?techStack=.*$/ },
+            { not: { path: /\.(tsx?|jsx)$/ } },
+          ],
+        },
+        loaders: [externalDemoLoader],
         as: '*.js',
       },
     ],


### PR DESCRIPTION


### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

closes: #2325 

### 💡 需求背景和解决方案 / Background or solution

utoopack 的 tsx 解析走进了 js parser 导致 type 文件被保留了，从而出现了 parse error

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
