### PR TITLE
fix: respect merged config in utoopack markdown loaders

### DIFF
--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -302,7 +302,7 @@ export default (api: IApi) => {
             ...(memo.utoopack.module || {}),
             rules: {
               ...(memo.utoopack.module?.rules || {}),
-              ...getUtoopackRules(api),
+              ...getUtoopackRules(api, memo),
             },
           },
         };

--- a/src/features/compile/utoopackLoaders.test.ts
+++ b/src/features/compile/utoopackLoaders.test.ts
@@ -60,3 +60,40 @@ test('utoopack preserves external demo source language for parsing', async () =>
     ),
   ).toBe(true);
 });
+
+test('utoopack markdown rules use current config memo', async () => {
+  registerTsResolveExtension();
+
+  const { getUtoopackRules } = await import('./utoopackLoaders');
+  const api = createApi();
+  const rules = getUtoopackRules(api, {
+    ...api.config,
+    alias: {
+      antd: '/tmp/dumi-app/components',
+    },
+    locales: [{ id: 'en-US', name: 'English', suffix: '' }],
+    resolve: {
+      atomDirs: [{ type: 'component', dir: 'components' }],
+      docDirs: [{ type: 'doc', dir: 'docs' }],
+      codeBlockMode: 'passive',
+      forceKebabCaseRouting: false,
+    },
+  });
+
+  const mdRules = rules['*.md'] as any[];
+  const defaultMdRule = mdRules.find((rule) => !rule.condition);
+  const defaultMdOptions = defaultMdRule.loaders[0].options;
+
+  expect(defaultMdOptions.alias).toEqual({
+    antd: '/tmp/dumi-app/components',
+  });
+  expect(defaultMdOptions.locales).toEqual([
+    { id: 'en-US', name: 'English', suffix: '' },
+  ]);
+  expect(defaultMdOptions.resolve).toMatchObject({
+    atomDirs: [{ type: 'component', dir: 'components' }],
+    docDirs: [{ type: 'doc', dir: 'docs' }],
+    codeBlockMode: 'passive',
+    forceKebabCaseRouting: false,
+  });
+});

--- a/src/features/compile/utoopackLoaders.ts
+++ b/src/features/compile/utoopackLoaders.ts
@@ -72,7 +72,10 @@ export function buildLoaderContextContent(
   );
 }
 
-export const getUtoopackRules = (api: IApi): Record<string, unknown> => {
+export const getUtoopackRules = (
+  api: IApi,
+  config: IApi['config'] = api.config,
+): Record<string, unknown> => {
   const disableLiveDemo = shouldDisabledLiveDemo(api);
 
   const loaderContextPath = path.join(
@@ -80,10 +83,10 @@ export const getUtoopackRules = (api: IApi): Record<string, unknown> => {
     LOADER_CTX_FILENAME,
   );
 
-  const cfgResolve = (api.config as any).resolve ?? {};
+  const cfgResolve = config.resolve ?? {};
   const serializableBaseOpts = toSerializable({
     cwd: api.cwd,
-    alias: api.config.alias || {},
+    alias: config.alias || {},
     resolve: {
       atomDirs: cfgResolve.atomDirs ?? [{ type: 'component', dir: 'src' }],
       docDirs: cfgResolve.docDirs ?? ['docs'],
@@ -93,7 +96,7 @@ export const getUtoopackRules = (api: IApi): Record<string, unknown> => {
     },
     routes: {},
     builtins: {},
-    locales: api.config.locales || [],
+    locales: config.locales || [],
     pkg: api.pkg,
     disableLiveDemo,
     [UTOOPACK_LOADER_CTX_KEY]: loaderContextPath,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix: respect merged config in utoopack markdown loaders       |
| 🇨🇳 Chinese |     修复 utoopack markdown loaders 的参数传递问题      |
