### PR TITLE
chore: enable utoopack for site template

### DIFF
--- a/docs/guide/initialize.md
+++ b/docs/guide/initialize.md
@@ -10,11 +10,11 @@ order: 0
 
 ## 环境准备
 
-确保正确安装 [Node.js](https://nodejs.org/en/) 且版本为 14+ 即可。
+确保正确安装 [Node.js](https://nodejs.org/en/) 且版本为 20+ 即可。
 
 ```bash
 $ node -v
-v14.19.1
+v20.11.0
 ```
 
 ## 脚手架

--- a/suites/boilerplate/templates/site/.dumirc.ts.tpl
+++ b/suites/boilerplate/templates/site/.dumirc.ts.tpl
@@ -1,6 +1,7 @@
 import { defineConfig } from 'dumi';
 
 export default defineConfig({
+  utoopack: {},
   themeConfig: {
     name: '{{{ name }}}',
   },

--- a/suites/boilerplate/templates/site/package.json.tpl
+++ b/suites/boilerplate/templates/site/package.json.tpl
@@ -13,6 +13,9 @@
     "{{{ author }}}"
   {{/author}}],
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"


### PR DESCRIPTION
## Summary

- enable `utoopack` in the default `create-dumi` Static Site template
- add a Node.js 20+ engine constraint to the generated site template
- update the initialization guide to document Node.js 20+ as the required runtime

## Validation

- `pnpm --filter create-dumi build`
- `pnpm prettier --check docs/guide/initialize.md`
- `pnpm prettier --check --parser typescript suites/boilerplate/templates/site/.dumirc.ts.tpl`

Note: `package.json.tpl` contains Mustache sections, so it was inspected structurally rather than parsed as plain JSON.