### PR TITLE
ci: update node version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [14, 16, 18]
+        node-version: [20, 22, 24]
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     steps:


### PR DESCRIPTION
## Summary

- update the CI Node.js matrix from 14/16/18 to 20/22/24
- align the matrix key with existing `matrix.node-version` references

## Test

- `git diff --check -- .github/workflows/ci.yml`