### PR TITLE
fix: preserve markdown plugins in utoopack

### DIFF
--- a/src/features/compile/fixtures/unifiedPlugins.cjs
+++ b/src/features/compile/fixtures/unifiedPlugins.cjs
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.remarkPluginForTest = function remarkPluginForTest() {};
+exports.rehypePluginForTest = function rehypePluginForTest() {};

--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -120,6 +120,8 @@ export default (api: IApi) => {
             techStacks,
             (api as any).service.themeData?.builtins ?? {},
             api.appData.routes ?? {},
+            api.config.extraRemarkPlugins,
+            api.config.extraRehypePlugins,
           ),
         });
       }

--- a/src/features/compile/utoopackLoaders.test.ts
+++ b/src/features/compile/utoopackLoaders.test.ts
@@ -97,3 +97,27 @@ test('utoopack markdown rules use current config memo', async () => {
     forceKebabCaseRouting: false,
   });
 });
+
+test('utoopack loader context serializes extra unified plugins', async () => {
+  const plugins = require('./fixtures/unifiedPlugins.cjs');
+  const { buildLoaderContextContent } = await import('./utoopackLoaders');
+  const content = buildLoaderContextContent(
+    [],
+    {},
+    {},
+    [plugins.remarkPluginForTest, ['remark-string-plugin', { value: 1 }]],
+    [[plugins.rehypePluginForTest, { enabled: true }], 'rehype-string-plugin'],
+  );
+  const exports: any = {};
+
+  new Function('require', 'exports', content)(require, exports);
+
+  expect(exports.extraRemarkPlugins).toEqual([
+    plugins.remarkPluginForTest,
+    ['remark-string-plugin', { value: 1 }],
+  ]);
+  expect(exports.extraRehypePlugins).toEqual([
+    [plugins.rehypePluginForTest, { enabled: true }],
+    'rehype-string-plugin',
+  ]);
+});

--- a/src/features/compile/utoopackLoaders.ts
+++ b/src/features/compile/utoopackLoaders.ts
@@ -8,6 +8,9 @@ export const UTOOPACK_LOADER_CTX_KEY = '__dumiLoaderContextPath';
 
 export const LOADER_CTX_FILENAME = 'dumi-loader-ctx.cjs';
 
+type UnifiedPluginConfig = NonNullable<IApi['config']['extraRemarkPlugins']>[0];
+type UnifiedPluginFn = (...args: any[]) => any;
+
 function toSerializable<T>(value: T): T {
   return JSON.parse(JSON.stringify(value));
 }
@@ -29,10 +32,55 @@ function findInRequireCache(
   return null;
 }
 
+function toRequireRef(found: { modulePath: string; exportName: string }) {
+  const modRef = `require(${JSON.stringify(found.modulePath)})`;
+
+  return found.exportName === 'module.exports'
+    ? modRef
+    : `(${modRef})[${JSON.stringify(found.exportName)}]`;
+}
+
+function toPluginTargetRef(target: string | UnifiedPluginFn) {
+  if (typeof target === 'string') return JSON.stringify(target);
+
+  const found = findInRequireCache(target);
+  if (!found) {
+    const name = target.name ? ` "${target.name}"` : '';
+
+    throw new Error(
+      `Utoopack markdown loader requires extra unified plugin function${name} to be exported from a module.`,
+    );
+  }
+
+  return toRequireRef(found);
+}
+
+function toPluginRefs(plugins: UnifiedPluginConfig[] = []) {
+  return `[${plugins
+    .map((plugin) => {
+      if (Array.isArray(plugin)) {
+        const [target, options] = plugin;
+        const optionsRef =
+          typeof options === 'undefined'
+            ? 'undefined'
+            : JSON.stringify(options);
+
+        return `[${toPluginTargetRef(
+          target as string | UnifiedPluginFn,
+        )}, ${optionsRef}]`;
+      }
+
+      return toPluginTargetRef(plugin as string | UnifiedPluginFn);
+    })
+    .join(', ')}]`;
+}
+
 export function buildLoaderContextContent(
   techStacks: IDumiTechStack[],
   builtins: Record<string, { specifier: string; source: string }> = {},
   routes: Record<string, unknown> = {},
+  extraRemarkPlugins: IApi['config']['extraRemarkPlugins'] = [],
+  extraRehypePlugins: IApi['config']['extraRehypePlugins'] = [],
 ): string {
   const refs: string[] = [];
 
@@ -43,23 +91,13 @@ export function buildLoaderContextContent(
       // Class instance — find the constructor in the require cache
       const found = findInRequireCache(ctor);
       if (found) {
-        const modRef = `require(${JSON.stringify(found.modulePath)})`;
-        const ctorRef =
-          found.exportName === 'module.exports'
-            ? modRef
-            : `(${modRef})[${JSON.stringify(found.exportName)}]`;
-        refs.push(`new (${ctorRef})()`);
+        refs.push(`new (${toRequireRef(found)})()`);
       }
     } else {
       // Plain object (defineTechStack) — find the object itself in the cache
       const found = findInRequireCache(ts);
       if (found) {
-        const modRef = `require(${JSON.stringify(found.modulePath)})`;
-        const ref =
-          found.exportName === 'module.exports'
-            ? modRef
-            : `(${modRef})[${JSON.stringify(found.exportName)}]`;
-        refs.push(ref);
+        refs.push(toRequireRef(found));
       }
     }
   }
@@ -68,7 +106,9 @@ export function buildLoaderContextContent(
     `'use strict';\n` +
     `exports.techStacks = [${refs.join(', ')}];\n` +
     `exports.builtins = ${JSON.stringify(builtins)};\n` +
-    `exports.routes = ${JSON.stringify(routes)};\n`
+    `exports.routes = ${JSON.stringify(routes)};\n` +
+    `exports.extraRemarkPlugins = ${toPluginRefs(extraRemarkPlugins)};\n` +
+    `exports.extraRehypePlugins = ${toPluginRefs(extraRehypePlugins)};\n`
   );
 }
 

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -445,6 +445,8 @@ export default function mdLoader(this: any, content: string) {
       techStacks: any[];
       builtins?: Record<string, { specifier: string; source: string }>;
       routes?: IMdLoaderOptions['routes'];
+      extraRemarkPlugins?: IMdLoaderOptions['extraRemarkPlugins'];
+      extraRehypePlugins?: IMdLoaderOptions['extraRehypePlugins'];
     };
     if (!opts.techStacks?.length) {
       (opts as any).techStacks = ctx.techStacks;
@@ -458,6 +460,12 @@ export default function mdLoader(this: any, content: string) {
     // routes are also generated later than modifyConfig in utoopack mode.
     if (ctx.routes && !Object.keys((opts as any).routes ?? {}).length) {
       (opts as any).routes = ctx.routes;
+    }
+    if (ctx.extraRemarkPlugins && !(opts as any).extraRemarkPlugins?.length) {
+      (opts as any).extraRemarkPlugins = ctx.extraRemarkPlugins;
+    }
+    if (ctx.extraRehypePlugins && !(opts as any).extraRehypePlugins?.length) {
+      (opts as any).extraRehypePlugins = ctx.extraRehypePlugins;
     }
   }
 


### PR DESCRIPTION
## Summary

- pass `extraRemarkPlugins` and `extraRehypePlugins` into the utoopack markdown loader context
- serialize function plugins as require-cache references so loader child processes can rehydrate them
- hydrate the extra unified plugins in the markdown loader before transforming markdown
- add coverage for string plugins, function plugins, and plugin options in the generated loader context

## Root Cause

The webpack and mako markdown paths pass `extraRemarkPlugins` / `extraRehypePlugins` directly to the markdown loader, but the utoopack path only wrote tech stacks, builtins, and routes into `dumi-loader-ctx.cjs`. When an app relies on custom markdown plugins, such as Ant Design's `rehypeAntd` transform for `ResourceCards`, utoopack skipped those plugins. The page then prerendered with missing props and failed at runtime.

## Checks

- `pnpm vitest run src/features/compile/utoopackLoaders.test.ts`
- `npx eslint src/features/compile/utoopackLoaders.ts src/features/compile/index.ts src/loaders/markdown/index.ts src/features/compile/utoopackLoaders.test.ts`
- `npx tsc --noEmit` still reports existing repository type errors unrelated to this change, but no errors in the touched files
