### PR TITLE
fix: resolve utoopack markdown plugins from config files

### DIFF
--- a/src/features/compile/fixtures/cacheClearedPlugin.ts
+++ b/src/features/compile/fixtures/cacheClearedPlugin.ts
@@ -1,0 +1,3 @@
+export default function cacheClearedPlugin() {}
+
+export function namedCacheClearedPlugin() {}

--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -122,6 +122,7 @@ export default (api: IApi) => {
             api.appData.routes ?? {},
             api.config.extraRemarkPlugins,
             api.config.extraRehypePlugins,
+            (api as any).service.configManager?.files ?? [],
           ),
         });
       }

--- a/src/features/compile/utoopackLoaders.test.ts
+++ b/src/features/compile/utoopackLoaders.test.ts
@@ -121,3 +121,30 @@ test('utoopack loader context serializes extra unified plugins', async () => {
     'rehype-string-plugin',
   ]);
 });
+
+test('utoopack loader context resolves plugins from config source files', async () => {
+  registerTsResolveExtension();
+
+  const pluginPath = require.resolve('./fixtures/cacheClearedPlugin.ts');
+  const plugins = require(pluginPath);
+  const { buildLoaderContextContent } = await import('./utoopackLoaders');
+
+  delete require.cache[pluginPath];
+
+  const content = buildLoaderContextContent(
+    [],
+    {},
+    {},
+    [plugins.default],
+    [plugins.namedCacheClearedPlugin],
+    [pluginPath],
+  );
+  const exports: any = {};
+
+  new Function('require', 'exports', content)(require, exports);
+
+  expect(exports.extraRemarkPlugins[0]).toBe(require(pluginPath).default);
+  expect(exports.extraRehypePlugins[0]).toBe(
+    require(pluginPath).namedCacheClearedPlugin,
+  );
+});

--- a/src/features/compile/utoopackLoaders.ts
+++ b/src/features/compile/utoopackLoaders.ts
@@ -1,4 +1,6 @@
 import type { IApi, IDumiTechStack } from '@/types';
+import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import { register } from '@umijs/utils';
 import path from 'path';
 import { shouldDisabledLiveDemo } from './utils';
 
@@ -15,9 +17,9 @@ function toSerializable<T>(value: T): T {
   return JSON.parse(JSON.stringify(value));
 }
 
-function findInRequireCache(
-  target: object,
-): { modulePath: string; exportName: string } | null {
+type RequireRef = { modulePath: string; exportName: string };
+
+function findInRequireCache(target: object): RequireRef | null {
   for (const [filename, mod] of Object.entries(require.cache)) {
     if (!mod?.exports) continue;
     const exp = mod.exports;
@@ -32,7 +34,72 @@ function findInRequireCache(
   return null;
 }
 
-function toRequireRef(found: { modulePath: string; exportName: string }) {
+function normalizeFnSource(fn: UnifiedPluginFn) {
+  return Function.prototype.toString.call(fn).replace(/\s+/g, ' ');
+}
+
+function isSameFunction(candidate: unknown, target: UnifiedPluginFn) {
+  return (
+    typeof candidate === 'function' &&
+    candidate.name === target.name &&
+    normalizeFnSource(candidate as UnifiedPluginFn) ===
+      normalizeFnSource(target)
+  );
+}
+
+function findInModuleExports(
+  target: UnifiedPluginFn,
+  mod: NodeJS.Module,
+): RequireRef | null {
+  const exp = mod.exports;
+  if (!exp) return null;
+  if (isSameFunction(exp, target)) {
+    return { modulePath: mod.filename, exportName: 'module.exports' };
+  }
+  if (isSameFunction(exp?.default, target)) {
+    return { modulePath: mod.filename, exportName: 'default' };
+  }
+  for (const [k, v] of Object.entries(exp as object)) {
+    if (isSameFunction(v, target)) {
+      return { modulePath: mod.filename, exportName: k };
+    }
+  }
+
+  return null;
+}
+
+function findInSourceFiles(
+  target: UnifiedPluginFn,
+  sourceFiles: string[],
+): RequireRef | null {
+  register.register({ implementor: esbuild });
+  register.clearFiles();
+
+  try {
+    for (const file of sourceFiles) {
+      try {
+        require(file);
+        const mod = require.cache[file];
+        if (!mod?.exports) continue;
+
+        const found = findInModuleExports(target, mod);
+        if (found) return found;
+      } catch {}
+    }
+
+    return null;
+  } finally {
+    for (const file of register.getFiles()) {
+      delete require.cache[file];
+    }
+    for (const file of sourceFiles) {
+      delete require.cache[file];
+    }
+    register.restore();
+  }
+}
+
+function toRequireRef(found: RequireRef) {
   const modRef = `require(${JSON.stringify(found.modulePath)})`;
 
   return found.exportName === 'module.exports'
@@ -40,10 +107,14 @@ function toRequireRef(found: { modulePath: string; exportName: string }) {
     : `(${modRef})[${JSON.stringify(found.exportName)}]`;
 }
 
-function toPluginTargetRef(target: string | UnifiedPluginFn) {
+function toPluginTargetRef(
+  target: string | UnifiedPluginFn,
+  sourceFiles: string[],
+) {
   if (typeof target === 'string') return JSON.stringify(target);
 
-  const found = findInRequireCache(target);
+  const found =
+    findInRequireCache(target) ?? findInSourceFiles(target, sourceFiles);
   if (!found) {
     const name = target.name ? ` "${target.name}"` : '';
 
@@ -55,7 +126,10 @@ function toPluginTargetRef(target: string | UnifiedPluginFn) {
   return toRequireRef(found);
 }
 
-function toPluginRefs(plugins: UnifiedPluginConfig[] = []) {
+function toPluginRefs(
+  plugins: UnifiedPluginConfig[] = [],
+  sourceFiles: string[] = [],
+) {
   return `[${plugins
     .map((plugin) => {
       if (Array.isArray(plugin)) {
@@ -67,10 +141,11 @@ function toPluginRefs(plugins: UnifiedPluginConfig[] = []) {
 
         return `[${toPluginTargetRef(
           target as string | UnifiedPluginFn,
+          sourceFiles,
         )}, ${optionsRef}]`;
       }
 
-      return toPluginTargetRef(plugin as string | UnifiedPluginFn);
+      return toPluginTargetRef(plugin as string | UnifiedPluginFn, sourceFiles);
     })
     .join(', ')}]`;
 }
@@ -81,6 +156,7 @@ export function buildLoaderContextContent(
   routes: Record<string, unknown> = {},
   extraRemarkPlugins: IApi['config']['extraRemarkPlugins'] = [],
   extraRehypePlugins: IApi['config']['extraRehypePlugins'] = [],
+  sourceFiles: string[] = [],
 ): string {
   const refs: string[] = [];
 
@@ -104,11 +180,20 @@ export function buildLoaderContextContent(
 
   return (
     `'use strict';\n` +
+    `try {\n` +
+    `  require('@umijs/utils').register.register({ implementor: require('@umijs/bundler-utils/compiled/esbuild') });\n` +
+    `} catch (_) {}\n` +
     `exports.techStacks = [${refs.join(', ')}];\n` +
     `exports.builtins = ${JSON.stringify(builtins)};\n` +
     `exports.routes = ${JSON.stringify(routes)};\n` +
-    `exports.extraRemarkPlugins = ${toPluginRefs(extraRemarkPlugins)};\n` +
-    `exports.extraRehypePlugins = ${toPluginRefs(extraRehypePlugins)};\n`
+    `exports.extraRemarkPlugins = ${toPluginRefs(
+      extraRemarkPlugins,
+      sourceFiles,
+    )};\n` +
+    `exports.extraRehypePlugins = ${toPluginRefs(
+      extraRehypePlugins,
+      sourceFiles,
+    )};\n`
   );
 }
 


### PR DESCRIPTION
## Summary

- fall back to Umi config dependency files when utoopack cannot find a markdown plugin function in `require.cache`
- re-register the Umi esbuild require hook in the generated loader context so TS config plugin modules can be required by loader child processes
- pass `service.configManager.files` into `buildLoaderContextContent`
- add coverage for config-loaded plugin modules after their require cache entries have been cleared

## Root Cause

#2344 preserved `extraRemarkPlugins` and `extraRehypePlugins` for utoopack by serializing function plugins as module export references. However, Umi's config loader removes config files and their imported dependencies from `require.cache` after loading `.dumirc.ts`.

For downstream apps such as Ant Design, functions like `.dumi/remarkAntd.ts`'s default export (`remarkMeta`) are still present in `api.config`, but their source module is no longer discoverable via `require.cache`. This made `dumi setup` fail with:

```text
Utoopack markdown loader requires extra unified plugin function "remarkMeta" to be exported from a module.
```

This change uses Umi's recorded config dependency files as a fallback source list, re-requires those files with the same esbuild register hook, and matches plugin exports by name and transformed function source.

## Verification

- `pnpm vitest run src/features/compile/utoopackLoaders.test.ts`
- `npx eslint src/features/compile/utoopackLoaders.ts src/features/compile/index.ts src/loaders/markdown/index.ts src/features/compile/utoopackLoaders.test.ts src/features/compile/fixtures/cacheClearedPlugin.ts`
- In `/Users/zoomdong/ant-design`, temporarily patched installed `node_modules/dumi/dist` with this change and verified:
  - `node ./node_modules/dumi/bin/dumi.js setup` passes
  - `ut site` passes the previous `remarkMeta` setup failure and successfully pre-renders `/docs/resources` and `/docs/resources-cn`

`ut site` then exposes a separate utoopack SSR runtime issue on `/components/icon`:

```text
TypeError: 'ownKeys' on proxy: trap returned extra keys but proxy target is non-extensible
```

That second failure happens at `Object.keys(AntdIcons)` in Ant Design's `IconSearch/fields.ts` and appears to belong to the generated utoopack SSR namespace proxy runtime rather than dumi's markdown plugin loader.

`npx tsc --noEmit` still reports existing repository type errors unrelated to this change, but no errors in the touched files.
