### PR TITLE
perf(demo): optimize utoopack demo HMR rebuilds

### DIFF
--- a/src/assetParsers/block.ts
+++ b/src/assetParsers/block.ts
@@ -1,4 +1,4 @@
-import { parseCodeFrontmatter } from '@/utils';
+import { getContentHash, parseCodeFrontmatter } from '@/utils';
 import { build } from '@umijs/bundler-utils/compiled/esbuild';
 import assert from 'assert';
 import type { ExampleBlockAsset } from 'dumi-assets-types';
@@ -24,7 +24,7 @@ export interface IParsedBlockAsset {
   frontmatter: ReturnType<typeof parseCodeFrontmatter>['frontmatter'];
 }
 
-async function parseBlockAsset(opts: {
+interface IParseBlockAssetOptions {
   fileAbsPath: string;
   fileLocale?: string;
   id: string;
@@ -32,7 +32,101 @@ async function parseBlockAsset(opts: {
   entryPointCode?: string;
   resolver: typeof sync;
   techStack: IDumiTechStack;
-}) {
+  cacheable?: boolean;
+}
+
+type BlockAssetCache = {
+  deps: string[];
+  depsKey: string;
+  result: IParsedBlockAsset;
+};
+
+const MAX_BLOCK_ASSET_CACHE_SIZE = 512;
+const blockAssetCache = new Map<string, BlockAssetCache>();
+
+function cloneParsedBlockAsset(ret: IParsedBlockAsset): IParsedBlockAsset {
+  return {
+    asset: JSON.parse(JSON.stringify(ret.asset)),
+    resolveMap: { ...ret.resolveMap },
+    frontmatter: ret.frontmatter
+      ? JSON.parse(JSON.stringify(ret.frontmatter))
+      : ret.frontmatter,
+  };
+}
+
+function getContentHashFromFile(file: string) {
+  try {
+    return getContentHash(fs.readFileSync(file, 'utf-8'));
+  } catch {
+    return 'missing';
+  }
+}
+
+function getDepsKey(deps: string[]) {
+  return JSON.stringify(
+    Array.from(new Set(deps))
+      .sort()
+      .map((file) => `${winPath(file)}:${getContentHashFromFile(file)}`),
+  );
+}
+
+function getParseCacheKey(opts: IParseBlockAssetOptions) {
+  const entryContent =
+    opts.entryPointCode ?? fs.readFileSync(opts.fileAbsPath, 'utf-8');
+
+  return JSON.stringify({
+    file: winPath(opts.fileAbsPath),
+    fileLocale: opts.fileLocale,
+    id: opts.id,
+    refAtomIds: opts.refAtomIds,
+    entryHash: getContentHash(entryContent),
+    techStack: opts.techStack.name,
+    runtimeOpts: opts.techStack.runtimeOpts,
+    hasOnBlockLoad: Boolean(opts.techStack.onBlockLoad),
+    hasGenerateMetadata: Boolean(opts.techStack.generateMetadata),
+    hasGenerateSources: Boolean(opts.techStack.generateSources),
+  });
+}
+
+function getParseDeps(ret: IParsedBlockAsset, entryFile: string) {
+  return Object.values(ret.resolveMap).filter(
+    (file) => path.isAbsolute(file) && file !== entryFile,
+  );
+}
+
+function getCachedBlockAsset(cacheKey: string) {
+  const cached = blockAssetCache.get(cacheKey);
+
+  if (cached && cached.depsKey === getDepsKey(cached.deps)) {
+    return cloneParsedBlockAsset(cached.result);
+  }
+}
+
+function setCachedBlockAsset(
+  cacheKey: string,
+  ret: IParsedBlockAsset,
+  deps: string[],
+) {
+  if (blockAssetCache.size >= MAX_BLOCK_ASSET_CACHE_SIZE) {
+    const firstKey = blockAssetCache.keys().next().value;
+    if (firstKey) blockAssetCache.delete(firstKey);
+  }
+
+  blockAssetCache.set(cacheKey, {
+    deps,
+    depsKey: getDepsKey(deps),
+    result: cloneParsedBlockAsset(ret),
+  });
+}
+
+async function parseBlockAsset(opts: IParseBlockAssetOptions) {
+  const cacheKey = opts.cacheable ? getParseCacheKey(opts) : '';
+  const cached = cacheKey ? getCachedBlockAsset(cacheKey) : undefined;
+
+  if (cached) {
+    return cached;
+  }
+
   const asset: IParsedBlockAsset['asset'] = {
     type: 'BLOCK',
     id: opts.id,
@@ -199,14 +293,24 @@ async function parseBlockAsset(opts: {
     ],
   });
 
+  let hasError = false;
   try {
     await deferrer;
   } catch {
+    hasError = true;
     /**
      * eat errors, for preserve the dependency relationship of demo & md for md loader
      * to make sure the parent md can be re-compiling when demo errors be fixed
      * and don't worry, the real error still be reported by the demo loader
      */
+  }
+
+  if (!hasError && cacheKey) {
+    setCachedBlockAsset(
+      cacheKey,
+      result,
+      getParseDeps(result, opts.fileAbsPath),
+    );
   }
 
   return result;

--- a/src/client/theme-api/DumiDemo/index.tsx
+++ b/src/client/theme-api/DumiDemo/index.tsx
@@ -1,16 +1,25 @@
 import { SP_ROUTE_PREFIX } from '@/constants';
 import { useAppData, useDemo, useSiteData } from 'dumi';
 import React, { ComponentType, createElement, type FC } from 'react';
-import type { IPreviewerProps } from '../types';
+import type { IDemoData, IPreviewerProps } from '../types';
 
 import Previewer from 'dumi/theme/builtins/Previewer';
 import { useRenderer } from '../useRenderer';
 import DemoErrorBoundary from './DemoErrorBoundary';
 
+type DemoGetter = () => Promise<{ demos: Record<string, IDemoData> }>;
+type UseDemo = (
+  id: string,
+  loader?: DemoGetter,
+  version?: string,
+) => IDemoData | undefined;
+
 export interface IDumiDemoProps {
   demo: {
     id: string;
     inline?: boolean;
+    loader?: DemoGetter;
+    version?: string;
   };
   previewerProps: Omit<IPreviewerProps, 'asset' | 'children'>;
 }
@@ -18,8 +27,8 @@ export interface IDumiDemoProps {
 const InternalDumiDemo = (props: IDumiDemoProps) => {
   const { historyType } = useSiteData();
   const { basename } = useAppData();
-  const id = props.demo.id;
-  const demo = useDemo(id)!;
+  const { id, loader, version } = props.demo;
+  const demo = (useDemo as UseDemo)(id, loader, version)!;
   const { component, asset, renderOpts } = demo;
 
   const { canvasRef } = useRenderer({

--- a/src/features/meta.ts
+++ b/src/features/meta.ts
@@ -13,6 +13,7 @@ type IMetaFiles = {
   file: string;
   id: string;
   isMarkdown?: boolean;
+  loadDemoIndex?: boolean;
 }[];
 
 export default (api: IApi) => {
@@ -63,6 +64,9 @@ export default (api: IApi) => {
     // mark isMarkdown flag
     parsedMetaFiles.forEach((metaFile) => {
       metaFile.isMarkdown = metaFile.file.endsWith('.md');
+      metaFile.loadDemoIndex =
+        metaFile.isMarkdown &&
+        !(api.env === 'development' && Boolean(api.config.utoopack));
     });
 
     api.writeTmpFile({

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -440,6 +440,9 @@ export default function mdLoader(this: any, content: string) {
   const loaderContextPath: string | undefined = (opts as any)[
     UTOOPACK_LOADER_CTX_KEY
   ];
+  const useUtoopackDemoHMR =
+    process.env.NODE_ENV === 'development' && Boolean(loaderContextPath);
+
   if (loaderContextPath) {
     const ctx = require(loaderContextPath) as {
       techStacks: any[];
@@ -485,6 +488,7 @@ export default function mdLoader(this: any, content: string) {
   const baseCacheKey = [
     this.resourcePath,
     getContentHash(content),
+    useUtoopackDemoHMR,
     JSON.stringify(lodash.omit(opts, ['mode', 'builtins', 'onResolveDemos'])),
   ].join(':');
   // format: {baseCacheKey:{deps:contenthash}[]}
@@ -515,6 +519,7 @@ export default function mdLoader(this: any, content: string) {
       'mode' | 'builtins' | 'onResolveDemos'
     >),
     fileAbsPath: winPath(this.resourcePath),
+    useUtoopackDemoHMR,
   });
 
   deferrer[cacheKey]

--- a/src/loaders/markdown/transformer/fixtures/demo/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/demo/expect.ts
@@ -1,8 +1,9 @@
 import type { IMdTransformerResult } from '../..';
+import { omitDemoLoader } from '../utils';
 
 export default (ret: IMdTransformerResult) => {
   // replace to global DumiDemo component
-  expect(ret.content).toEqual(`<><DumiDemo {...{
+  expect(omitDemoLoader(ret.content)).toEqual(`<><DumiDemo {...{
   "demo": {
     "id": "demo-0"
   },

--- a/src/loaders/markdown/transformer/fixtures/skip-only/case01/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/skip-only/case01/expect.ts
@@ -1,7 +1,8 @@
 import type { IMdTransformerResult } from '../..';
+import { omitDemoLoader } from '../../utils';
 
 export default (ret: IMdTransformerResult) => {
-  expect(ret.content).toEqual(`<><DumiDemo {...{
+  expect(omitDemoLoader(ret.content)).toEqual(`<><DumiDemo {...{
   "demo": {
     "id": "demo-bar"
   },

--- a/src/loaders/markdown/transformer/fixtures/skip-only/case02/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/skip-only/case02/expect.ts
@@ -1,7 +1,8 @@
 import type { IMdTransformerResult } from '../..';
+import { omitDemoLoader } from '../../utils';
 
 export default (ret: IMdTransformerResult) => {
-  expect(ret.content).toEqual(`<><DumiDemoGrid items={[{
+  expect(omitDemoLoader(ret.content)).toEqual(`<><DumiDemoGrid items={[{
   "demo": {
     "id": "demo-foo"
   },

--- a/src/loaders/markdown/transformer/fixtures/skip-only/case03/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/skip-only/case03/expect.ts
@@ -1,7 +1,8 @@
 import type { IMdTransformerResult } from '../..';
+import { omitDemoLoader } from '../../utils';
 
 export default (ret: IMdTransformerResult) => {
-  expect(ret.content).toEqual(`<><DumiDemo {...{
+  expect(omitDemoLoader(ret.content)).toEqual(`<><DumiDemo {...{
   "demo": {
     "id": "demo-foo"
   },

--- a/src/loaders/markdown/transformer/fixtures/skip-only/case04/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/skip-only/case04/expect.ts
@@ -1,7 +1,8 @@
 import type { IMdTransformerResult } from '../..';
+import { omitDemoLoader } from '../../utils';
 
 export default (ret: IMdTransformerResult) => {
-  expect(ret.content).toEqual(`<><DumiDemo {...{
+  expect(omitDemoLoader(ret.content)).toEqual(`<><DumiDemo {...{
   "demo": {
     "id": "demo-bar"
   },

--- a/src/loaders/markdown/transformer/fixtures/skip-only/case05/expect.ts
+++ b/src/loaders/markdown/transformer/fixtures/skip-only/case05/expect.ts
@@ -1,7 +1,8 @@
 import type { IMdTransformerResult } from '../..';
+import { omitDemoLoader } from '../../utils';
 
 export default (ret: IMdTransformerResult) => {
-  expect(ret.content).toEqual(`<><DumiDemo {...{
+  expect(omitDemoLoader(ret.content)).toEqual(`<><DumiDemo {...{
   "demo": {
     "id": "demo-baz"
   },

--- a/src/loaders/markdown/transformer/fixtures/utils.ts
+++ b/src/loaders/markdown/transformer/fixtures/utils.ts
@@ -1,0 +1,9 @@
+export function omitDemoLoader(content: string) {
+  expect(content).toContain('"loader": () => import(');
+  expect(content).toContain("?type=demo'");
+
+  return content.replace(
+    /,\n    "loader": \(\) => import\('[^']+\\?type=demo'\),\n    "version": "[^"]+"/g,
+    '',
+  );
+}

--- a/src/loaders/markdown/transformer/index.test.ts
+++ b/src/loaders/markdown/transformer/index.test.ts
@@ -21,28 +21,48 @@ class FakeTechStack implements IDumiTechStack {
   }
 }
 
+function getTransformerOptions(
+  fileAbsPath: string,
+  useUtoopackDemoHMR?: boolean,
+) {
+  return {
+    techStacks: [new FakeTechStack()],
+    cwd: path.dirname(fileAbsPath),
+    fileAbsPath,
+    ...(useUtoopackDemoHMR === undefined ? {} : { useUtoopackDemoHMR }),
+    resolve: {
+      codeBlockMode: 'active' as const,
+      atomDirs: [],
+      docDirs: [],
+      forceKebabCaseRouting: true,
+    },
+    locales: [],
+    routes: {},
+    pkg: {},
+    alias: {
+      '@': __dirname,
+    },
+  };
+}
+
 for (let casePath of cases) {
   test(`markdown transformer: ${casePath}`, async () => {
     const fileAbsPath = path.join(CASES_DIR, casePath, 'index.md');
     const content = fs.readFileSync(fileAbsPath, 'utf8');
-    const ret = await transformer(content, {
-      techStacks: [new FakeTechStack()],
-      cwd: path.dirname(fileAbsPath),
-      fileAbsPath: fileAbsPath,
-      resolve: {
-        codeBlockMode: 'active',
-        atomDirs: [],
-        docDirs: [],
-        forceKebabCaseRouting: true,
-      },
-      locales: [],
-      routes: {},
-      pkg: {},
-      alias: {
-        '@': __dirname,
-      },
-    });
+    const ret = await transformer(
+      content,
+      getTransformerOptions(fileAbsPath, true),
+    );
 
     (await import(`${CASES_DIR}/${casePath}/expect.ts`)).default(ret);
   });
 }
+
+test('markdown transformer: skips local demo loader by default', async () => {
+  const fileAbsPath = path.join(CASES_DIR, 'demo', 'index.md');
+  const content = fs.readFileSync(fileAbsPath, 'utf8');
+  const ret = await transformer(content, getTransformerOptions(fileAbsPath));
+
+  expect(ret.content).not.toContain('"loader": () => import');
+  expect(ret.content).not.toContain('"version":');
+});

--- a/src/loaders/markdown/transformer/index.ts
+++ b/src/loaders/markdown/transformer/index.ts
@@ -71,6 +71,7 @@ declare module 'vfile' {
 export interface IMdTransformerOptions {
   cwd: string;
   fileAbsPath: string;
+  useUtoopackDemoHMR?: boolean;
   alias: ResolveOptions['alias'];
   parentAbsPath?: string;
   techStacks: IDumiTechStack[];
@@ -189,6 +190,7 @@ export default async (raw: string, opts: IMdTransformerOptions) => {
       fileAbsPath: opts.fileAbsPath,
       fileLocaleLessPath,
       fileLocale,
+      useUtoopackDemoHMR: opts.useUtoopackDemoHMR,
       resolve: opts.resolve,
       resolver,
     })

--- a/src/loaders/markdown/transformer/rehypeDemo.ts
+++ b/src/loaders/markdown/transformer/rehypeDemo.ts
@@ -1,6 +1,6 @@
 import parseBlockAsset from '@/assetParsers/block';
 import type { IDumiDemoProps } from '@/client/theme-api/DumiDemo';
-import { getFileIdFromFsPath } from '@/utils';
+import { getContentHash, getFileIdFromFsPath } from '@/utils';
 import type { sync } from 'enhanced-resolve';
 import type { Element, Root } from 'hast';
 import path from 'path';
@@ -17,6 +17,11 @@ let isElement: typeof import('hast-util-is-element').isElement;
 const DEMO_NODE_CONTAINER = '$demo-container';
 
 export const DEMO_PROP_VALUE_KEY = '$demo-prop-value-key';
+const DEMO_LOADER_PLACEHOLDER = '__DUMI_DEMO_LOADER__';
+const DEMO_LOADER_PLACEHOLDER_VALUE =
+  DEMO_LOADER_PLACEHOLDER as unknown as NonNullable<
+    IDumiDemoProps['demo']['loader']
+  >;
 export const DUMI_DEMO_TAG = 'DumiDemo';
 export const DUMI_DEMO_GRID_TAG = 'DumiDemoGrid';
 export const SKIP_DEMO_PARSE = 'pure';
@@ -41,6 +46,7 @@ type IRehypeDemoOptions = Pick<
   resolver: typeof sync;
   fileLocaleLessPath: string;
   fileLocale?: string;
+  useUtoopackDemoHMR?: boolean;
 };
 
 /**
@@ -334,11 +340,17 @@ export default function rehypeDemo(
             }
 
             const propDemo: IDumiDemoProps['demo'] = { id: parseOpts.id };
+            if (opts.useUtoopackDemoHMR) {
+              propDemo.loader = DEMO_LOADER_PLACEHOLDER_VALUE;
+            }
             demoIds.push(parseOpts.id);
 
             // generate asset data for demo
             deferrers.push(
-              parseBlockAsset(parseOpts).then(
+              parseBlockAsset({
+                ...parseOpts,
+                cacheable: opts.useUtoopackDemoHMR,
+              }).then(
                 async ({ asset, resolveMap, frontmatter }) => {
                   // repeat id to give warning
                   if (
@@ -388,6 +400,12 @@ export default function rehypeDemo(
                   validAssetAttrs.forEach((key) => {
                     if (originalProps[key]) asset[key] = originalProps[key];
                   });
+
+                  if (opts.useUtoopackDemoHMR) {
+                    propDemo.version = getContentHash(
+                      JSON.stringify(asset.dependencies),
+                    );
+                  }
 
                   // do not generate previewer props & asset for inline demo
                   if (
@@ -518,7 +536,17 @@ export default function rehypeDemo(
 
       // parse final value for jsx attributes
       replaceNodes.forEach((node) => {
-        const value = JSON.stringify(node.data![DEMO_PROP_VALUE_KEY]);
+        const demoLoader = `() => import('${winPath(
+          opts.fileAbsPath,
+        )}?type=demo')`;
+        let value = JSON.stringify(node.data![DEMO_PROP_VALUE_KEY]);
+
+        if (opts.useUtoopackDemoHMR) {
+          value = value.replace(
+            new RegExp(`"${DEMO_LOADER_PLACEHOLDER}"`, 'g'),
+            demoLoader,
+          );
+        }
 
         if (node.JSXAttributes![0].type === 'JSXAttribute') {
           node.JSXAttributes![0].value = value;

--- a/src/templates/meta/exports.ts.tpl
+++ b/src/templates/meta/exports.ts.tpl
@@ -46,6 +46,8 @@ const demoIdMap = Object.keys(filesMeta).reduce((total, current) => {
   return total;
 }, {});
 
+type DemoGetter = () => Promise<{ demos: Record<string, IDemoData> }>;
+
 const demosCache = new Map<string, Promise<IDemoData | undefined>>();
 
 /**
@@ -68,19 +70,31 @@ function expandDemoContext(context?: IDemoData['context']) {
 /**
  * use demo data by id
  */
-export function useDemo(id: string): IDemoData | undefined {
-  if (!demosCache.get(id)) {
+export function useDemo(
+  id: string,
+  loader?: DemoGetter,
+  version?: string,
+): IDemoData | undefined {
+  const cacheKey = version ? `${id}:${version}` : id;
+  const getter = loader ?? demoIdMap[id];
+
+  if (!demosCache.get(cacheKey)) {
+    if (!getter) return undefined;
+
     demosCache.set(
-      id,
-      demoIdMap[id]?.().then(({ demos }) => {
+      cacheKey,
+      getter().then(({ demos }) => {
         // expand context for omit ext
         expandDemoContext(demos[id].context);
         return demos[id];
       }),
     );
+
+    // Reuse local demo data for consumers that still call useDemo(id), such as useLiveDemo.
+    demosCache.set(id, demosCache.get(cacheKey)!);
   }
 
-  return use(demosCache.get(id)!);
+  return use(demosCache.get(cacheKey)!);
 }
 
 /**

--- a/src/templates/meta/index.ts.tpl
+++ b/src/templates/meta/index.ts.tpl
@@ -1,10 +1,10 @@
 {{#metaFiles}}
-{{#isMarkdown}}
+{{#loadDemoIndex}}
 import { frontmatter as fm{{{index}}}, toc as t{{{index}}}, demoIndex as dmi{{{index}}} } from '{{{file}}}?type=frontmatter';
-{{/isMarkdown}}
-{{^isMarkdown}}
+{{/loadDemoIndex}}
+{{^loadDemoIndex}}
 import { frontmatter as fm{{{index}}}, toc as t{{{index}}} } from '{{{file}}}?type=frontmatter';
-{{/isMarkdown}}
+{{/loadDemoIndex}}
 {{/metaFiles}}
 
 export const filesMeta = {
@@ -12,9 +12,9 @@ export const filesMeta = {
   '{{{id}}}': {
     frontmatter: fm{{{index}}},
     toc: t{{{index}}},
-    {{#isMarkdown}}
+    {{#loadDemoIndex}}
     demoIndex: dmi{{{index}}},
-    {{/isMarkdown}}
+    {{/loadDemoIndex}}
     {{#tabs}}
     tabs: {{{tabs}}},
     {{/tabs}}


### PR DESCRIPTION
## Summary

- avoid loading markdown demo indexes into global meta during dev + utoopack, so demo edits no longer route through the global meta runtime
- pass page-local demo loaders into DumiDemo only for dev + utoopack and keep the default markdown transform output unchanged
- cache parseBlockAsset results only for dev + utoopack, with dependency hash validation before reuse to reduce repeated esbuild dependency collection for unchanged demos

## Testing

- npx vitest run src/loaders/markdown/transformer/index.test.ts
- npx eslint src/assetParsers/block.ts src/client/theme-api/DumiDemo/index.tsx src/features/meta.ts src/loaders/markdown/index.ts src/loaders/markdown/transformer/index.ts src/loaders/markdown/transformer/index.test.ts src/loaders/markdown/transformer/rehypeDemo.ts src/loaders/markdown/transformer/fixtures/utils.ts
- npx father build
- npm run docs:build
