### PR TITLE
fix(demo): enable utoopack demo loader outside production

### DIFF
--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -441,7 +441,7 @@ export default function mdLoader(this: any, content: string) {
     UTOOPACK_LOADER_CTX_KEY
   ];
   const useUtoopackDemoHMR =
-    process.env.NODE_ENV === 'development' && Boolean(loaderContextPath);
+    process.env.NODE_ENV !== 'production' && Boolean(loaderContextPath);
 
   if (loaderContextPath) {
     const ctx = require(loaderContextPath) as {


### PR DESCRIPTION
## Summary

- fix a regression from #2348 where dev builds with utoopack can run markdown loaders without `NODE_ENV=development`
- keep the local demo loader enabled for any non-production utoopack loader context so pages do not lose demo data after global demo indexes are skipped

## Testing

- npx eslint src/loaders/markdown/index.ts
- npx vitest run src/loaders/markdown/transformer/index.test.ts
- npx father build
- npm run docs:build
- locally invoked the markdown loader for `components/button/index.zh-CN.md` in ant-design and verified generated demo props include `loader` and `version` when `NODE_ENV` is undefined
