### PR TITLE
perf(demo): add utoopack demo index fallback

### DIFF
--- a/src/client/pages/Demo/index.ts
+++ b/src/client/pages/Demo/index.ts
@@ -1,13 +1,24 @@
-import { useDemo, useLiveDemo, useParams } from 'dumi';
+import { useDemo, useLiveDemo, useLocation, useParams } from 'dumi';
 import { ComponentType, createElement, useEffect, type FC } from 'react';
+import type { IDemoData } from '../../theme-api/types';
 import { useRenderer } from '../../theme-api/useRenderer';
 import './index.less';
 
+type DemoGetter = () => Promise<{ demos: Record<string, IDemoData> }>;
+type UseDemo = (
+  id: string,
+  loader?: DemoGetter,
+  version?: string,
+  routeId?: string,
+) => IDemoData | undefined;
+
 const DemoRenderPage: FC = () => {
   const params = useParams();
+  const { search } = useLocation();
   const id = params.id!;
+  const routeId = new URLSearchParams(search).get('routeId') || undefined;
 
-  const demo = useDemo(id)!;
+  const demo = (useDemo as UseDemo)(id, undefined, undefined, routeId)!;
   const { canvasRef } = useRenderer({
     id,
     component: demo.component,

--- a/src/client/theme-api/DumiDemo/index.tsx
+++ b/src/client/theme-api/DumiDemo/index.tsx
@@ -12,6 +12,7 @@ type UseDemo = (
   id: string,
   loader?: DemoGetter,
   version?: string,
+  routeId?: string,
 ) => IDemoData | undefined;
 
 export interface IDumiDemoProps {
@@ -56,6 +57,9 @@ const InternalDumiDemo = (props: IDumiDemoProps) => {
   }
 
   const isHashRoute = historyType === 'hash';
+  const routeQuery = demo.routeId
+    ? `?routeId=${encodeURIComponent(demo.routeId)}`
+    : '';
 
   return (
     <Previewer
@@ -66,7 +70,7 @@ const InternalDumiDemo = (props: IDumiDemoProps) => {
         // when use hash route, browser can automatically handle relative paths starting with #
         `${isHashRoute ? `#` : ''}${basename}${SP_ROUTE_PREFIX}demos/${
           props.demo.id
-        }`
+        }${routeQuery}`
       }
       {...props.previewerProps}
     >

--- a/src/features/meta.ts
+++ b/src/features/meta.ts
@@ -7,6 +7,7 @@ import { isTabRouteFile } from './tabs';
 
 export const TABS_META_PATH = 'dumi/meta/tabs.ts';
 export const ATOMS_META_PATH = 'dumi/meta/atoms.ts';
+export const DEMO_INDEX_META_PATH = 'dumi/meta/demoIndex.ts';
 
 type IMetaFiles = {
   index: number;
@@ -14,6 +15,7 @@ type IMetaFiles = {
   id: string;
   isMarkdown?: boolean;
   loadDemoIndex?: boolean;
+  loadDemoIndexMap?: boolean;
 }[];
 
 export default (api: IApi) => {
@@ -62,11 +64,13 @@ export default (api: IApi) => {
     });
 
     // mark isMarkdown flag
+    const useUtoopackDemoHMR =
+      api.env === 'development' && Boolean(api.config.utoopack);
+
     parsedMetaFiles.forEach((metaFile) => {
       metaFile.isMarkdown = metaFile.file.endsWith('.md');
-      metaFile.loadDemoIndex =
-        metaFile.isMarkdown &&
-        !(api.env === 'development' && Boolean(api.config.utoopack));
+      metaFile.loadDemoIndex = metaFile.isMarkdown && !useUtoopackDemoHMR;
+      metaFile.loadDemoIndexMap = metaFile.isMarkdown && useUtoopackDemoHMR;
     });
 
     api.writeTmpFile({
@@ -85,6 +89,15 @@ export default (api: IApi) => {
             api.config.locales?.map(({ id }) => id),
           )}" */`;
         },
+      },
+    });
+
+    api.writeTmpFile({
+      noPluginDir: true,
+      path: DEMO_INDEX_META_PATH,
+      tplPath: require.resolve('../templates/meta/demoIndex.ts.tpl'),
+      context: {
+        metaFiles: parsedMetaFiles,
       },
     });
 

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -79,6 +79,21 @@ function isRelativePath(path: string) {
   return /^\.{1,2}(?!\w)/.test(path);
 }
 
+function normalizeRouteFile(file: string) {
+  return winPath(file).replace(/\.(mdx?)\.js$/, '.$1');
+}
+
+function getRouteId(opts: IMdLoaderOptions, fileAbsPath: string) {
+  const normalizedFile = normalizeRouteFile(fileAbsPath);
+  const route = Object.values(opts.routes ?? {}).find((item) => {
+    const routeFile = (item as any).file || (item as any).__absFile;
+
+    return routeFile && normalizeRouteFile(routeFile) === normalizedFile;
+  });
+
+  return (route as any)?.id as string | undefined;
+}
+
 function emitDefault(
   this: any,
   opts: IMdLoaderDefaultModeOptions,
@@ -197,6 +212,8 @@ function emitDemo(
             .filter((item): item is IDemoDependency => item !== undefined),
         );
       }, []);
+  const routeId = getRouteId(opts, this.resourcePath);
+
   return Mustache.render(
     `import React from 'react';
 import '${winPath(this.resourcePath)}?watch=parent';
@@ -210,6 +227,9 @@ export const demos = {
     component: {{{component}}},
     {{/component}}
     asset: {{{renderAsset}}},
+    {{#routeId}}
+    routeId: '{{{routeId}}}',
+    {{/routeId}}
     context: {{{renderContext}}},
     renderOpts: {{{renderRenderOpts}}},
   },
@@ -218,6 +238,7 @@ export const demos = {
     {
       demos,
       dedupedDemosDeps,
+      routeId,
       renderAsset: function renderAsset(this: NonNullable<typeof demos>[0]) {
         // do not render asset for inline demo
         if (!('asset' in this)) return 'null';
@@ -404,8 +425,11 @@ function emit(this: any, opts: IMdLoaderOptions, ret: IMdTransformerResult) {
   // declare embedded files as loader dependency, for re-compiling when file changed
   embeds!.forEach((file) => this.addDependency(file));
 
-  // declare demo source files as loader dependency, for re-compiling when file changed
-  getDemoSourceFiles(demos).forEach((file) => this.addDependency(file));
+  // demo-index only needs demo ids and lazy getters. Keep demo source files out
+  // of the global meta dependency graph so JSX edits can stay local.
+  if (opts.mode !== 'demo-index') {
+    getDemoSourceFiles(demos).forEach((file) => this.addDependency(file));
+  }
 
   // to avoid compile watch=parent virtual module
   if (this.resourceQuery.includes('watch=parent')) return null;

--- a/src/templates/meta/demoIndex.ts.tpl
+++ b/src/templates/meta/demoIndex.ts.tpl
@@ -1,0 +1,10 @@
+export const demoIndexMap = {
+  {{#metaFiles}}
+  {{#loadDemoIndexMap}}
+  '{{{id}}}': () =>
+    import('{{{file}}}?type=demo-index').then(
+      ({ demoIndex }) => demoIndex,
+    ),
+  {{/loadDemoIndexMap}}
+  {{/metaFiles}}
+};

--- a/src/templates/meta/exports.ts.tpl
+++ b/src/templates/meta/exports.ts.tpl
@@ -34,21 +34,53 @@ export function use<T>(promise: ReactPromise<T>): T {
   }
 }
 
-const demoIdMap = Object.keys(filesMeta).reduce((total, current) => {
-  if (filesMeta[current].demoIndex) {
-    const { ids, getter } = filesMeta[current].demoIndex;
-
-    ids.forEach((id) => {
-      total[id] = getter;
-    });
-  }
-
-  return total;
-}, {});
-
 type DemoGetter = () => Promise<{ demos: Record<string, IDemoData> }>;
+type DemoIndex = {
+  ids: string[];
+  getter: DemoGetter;
+};
+type DemoIndexGetter = () => Promise<DemoIndex>;
+
+const demoIndexes = Object.entries(filesMeta)
+  .map(([id, meta]) => ({
+    id,
+    demoIndex: meta.demoIndex,
+  }))
+  .filter(
+    (item): item is { id: string; demoIndex: DemoIndex } =>
+      Boolean(item.demoIndex),
+  );
+
+const demoIdMap = demoIndexes.reduce<Record<string, DemoGetter>>(
+  (total, { demoIndex }) => {
+    if (demoIndex) {
+      const { ids, getter } = demoIndex;
+
+      ids.forEach((id) => {
+        total[id] = getter;
+      });
+    }
+
+    return total;
+  },
+  {},
+);
 
 const demosCache = new Map<string, Promise<IDemoData | undefined>>();
+let demoIndexMapPromise:
+  | Promise<Record<string, DemoIndexGetter | undefined>>
+  | undefined;
+
+function loadDemoIndexMap() {
+  if (!demoIndexMapPromise) {
+    demoIndexMapPromise = import('./demoIndex').then(
+      ({ demoIndexMap }) =>
+        demoIndexMap as Record<string, DemoIndexGetter | undefined>,
+    );
+  }
+
+  return demoIndexMapPromise;
+}
 
 /**
  * expand context for source omit extension
@@ -67,6 +99,65 @@ function expandDemoContext(context?: IDemoData['context']) {
   }
 }
 
+function getDemoIdCandidates(id: string) {
+  const ids = [id];
+  const localeLessId = id.replace(/-[a-z]{2}(?:-[A-Z]{2})?$/, '');
+
+  if (localeLessId !== id) {
+    ids.push(localeLessId);
+  }
+
+  return ids;
+}
+
+async function getDemoFromDemoIndex(
+  id: string,
+  demoIndexGetter: DemoIndexGetter,
+) {
+  const demoIndex = await demoIndexGetter();
+  const demoId = getDemoIdCandidates(id).find((candidate) =>
+    demoIndex.ids.includes(candidate),
+  );
+  const getter = demoId ? demoIndex.getter : undefined;
+
+  if (!getter) return undefined;
+
+  demoIdMap[id] = getter;
+  const { demos } = await getter();
+  const demo = demos[id] ?? demos[demoId!];
+
+  if (!demo) return undefined;
+
+  expandDemoContext(demo.context);
+  return demo;
+}
+
+async function getDemoFromRouteIndex(id: string, routeId: string) {
+  const demoIndexMap = await loadDemoIndexMap();
+  const demoIndexGetter = demoIndexMap[routeId];
+
+  if (!demoIndexGetter) return getDemoFromIndexMap(id);
+
+  return (
+    (await getDemoFromDemoIndex(id, demoIndexGetter)) ??
+    getDemoFromIndexMap(id)
+  );
+}
+
+async function getDemoFromIndexMap(id: string) {
+  const demoIndexMap = await loadDemoIndexMap();
+  const demoIndexGetters = Object.values(demoIndexMap).filter(
+    (item): item is DemoIndexGetter => Boolean(item),
+  );
+
+  for (const demoIndexGetter of demoIndexGetters) {
+    const demo = await getDemoFromDemoIndex(id, demoIndexGetter).catch(
+      () => undefined,
+    );
+    if (demo) return demo;
+  }
+}
+
 /**
  * use demo data by id
  */
@@ -74,20 +165,30 @@ export function useDemo(
   id: string,
   loader?: DemoGetter,
   version?: string,
+  routeId?: string,
 ): IDemoData | undefined {
-  const cacheKey = version ? `${id}:${version}` : id;
+  const cacheKey = version
+    ? `${id}:${version}`
+    : routeId
+      ? `${id}:route=${routeId}`
+      : id;
   const getter = loader ?? demoIdMap[id];
 
   if (!demosCache.get(cacheKey)) {
-    if (!getter) return undefined;
-
     demosCache.set(
       cacheKey,
-      getter().then(({ demos }) => {
-        // expand context for omit ext
-        expandDemoContext(demos[id].context);
-        return demos[id];
-      }),
+      getter
+        ? getter().then(({ demos }) => {
+            const demo = demos[id];
+            if (!demo) return undefined;
+
+            // expand context for omit ext
+            expandDemoContext(demo.context);
+            return demo;
+          })
+        : routeId
+          ? getDemoFromRouteIndex(id, routeId)
+          : getDemoFromIndexMap(id),
     );
 
     // Reuse local demo data for consumers that still call useDemo(id), such as useLiveDemo.
@@ -101,14 +202,25 @@ export function useDemo(
  * get all demos
  */
 export async function getFullDemos() {
-  const demoFilesMeta = Object.entries(filesMeta).filter(
-    ([_id, meta]) => meta.demoIndex,
+  const demoIndexMap = await loadDemoIndexMap();
+  const lazyDemoIndexes = await Promise.all(
+    Object.entries(demoIndexMap).map(async ([id, demoIndexGetter]) => ({
+      id,
+      demoIndex: await demoIndexGetter?.().catch(() => undefined),
+    })),
+  );
+  const allDemoIndexes = [
+    ...demoIndexes,
+    ...lazyDemoIndexes,
+  ].filter(
+    (item): item is { id: string; demoIndex: DemoIndex } =>
+      Boolean(item.demoIndex),
   );
 
   return Promise.all(
-    demoFilesMeta.map(async ([id, meta]) => ({
+    allDemoIndexes.map(async ({ id, demoIndex }) => ({
       id,
-      demos: (await meta.demoIndex.getter()).demos as Record<string, IDemoData>,
+      demos: (await demoIndex.getter()).demos as Record<string, IDemoData>,
     })),
   ).then((ret) =>
     ret.reduce<Record<string, IDemoData>>((total, { id, demos }) => {


### PR DESCRIPTION
## Summary
- add a lightweight demo index map for utoopack dev so standalone demo routes can still resolve demos without loading full demo data into page meta
- keep demo-index modules out of demo source dependency tracking to avoid pulling demo source edits into the global meta graph
- guard local demo cache population when a requested id is missing from a loaded demo module

## Verification
- ./node_modules/.bin/father build
- ./node_modules/.bin/vitest run src/loaders/markdown/transformer/index.test.ts
- copied built dumi artifacts into ant-design and verified /components/button-cn renders without the DumiDemo component error
- verified /~demos/button-demo-basic renders without the DemoRenderPage component error