### PR TITLE
fix: track external demo sidecar markdown dependencies

### DIFF
--- a/src/loaders/markdown/index.test.ts
+++ b/src/loaders/markdown/index.test.ts
@@ -1,5 +1,22 @@
+import fs from 'fs';
+import Module from 'module';
+import os from 'os';
+import path from 'path';
 import { vi } from 'vitest';
-import { getMdLoaderCacheSync } from '.';
+
+let getDemoSourceFiles: typeof import('.')['getDemoSourceFiles'];
+let getMdLoaderCacheSync: typeof import('.')['getMdLoaderCacheSync'];
+
+function registerTsResolveExtension() {
+  const extensions = (Module as any)._extensions as NodeJS.RequireExtensions;
+
+  extensions['.ts'] ??= extensions['.js'];
+}
+
+beforeAll(async () => {
+  registerTsResolveExtension();
+  ({ getDemoSourceFiles, getMdLoaderCacheSync } = await import('.'));
+});
 
 test('markdown loader reads md-loader cache', () => {
   const cache = {
@@ -30,4 +47,28 @@ test('markdown loader rethrows non-json cache errors', () => {
   expect(() => getMdLoaderCacheSync(cache, 'key', '')).toThrow(
     'EACCES: permission denied',
   );
+});
+
+test('markdown loader tracks external demo sidecar markdown files', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dumi-demo-source-'));
+  const demoFile = path.join(dir, 'basic.tsx');
+  const demoMdFile = path.join(dir, 'basic.md');
+
+  fs.writeFileSync(demoFile, 'export default () => null;');
+  fs.writeFileSync(demoMdFile, '## zh-CN\n\nDemo description');
+
+  try {
+    expect(
+      getDemoSourceFiles([
+        {
+          id: 'button-demo-basic',
+          resolveMap: {
+            'index.tsx': demoFile,
+          },
+        } as any,
+      ]),
+    ).toEqual([demoFile, demoMdFile]);
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
 });

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -91,16 +91,32 @@ export function getMdLoaderCacheSync<T>(
   }
 }
 
-function getDemoSourceFiles(demos: IMdTransformerResult['meta']['demos'] = []) {
-  return demos.reduce<string[]>((ret, demo) => {
-    if ('resolveMap' in demo) {
-      ret.push(
-        ...Object.values(demo.resolveMap).filter((p) => path.isAbsolute(p)),
-      );
-    }
+function getDemoSidecarFiles(file: string) {
+  const { dir, name } = path.parse(file);
+  const mdFile = path.join(dir, `${name}.md`);
 
-    return ret;
-  }, []);
+  return fs.existsSync(mdFile) ? [mdFile] : [];
+}
+
+export function getDemoSourceFiles(
+  demos: IMdTransformerResult['meta']['demos'] = [],
+) {
+  const files = new Set<string>();
+
+  demos.forEach((demo) => {
+    if ('resolveMap' in demo) {
+      Object.values(demo.resolveMap)
+        .filter((p) => path.isAbsolute(p))
+        .forEach((file) => {
+          files.add(file);
+          getDemoSidecarFiles(file).forEach((sidecarFile) =>
+            files.add(sidecarFile),
+          );
+        });
+    }
+  });
+
+  return Array.from(files);
 }
 
 function isRelativePath(path: string) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

修改 https://github.com/ant-design/ant-design/blob/master/components/button/demo/basic.md#L8-L7

hmr 不会出发，需要把 md 添加到 dependencies 里面去。

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    track external demo sidecar markdown dependencies        |
| 🇨🇳 Chinese |     修复 demo 的 markdown dependencies 不被跟踪导致热更新失效的问题      |
