### PR TITLE
fix: generate demo pages in utoopack static export

### DIFF
--- a/src/features/compile/index.ts
+++ b/src/features/compile/index.ts
@@ -11,6 +11,7 @@ import { getLoadHook } from './makoHooks';
 import { shouldDisabledLiveDemo } from './utils';
 import {
   LOADER_CTX_FILENAME,
+  UTOOPACK_DEMO_ASSETS_FILENAME,
   buildLoaderContextContent,
   getUtoopackRules,
 } from './utoopackLoaders';
@@ -113,6 +114,12 @@ export default (api: IApi) => {
   api.onGenerateFiles({
     fn() {
       if (api.config.utoopack) {
+        const demoAssetsFile = path.join(
+          api.paths.absTmpPath,
+          UTOOPACK_DEMO_ASSETS_FILENAME,
+        );
+
+        fs.rmSync(demoAssetsFile, { force: true });
         api.writeTmpFile({
           noPluginDir: true,
           path: LOADER_CTX_FILENAME,
@@ -123,6 +130,7 @@ export default (api: IApi) => {
             api.config.extraRemarkPlugins,
             api.config.extraRehypePlugins,
             (api as any).service.configManager?.files ?? [],
+            demoAssetsFile,
           ),
         });
       }

--- a/src/features/compile/utoopackLoaders.test.ts
+++ b/src/features/compile/utoopackLoaders.test.ts
@@ -124,6 +124,8 @@ test('utoopack loader context serializes extra unified plugins', async () => {
     {},
     [plugins.remarkPluginForTest, ['remark-string-plugin', { value: 1 }]],
     [[plugins.rehypePluginForTest, { enabled: true }], 'rehype-string-plugin'],
+    [],
+    '/tmp/dumi-app/.dumi/tmp/dumi-utoopack-demo-assets.jsonl',
   );
   const exports: any = {};
 
@@ -137,6 +139,9 @@ test('utoopack loader context serializes extra unified plugins', async () => {
     [plugins.rehypePluginForTest, { enabled: true }],
     'rehype-string-plugin',
   ]);
+  expect(exports.demoAssetsFile).toBe(
+    '/tmp/dumi-app/.dumi/tmp/dumi-utoopack-demo-assets.jsonl',
+  );
 });
 
 test('utoopack loader context registers TS hook without project root phantom deps', async () => {

--- a/src/features/compile/utoopackLoaders.ts
+++ b/src/features/compile/utoopackLoaders.ts
@@ -13,6 +13,7 @@ const esbuildImplementorPath = require.resolve(
 export const UTOOPACK_LOADER_CTX_KEY = '__dumiLoaderContextPath';
 
 export const LOADER_CTX_FILENAME = 'dumi-loader-ctx.cjs';
+export const UTOOPACK_DEMO_ASSETS_FILENAME = 'dumi-utoopack-demo-assets.jsonl';
 
 type UnifiedPluginConfig = NonNullable<IApi['config']['extraRemarkPlugins']>[0];
 type UnifiedPluginFn = (...args: any[]) => any;
@@ -197,6 +198,7 @@ export function buildLoaderContextContent(
   extraRemarkPlugins: IApi['config']['extraRemarkPlugins'] = [],
   extraRehypePlugins: IApi['config']['extraRehypePlugins'] = [],
   sourceFiles: string[] = [],
+  demoAssetsFile?: string,
 ): string {
   const refs = toTechStackRefs(techStacks);
 
@@ -214,6 +216,7 @@ export function buildLoaderContextContent(
     `exports.techStacks = [${refs.join(', ')}];\n` +
     `exports.builtins = ${JSON.stringify(builtins)};\n` +
     `exports.routes = ${JSON.stringify(routes)};\n` +
+    `exports.demoAssetsFile = ${JSON.stringify(demoAssetsFile)};\n` +
     `exports.extraRemarkPlugins = ${toPluginRefs(
       extraRemarkPlugins,
       sourceFiles,

--- a/src/features/exportStatic.ts
+++ b/src/features/exportStatic.ts
@@ -1,12 +1,35 @@
 import { SP_ROUTE_PREFIX } from '@/constants';
 import type { IApi } from '@/types';
+import type { ExampleAsset } from 'dumi-assets-types';
+import fs from 'fs';
+import path from 'path';
+import { lodash } from 'umi/plugin-utils';
 import { getExampleAssets } from './assets';
+import { UTOOPACK_DEMO_ASSETS_FILENAME } from './compile/utoopackLoaders';
 
 const NO_PRERENDER_ROUTES = [
   // disable prerender for demo render page, because umi-hd doesn't support ssr
   // ref: https://github.com/umijs/dumi/pull/1451
   'demo-render',
 ];
+
+function readExampleAssetsFile(filePath: string) {
+  if (!fs.existsSync(filePath)) return [];
+
+  return fs
+    .readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .reduce<ExampleAsset[]>((acc, line) => {
+      try {
+        acc.push(JSON.parse(line));
+      } catch {
+        // ignore malformed records from interrupted builds
+      }
+
+      return acc;
+    }, []);
+}
 
 export default (api: IApi) => {
   api.describe({
@@ -38,7 +61,15 @@ export default (api: IApi) => {
       // because umi exportStatic will handle relative publicPath
       // so push routes to exportHtmlData to make it also work for demo routes
       const routePrefix = `${SP_ROUTE_PREFIX}demos`;
-      const examples = getExampleAssets();
+      const examples = lodash.uniqBy(
+        [
+          ...getExampleAssets(),
+          ...readExampleAssetsFile(
+            path.join(api.paths.absTmpPath, UTOOPACK_DEMO_ASSETS_FILENAME),
+          ),
+        ],
+        'id',
+      );
 
       api.appData.exportHtmlData.push(
         ...examples.map(({ id }) => ({

--- a/src/loaders/markdown/index.ts
+++ b/src/loaders/markdown/index.ts
@@ -22,6 +22,7 @@ interface IMdLoaderDefaultModeOptions
     atomId: string,
     meta: IMdTransformerResult['meta']['frontmatter'],
   ) => void;
+  demoAssetsFile?: string;
   disableLiveDemo: boolean;
 }
 
@@ -151,6 +152,18 @@ function emitDefault(
   // apply demos resolve hook
   if (demos && opts.onResolveDemos) {
     opts.onResolveDemos(demos);
+  }
+
+  if (demos && opts.demoAssetsFile) {
+    const assets = demos.reduce<string[]>((acc, demo) => {
+      if ('asset' in demo) acc.push(JSON.stringify(demo.asset));
+      return acc;
+    }, []);
+
+    if (assets.length) {
+      fs.mkdirSync(path.dirname(opts.demoAssetsFile), { recursive: true });
+      fs.appendFileSync(opts.demoAssetsFile, `${assets.join('\n')}\n`);
+    }
   }
 
   // apply atom meta resolve hook
@@ -518,6 +531,7 @@ export default function mdLoader(this: any, content: string) {
       routes?: IMdLoaderOptions['routes'];
       extraRemarkPlugins?: IMdLoaderOptions['extraRemarkPlugins'];
       extraRehypePlugins?: IMdLoaderOptions['extraRehypePlugins'];
+      demoAssetsFile?: string;
     };
     if (!opts.techStacks?.length) {
       (opts as any).techStacks = ctx.techStacks;
@@ -538,6 +552,9 @@ export default function mdLoader(this: any, content: string) {
     if (ctx.extraRehypePlugins && !(opts as any).extraRehypePlugins?.length) {
       (opts as any).extraRehypePlugins = ctx.extraRehypePlugins;
     }
+    if (ctx.demoAssetsFile && !(opts as any).demoAssetsFile) {
+      (opts as any).demoAssetsFile = ctx.demoAssetsFile;
+    }
   }
 
   const cb = this.async();
@@ -546,7 +563,9 @@ export default function mdLoader(this: any, content: string) {
   // because the onResolveDemos and onResolveAtomMeta hook does not be fired when cache hit
   if (
     process.env.NODE_ENV === 'production' &&
-    ['onResolveDemos', 'onResolveAtomMeta'].some((k) => k in opts)
+    ['onResolveDemos', 'onResolveAtomMeta', 'demoAssetsFile'].some(
+      (k) => k in opts,
+    )
   ) {
     this.cacheable(false);
   }


### PR DESCRIPTION
## Summary

- collect demo assets from utoopack markdown loader workers through a temporary JSONL file
- merge the collected demo assets into static export HTML data so `/~demos/:id` pages are generated
- keep webpack and mako behavior unchanged by continuing to use the existing in-memory `getExampleAssets()` path

## Root Cause

`exportStatic` relies on `getExampleAssets()` to append `/~demos/:id` pages. Webpack and mako can call `onResolveDemos -> addExampleAssets()` directly, but utoopack loader options are serialized and do not reliably share that in-memory callback/state with dumi. As a result, utoopack production builds exported normal docs pages but skipped demo HTML pages, making iframe demos 404.

## Verification

- `./node_modules/.bin/vitest run src/features/compile/utoopackLoaders.test.ts`
- `./node_modules/.bin/prettier --check src/features/compile/index.ts src/features/compile/utoopackLoaders.ts src/features/compile/utoopackLoaders.test.ts src/features/exportStatic.ts src/loaders/markdown/index.ts`
- `./node_modules/.bin/father build`
- copied the built `dist` into `ant-design/node_modules/dumi/dist` and ran `NODE_OPTIONS='--max-old-space-size=8192' NODE_ENV=production ./node_modules/.bin/dumi build`
- verified `_site/~demos/tooltip-demo-shift/index.html` exists and `_site/~demos` contains 1164 demo HTML files
