### PR TITLE
fix: export localized demo pages

### DIFF
--- a/src/features/exportStatic.ts
+++ b/src/features/exportStatic.ts
@@ -70,9 +70,20 @@ export default (api: IApi) => {
         ],
         'id',
       );
+      const localeSuffixes = api.config.locales
+        .map((locale) => ('suffix' in locale ? locale.suffix : ''))
+        .filter(Boolean);
+      const exampleIds = lodash.uniq(
+        examples.flatMap(({ id }) => [
+          id,
+          ...localeSuffixes.map((suffix) =>
+            id.endsWith(suffix) ? id : `${id}${suffix}`,
+          ),
+        ]),
+      );
 
       api.appData.exportHtmlData.push(
-        ...examples.map(({ id }) => ({
+        ...exampleIds.map((id) => ({
           route: { path: `/${routePrefix}/${id}` },
           file: `${routePrefix}/${id}/index.html`,
           prerender: false,


### PR DESCRIPTION
## Summary

- export locale-suffixed demo HTML aliases for suffix-based locales
- keep the existing base demo pages while adding paths like `/~demos/tooltip-demo-shift-cn/`

## Root Cause

#2359 restored static `/~demos/:id` pages for utoopack builds, but suffix-based locale sites can still redirect demo iframe pages to a localized path. In Ant Design's Chinese docs, the iframe URL includes `routeId=...zh-CN`; the page language script redirects `/~demos/tooltip-demo-shift/` to `/~demos/tooltip-demo-shift-cn/`. That localized demo alias was not exported, so the deployed iframe could still hit a 404.

## Verification

- `./node_modules/.bin/prettier --check src/features/exportStatic.ts`
- `./node_modules/.bin/father build`
- copied the built `dist` into `ant-design/node_modules/dumi/dist`
- verified the copied `dist/features/exportStatic.js` contains the locale alias export logic

Note: a full Ant Design production build in the current local workspace is blocked by an unrelated `/theme-editor-cn` SSR pre-render error (`TypeError: d is not a function`).
