### PR TITLE
fix: resolve localized demo aliases at runtime

### DIFF
--- a/src/templates/meta/exports.ts.tpl
+++ b/src/templates/meta/exports.ts.tpl
@@ -167,19 +167,22 @@ export function useDemo(
   version?: string,
   routeId?: string,
 ): IDemoData | undefined {
+  const mappedDemoId = loader
+    ? undefined
+    : getDemoIdCandidates(id).find((candidate) => demoIdMap[candidate]);
   const cacheKey = version
     ? `${id}:${version}`
     : routeId
       ? `${id}:route=${routeId}`
       : id;
-  const getter = loader ?? demoIdMap[id];
+  const getter = loader ?? (mappedDemoId ? demoIdMap[mappedDemoId] : undefined);
 
   if (!demosCache.get(cacheKey)) {
     demosCache.set(
       cacheKey,
       getter
         ? getter().then(({ demos }) => {
-            const demo = demos[id];
+            const demo = demos[id] ?? (mappedDemoId && demos[mappedDemoId]);
             if (!demo) return undefined;
 
             // expand context for omit ext


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

Follow-up to #2362.

### 💡 需求背景和解决方案 / Background or solution

#2362 exports localized demo HTML aliases such as `/~demos/foo-cn/`. In production, however, `useDemo` resolves eagerly collected demos through `demoIdMap`, while the lazy `demoIndexMap` used by the existing locale fallback is empty. As a result, the alias HTML exists but the demo still renders blank.

Reuse the existing demo ID candidates when resolving production `demoIdMap` entries and the loaded demo record. The fallback is limited to calls without an explicit loader, so regular embedded demos, versioned demos, and custom loader behavior retain their existing exact-ID semantics.

Validation:

- `pnpm exec father build`
- `pnpm test` (104 passed, 12 skipped)
- Ant Design utoopack production build with the local dumi output (`utoo pack v1.4.23`)
- Verified both `tooltip-demo-shift` and `tooltip-demo-shift-cn` HTML aliases are emitted
- Verified `tooltip-demo-shift-cn` renders the `Scroll The Window` demo in the browser instead of a blank page

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix localized standalone demo pages rendering blank in production. |
| 🇨🇳 Chinese | 修复本地化独立 Demo 页面在生产环境中渲染空白的问题。 |
