### PR TITLE
fix: prevent Vue preset from hanging dumi setup

### DIFF
--- a/suites/preset-vue/src/common.ts
+++ b/suites/preset-vue/src/common.ts
@@ -14,28 +14,36 @@ export default (api: IApi) => {
     return memo;
   });
 
-  api.modifyConfig((memo) => {
-    const userConfig = api.userConfig;
+  // Create the Vue atom parser only for commands that actually need it (dev/build).
+  // `onCheckPkgJSON` is NOT triggered by the `setup` command, so the parser's
+  // worker_threads Worker is never spawned during `dumi setup`; previously it was
+  // created in `modifyConfig` (which runs for every command) and never terminated,
+  // keeping the process alive and hanging on "generate files" (#2283).
+  // Lowest stage so this runs before dumi core's apiParser feature, which skips
+  // creating its React parser when `api.service.atomParser` is already a
+  // BaseAtomAssetsParser.
+  api.onCheckPkgJSON({
+    stage: -Infinity,
+    fn() {
+      const vueConfig = api.userConfig?.vue;
 
-    const vueConfig = userConfig?.vue;
+      const parserOptions: Partial<VueParserOptions> = {
+        directory: vueConfig?.directory ?? api.pkg.repository?.directory,
+        tsconfigPath: vueConfig?.tsconfigPath,
+        checkerOptions: vueConfig?.checkerOptions,
+      };
 
-    const parserOptions: Partial<VueParserOptions> = {
-      directory: vueConfig?.directory ?? api.pkg.repository?.directory,
-      tsconfigPath: vueConfig?.tsconfigPath,
-      checkerOptions: vueConfig?.checkerOptions,
-    };
+      const entryFile = api.userConfig?.resolve?.entryFile;
+      const resolveDir = api.cwd;
+      const options = {
+        entryFile,
+        resolveDir,
+      };
+      Object.assign(options, parserOptions);
 
-    const entryFile = userConfig?.resolve?.entryFile;
-    const resolveDir = api.cwd;
-    const options = {
-      entryFile,
-      resolveDir,
-    };
-    Object.assign(options, parserOptions);
+      if (!options.entryFile || !options.resolveDir) return;
 
-    if (!options.entryFile || !options.resolveDir) return memo;
-
-    api.service.atomParser = VueApiParser(options as VueParserOptions);
-    return memo;
+      api.service.atomParser = VueApiParser(options as VueParserOptions);
+    },
   });
 };


### PR DESCRIPTION
### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] bug 修复 / Fix bug

### 🔗 相关 Issue / Related Issue

Closes #2283

### 💡 需求背景和解决方案 / Background or solution

`dumi setup` hangs forever after printing `info - generate files` when using the **Vue Library** template (`npx create-dumi`). The `prepare` script (`husky install && dumi setup`) never returns control and the user must `Ctrl+C` to continue. The React template does not hang. Collaborator `jeffwcx` confirmed the bug on #2283 and a second user reproduced it.

Root cause: the Vue preset creates the shared atom parser inside `api.modifyConfig`, which runs for **every** command including `setup`. That parser (`VueApiParser` -> `BaseAtomAssetsParser`) owns a long-lived `worker_threads` Worker created on the main thread. The Worker is only ever terminated by the dev/build hooks (`onDevCompileDone` watch, `onBuildComplete` -> `destroyWorker`), none of which fire during `setup`. A live Worker keeps the Node event loop alive, so the process never exits.

dumi core already avoids this for React by creating its parser in `onCheckPkgJSON`, which (per the comment at `src/features/parser.ts:90-93`) "only be called in dev and build" and is **not** triggered by `setup`. The Vue preset just needs to do the same.

This moves the Vue atom-parser creation from `modifyConfig` into `onCheckPkgJSON` with `stage: -Infinity`, so:

- the Worker is no longer spawned during `dumi setup` -> `setup` exits on its own, matching the React template's behavior;
- the parser is still created for `dumi dev` / `dumi build`, so the component API/props tables render as before and the worker is still torn down cleanly on build complete;
- the low stage ensures `api.service.atomParser` is already a `BaseAtomAssetsParser` before dumi core's `apiParser` feature runs its own `onCheckPkgJSON` (`src/features/parser.ts:94`), so core skips creating a competing React parser.

Only `suites/preset-vue/src/common.ts` changes; the worker lifecycle in `src/assetParsers/*` is left untouched because it is correct for dev/build. Verified: `pnpm install` + `father build` (preset-vue) pass, `tsc --noEmit` is clean, and `vitest` for the suite is 9/9 green.

Every Vue Library scaffold currently appears to freeze during install and requires a manual `Ctrl+C`, which reads as a broken scaffold. This restores parity with the React template and lets `dumi setup` complete unattended.

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `dumi setup` hanging at "generate files" for the Vue Library template by creating the Vue atom parser only in dev/build, not during `setup`. |
| 🇨🇳 Chinese | 修复 Vue Library 模板下 `dumi setup` 卡在 "generate files" 不退出的问题：Vue atom parser 仅在 dev/build 阶段创建，`setup` 命令不再创建其 worker。 |
