### PR TITLE
chore: update dumi 1 bundler ad

### DIFF
--- a/packages/dumi/src/index.ts
+++ b/packages/dumi/src/index.ts
@@ -3,8 +3,19 @@ const { fork } = require('child_process');
 module.exports = () => {
   process.env.UMI_PRESETS = require.resolve('@umijs/preset-dumi');
 
+  const cliArgs = process.argv.slice(2) || [];
+  const shouldPrintUtoopackAd = cliArgs[0] === 'dev' && process.env.MAKO_AD !== 'none';
+
+  // Umi 3 promotes Mako during dev, but dumi 2 supports utoopack instead.
+  process.env.MAKO_AD = 'none';
+  if (shouldPrintUtoopackAd) {
+    process.stdout.write(
+      'Utoopack https://github.com/utooland/utoo is a fast Rust-based bundler for dumi 2. Upgrade to dumi 2 and enable it with `utoopack: {}`. Visit https://d.umijs.org/config#utoopack for more details.\n',
+    );
+  }
+
   // start umi use child process
-  const child = fork(require.resolve('umi/bin/umi'), [...(process.argv.slice(2) || [])], {
+  const child = fork(require.resolve('umi/bin/umi'), cliArgs, {
     stdio: 'inherit',
   });
 


### PR DESCRIPTION
## What changed

- suppress the Mako advertisement inherited from Umi 3 when running `dumi dev`
- replace it with an accurate migration hint for upgrading to dumi 2 and enabling `utoopack: {}`
- preserve `MAKO_AD=none` as the opt-out for the replacement message

## Why

dumi 1 depends on `umi@^3.5.27`, whose current `3.x` dev command advertises Mako. dumi 1 cannot enable utoopack directly, so a literal bundler replacement would be misleading. The new message points users to dumi 2, where utoopack is supported.

## User impact

dumi 1 users will no longer see the outdated Mako promotion. During `dumi dev`, they will instead see a link to the dumi 2 utoopack configuration guide.

## Validation

- isolated CLI test verifies the utoopack migration message is printed for `dumi dev`
- isolated CLI test verifies `MAKO_AD=none` suppresses the message
- Prettier check
- ESLint check
- `git diff --check`

A full dumi 1 build was not run because this checkout has dumi 2 dependencies installed; the changed CLI behavior was tested with the child process and module resolution stubbed.